### PR TITLE
Fixed code per issue request.

### DIFF
--- a/web-ui/src/context/selectors.js
+++ b/web-ui/src/context/selectors.js
@@ -179,11 +179,10 @@ export const selectOpenCheckinsForMember = createSelector(
 
 export const selectMostRecentCheckin = createSelector(
   selectCheckinsForMember,
-  selectOpenCheckinsForMember,
-  (checkins, openCheckins) => {
-    if (openCheckins && openCheckins.length > 0) {
-      return openCheckins[openCheckins.length - 1];
-    } else return checkins && checkins[checkins.length - 1];
+  (checkins) => {
+    if (checkins && checkins.length > 0) {
+      return checkins && checkins[checkins.length-1]
+    }
   }
 );
 

--- a/web-ui/src/pages/CheckinsPage.jsx
+++ b/web-ui/src/pages/CheckinsPage.jsx
@@ -63,13 +63,6 @@ const CheckinsPage = () => {
   const currentUserId = memberProfile?.id;
   const mostRecent = selectMostRecentCheckin(state, memberId);
 
-  const getCheckinDate = () => {
-    if (mostRecent) {
-      const [year, month, day, hour, minute] = mostRecent.checkInDate;
-      return new Date(year, month - 1, day, hour, minute, 0).getTime();
-    }
-  };
-
   const selectedProfile = selectProfile(state, memberId);
   const memberCheckins = selectCheckinsForMember(
     state,
@@ -91,22 +84,6 @@ const CheckinsPage = () => {
       history.push(`/checkins/${memberId}/${mostRecent.id}`);
     }
   }, [currentUserId, memberId, checkinId, mostRecent, history]);
-
-  useEffect(() => {
-    const isOpenInPast =
-      !mostRecent?.completed &&
-      new Date(getCheckinDate()) < new Date(Date.now());
-    if (isOpenInPast === true) {
-      window.snackDispatch({
-        type: UPDATE_TOAST,
-        payload: {
-          severity: "success",
-          toast: `Just so you know, this open Check-In is in the past`,
-        },
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mostRecent]);
 
   const currentCheckin = selectCheckin(state, checkinId);
   const isAdmin = selectIsAdmin(state);


### PR DESCRIPTION
Navigating to an open past check-in no longer triggers a "this check-in is in the past" alert.  selectMostRecentCheckin function (selector) now selects most recent check-in from all check-ins, both closed and open. Removed unused select date code from top of check-ins page.