### PR TITLE
Bugfix 1608/fix xss quill vulnerability

### DIFF
--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -58,6 +58,7 @@
     "react-scripts": "4.0.3",
     "react-test-renderer": "^17.0.2",
     "reselect": "^4.0.0",
+    "sanitize-html": "^2.6.1",
     "styled-components": "^5.3.1",
     "universal-cookie": "^4.0.4"
   },

--- a/web-ui/src/components/notes/Note.jsx
+++ b/web-ui/src/components/notes/Note.jsx
@@ -15,14 +15,17 @@ import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
 import MarkdownNote from "../markdown-note/MarkdownNote";
 import "./Note.css";
+import { sanitizeQuillElements } from "../../helpers/sanitizehtml";
 
 async function realUpdate(note, csrf) {
-  await updateCheckinNote(note, csrf);
+  let cleanedNote = sanitizeQuillElements(note.description)
+  await updateCheckinNote(cleanedNote, csrf);
 }
 
 const updateNote = debounce(realUpdate, 1000);
 
 const Notes = (props) => {
+  console.log("bro am i an idiot ;/")
   const { state } = useContext(AppContext);
   const { checkinId, memberId } = useParams();
   const csrf = selectCsrfToken(state);
@@ -31,9 +34,9 @@ const Notes = (props) => {
   const currentCheckin = selectCheckin(state, checkinId);
   const currentMember = selectProfile(state, memberId);
   const pdlId = currentMember?.pdlId;
-
   const noteRef = useRef([]);
   const [note, setNote] = useState();
+  console.log("Note???" + note)
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -42,11 +45,13 @@ const Notes = (props) => {
       try {
         let res = await getNoteByCheckinId(checkinId, csrf);
         if (res.error) throw new Error(res.error);
-        const currentNote =
+        let currentNote =
           res.payload && res.payload.data && res.payload.data.length > 0
             ? res.payload.data[0]
             : null;
         if (currentNote) {
+           currentNote.description= sanitizeQuillElements(currentNote.description)
+          console.log("Current note " + currentNote)
           setNote(currentNote);
         } else if (currentUserId === pdlId) {
           if (!noteRef.current.some((id) => id === checkinId)) {
@@ -81,6 +86,7 @@ const Notes = (props) => {
       setIsLoading(false);
     }
     if (csrf) {
+      console.log('get notes')
       getNotes();
     }
   }, [csrf, checkinId, currentUserId, pdlId]);

--- a/web-ui/src/components/notes/Note.jsx
+++ b/web-ui/src/components/notes/Note.jsx
@@ -18,14 +18,14 @@ import "./Note.css";
 import { sanitizeQuillElements } from "../../helpers/sanitizehtml";
 
 async function realUpdate(note, csrf) {
-  let cleanedNote = sanitizeQuillElements(note.description)
-  await updateCheckinNote(cleanedNote, csrf);
+  //Clean note of potential malicious content before upload
+  note.description = sanitizeQuillElements(note.description)
+  await updateCheckinNote(note,csrf)
 }
 
 const updateNote = debounce(realUpdate, 1000);
 
 const Notes = (props) => {
-  console.log("bro am i an idiot ;/")
   const { state } = useContext(AppContext);
   const { checkinId, memberId } = useParams();
   const csrf = selectCsrfToken(state);
@@ -36,8 +36,8 @@ const Notes = (props) => {
   const pdlId = currentMember?.pdlId;
   const noteRef = useRef([]);
   const [note, setNote] = useState();
-  console.log("Note???" + note)
   const [isLoading, setIsLoading] = useState(true);
+
 
   useEffect(() => {
     async function getNotes() {
@@ -50,8 +50,8 @@ const Notes = (props) => {
             ? res.payload.data[0]
             : null;
         if (currentNote) {
-           currentNote.description= sanitizeQuillElements(currentNote.description)
-          console.log("Current note " + currentNote)
+          //Clean note of potential malicious content from database before rendering
+          currentNote.description= sanitizeQuillElements(currentNote.description)
           setNote(currentNote);
         } else if (currentUserId === pdlId) {
           if (!noteRef.current.some((id) => id === checkinId)) {
@@ -86,8 +86,7 @@ const Notes = (props) => {
       setIsLoading(false);
     }
     if (csrf) {
-      console.log('get notes')
-      getNotes();
+      getNotes()
     }
   }, [csrf, checkinId, currentUserId, pdlId]);
 

--- a/web-ui/src/components/private-note/PrivateNote.jsx
+++ b/web-ui/src/components/private-note/PrivateNote.jsx
@@ -36,6 +36,7 @@ const PrivateNote = () => {
 
   const noteRef = useRef([]);
   const [note, setNote] = useState();
+  console.log(note)
   const [isLoading, setIsLoading] = useState(true);
 
   const pdlorAdmin = selectIsPDL(state) || isAdmin;

--- a/web-ui/src/components/private-note/PrivateNote.jsx
+++ b/web-ui/src/components/private-note/PrivateNote.jsx
@@ -13,11 +13,13 @@ import Skeleton from '@mui/material/Skeleton';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
-
 import "./PrivateNote.css";
 import MarkdownNote from "../markdown-note/MarkdownNote";
+import { sanitizeQuillElements } from "../../helpers/sanitizehtml";
 
 async function realUpdate(note, csrf) {
+  //Clean note of potential malicious content before upload
+  note.description = sanitizeQuillElements(note.description)
   await updatePrivateNote(note, csrf);
 }
 
@@ -36,7 +38,6 @@ const PrivateNote = () => {
 
   const noteRef = useRef([]);
   const [note, setNote] = useState();
-  console.log(note)
   const [isLoading, setIsLoading] = useState(true);
 
   const pdlorAdmin = selectIsPDL(state) || isAdmin;
@@ -53,6 +54,8 @@ const PrivateNote = () => {
             ? res.payload.data[0]
             : null;
         if (currentNote) {
+          //Clean note of potential malicious content from database before rendering
+          currentNote.description= sanitizeQuillElements(currentNote.description)
           setNote(currentNote);
         } else if (currentUserId === pdlId) {
           if (!noteRef.current.some((id) => id === checkinId)) {

--- a/web-ui/src/helpers/sanitizehtml.js
+++ b/web-ui/src/helpers/sanitizehtml.js
@@ -1,0 +1,41 @@
+import sanitizeHTML from "sanitize-html"
+
+export const sanitizeQuillElements = (htmlInput) => {
+    const cleaner = sanitizeHTML(htmlInput, {
+        allowedTags: 
+        ['b', 
+        'i', 
+        'strong', 
+        'a',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'em',
+        'p',
+        'ins',
+        'sup',
+        'sub',
+        'span',
+        'mark',
+        'small',
+        'del',
+        'a',
+        'ul',
+        'ol',
+        'li',
+        'br',
+        'u',
+        'blockquote',
+        'q',
+        'abbr',
+        'cite'],
+        allowedAttributes: {
+          a: ['href', 'target', 'title',]
+        }
+      });
+      console.log(cleaner)
+      return cleaner;
+    }

--- a/web-ui/src/helpers/sanitizehtml.js
+++ b/web-ui/src/helpers/sanitizehtml.js
@@ -1,5 +1,9 @@
 import sanitizeHTML from "sanitize-html"
 
+//This function is a helper function that sanitizes user inputs on 
+//Quill/rich text editor elements to prevent XSS attacks. It is used in 
+//Notes and PrivateNotes to prevent bad content from being uploaded to the
+//server or rendered on the DOM.
 export const sanitizeQuillElements = (htmlInput) => {
     const cleaner = sanitizeHTML(htmlInput, {
         allowedTags: 
@@ -36,6 +40,5 @@ export const sanitizeQuillElements = (htmlInput) => {
           a: ['href', 'target', 'title',]
         }
       });
-      console.log(cleaner)
       return cleaner;
     }

--- a/web-ui/src/pages/ErrorBoundaryPage.jsx
+++ b/web-ui/src/pages/ErrorBoundaryPage.jsx
@@ -9,6 +9,7 @@ import MarkdownNote from "../components/markdown-note/MarkdownNote";
 import { Button, Modal, TextField } from "@mui/material";
 
 import "./ErrorBoundaryPage.css";
+import { sanitizeQuillElements } from "../helpers/sanitizehtml";
 
 const ErrorFallback = ({ error }) => {
   const { state } = useContext(AppContext);
@@ -34,7 +35,10 @@ const ErrorFallback = ({ error }) => {
       });
       return;
     }
-    let res = await newGitHubIssue(body, title, csrf);
+    //Clean new issue of potentially malicious content in body
+    //before upload to server
+    let sanitizeBody = sanitizeQuillElements(body)
+    let res = await newGitHubIssue(sanitizeBody, title, csrf);
     if (res && res.payload) {
       setLink(res.payload.data[0].html_url);
       window.snackDispatch({

--- a/web-ui/yarn.lock
+++ b/web-ui/yarn.lock
@@ -8580,7 +8580,7 @@ html-webpack-plugin@^4.0.0:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-htmlparser2@^6.1.0:
+htmlparser2@^6.0.0, htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
   integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
@@ -9263,6 +9263,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -11002,6 +11007,11 @@ nanoid@^3.1.25:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
+nanoid@^3.1.30:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -11678,6 +11688,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=
+
 parse5-htmlparser2-tree-adapter@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
@@ -11802,6 +11817,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
@@ -12595,6 +12615,15 @@ postcss@^8.1.0:
     nanocolors "^0.2.2"
     nanoid "^3.1.25"
     source-map-js "^0.6.2"
+
+postcss@^8.3.11:
+  version "8.4.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
+  integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -14000,6 +14029,18 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sanitize-html@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.6.1.tgz#5d37c08e189c61c0631560a889b10d9d155d000e"
+  integrity sha512-DzjSz3H5qDntD7s1TcWCSoRPmNR8UmA+y+xZQOvWgjATe2Br9ZW73+vD3Pj6Snrg0RuEuJdXgrKvnYuiuixRkA==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^6.0.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
+
 sanitize.css@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-10.0.0.tgz#b5cb2547e96d8629a60947544665243b1dc3657a"
@@ -14384,6 +14425,11 @@ source-map-js@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
+source-map-js@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
Notes, Private Notes, and Error Boundary are now sanitized of potentially malicious content and disallowed tags by a function in "helpers" called "sanitizeQuillElements." Let me know if you want sanitization to be moved to somewhere in the API calls or wherever else. Note that React escapes html script automatically, so it can be a bit harder to launch a test attack.