### PR TITLE
Added supervisor and PDL info to the member profile page

### DIFF
--- a/web-ui/src/pages/MemberProfilePage.jsx
+++ b/web-ui/src/pages/MemberProfilePage.jsx
@@ -9,7 +9,10 @@ import { getGuildsForMember } from "../api/guild";
 import { getAvatarURL } from "../api/api.js";
 import ProfilePage from "./ProfilePage";
 import { levelList } from "../context/util";
-import { getMember } from "../api/member.js";
+import {
+  selectOrderedPdls,
+  selectOrderedMemberFirstName,
+} from "../context/selectors";
 
 import "./MemberProfilePage.css";
 
@@ -30,36 +33,10 @@ const MemberProfilePage = () => {
   const { csrf, skills, userProfile } = state;
   const { memberId } = useParams();
   const [selectedMember, setSelectedMember] = useState(null);
-  const [supervisor, setSupervisor] = useState(null)
-  const[pdl, setPDL ] = useState(null)
-
-  useEffect(() => {
-    async function getPDLName() {
-      if (selectedMember?.pdlId) {
-        let res = await getMember(selectedMember.pdlId, csrf);
-        let pdlProfile =
-          res.payload.data && !res.error ? res.payload.data : undefined;
-        setPDL(pdlProfile ? pdlProfile.name : "");
-      }
-    }
-    if (csrf) {
-      getPDLName();
-    }
-  }, [csrf, selectedMember]);
-
-useEffect(() => {
-    async function getSupervisorName() {
-      if (selectedMember?.supervisorid) {
-        let res = await getMember(selectedMember.supervisorid, csrf);
-        let supervisorProfile =
-          res.payload.data && !res.error ? res.payload.data : undefined;
-        setSupervisor(supervisorProfile ? supervisorProfile.name : "");
-      }
-    }
-    if (csrf) {
-      getSupervisorName();
-    }
-  }, [csrf, selectedMember]);
+  const sortedPdls = selectOrderedPdls(state);
+  const sortedMembers = selectOrderedMemberFirstName(state);
+  let pdlInfo = sortedPdls && sortedPdls.find((pdl) => pdl?.id === selectedMember?.pdlId)
+  let supervisorInfo = sortedMembers && sortedMembers.find((memberProfile) => memberProfile?.id === selectedMember?.supervisorid)
 
 
   useEffect(() => {
@@ -78,7 +55,6 @@ useEffect(() => {
   const [selectedMemberSkills, setSelectedMemberSkills] = useState([]);
   const [teams, setTeams] = useState([]);
   const [guilds, setGuilds] = useState([]);
-
   const isCurrentUser = userProfile?.memberProfile?.id === memberId;
 
   useEffect(() => {
@@ -177,8 +153,10 @@ useEffect(() => {
                       <h4>Email: {selectedMember.workEmail || ""}</h4>
                       <h4>Location: {selectedMember.location || ""}</h4>
                       <h4>Bio: {selectedMember.bioText || ""}</h4>
-                      {supervisor && <h4>Supervisor: {supervisor || ""}</h4>}
-                      {pdl && <h4>PDL: {pdl || ""}</h4>}
+                      {console.log(supervisorInfo)}
+                      {console.log(pdlInfo)}
+                      <h4>{(supervisorInfo && "Supervisor: " + supervisorInfo.firstName + " " + supervisorInfo.lastName) || ("")}</h4>
+                      <h4>{(pdlInfo && "PDL: " + pdlInfo.firstName + " " + pdlInfo.lastName) || ("")}</h4>
                     </Typography>
                   </Container>
                 </CardContent>

--- a/web-ui/src/pages/MemberProfilePage.jsx
+++ b/web-ui/src/pages/MemberProfilePage.jsx
@@ -9,6 +9,7 @@ import { getGuildsForMember } from "../api/guild";
 import { getAvatarURL } from "../api/api.js";
 import ProfilePage from "./ProfilePage";
 import { levelList } from "../context/util";
+import { getMember } from "../api/member.js";
 
 import "./MemberProfilePage.css";
 
@@ -29,6 +30,37 @@ const MemberProfilePage = () => {
   const { csrf, skills, userProfile } = state;
   const { memberId } = useParams();
   const [selectedMember, setSelectedMember] = useState(null);
+  const [supervisor, setSupervisor] = useState(null)
+  const[pdl, setPDL ] = useState(null)
+
+  useEffect(() => {
+    async function getPDLName() {
+      if (selectedMember?.pdlId) {
+        let res = await getMember(selectedMember.pdlId, csrf);
+        let pdlProfile =
+          res.payload.data && !res.error ? res.payload.data : undefined;
+        setPDL(pdlProfile ? pdlProfile.name : "");
+      }
+    }
+    if (csrf) {
+      getPDLName();
+    }
+  }, [csrf, selectedMember]);
+
+useEffect(() => {
+    async function getSupervisorName() {
+      if (selectedMember?.supervisorid) {
+        let res = await getMember(selectedMember.supervisorid, csrf);
+        let supervisorProfile =
+          res.payload.data && !res.error ? res.payload.data : undefined;
+        setSupervisor(supervisorProfile ? supervisorProfile.name : "");
+      }
+    }
+    if (csrf) {
+      getSupervisorName();
+    }
+  }, [csrf, selectedMember]);
+
 
   useEffect(() => {
     // in the case of a terminated member, member details will still display
@@ -145,6 +177,8 @@ const MemberProfilePage = () => {
                       <h4>Email: {selectedMember.workEmail || ""}</h4>
                       <h4>Location: {selectedMember.location || ""}</h4>
                       <h4>Bio: {selectedMember.bioText || ""}</h4>
+                      {supervisor && <h4>Supervisor: {supervisor || ""}</h4>}
+                      {pdl && <h4>PDL: {pdl || ""}</h4>}
                     </Typography>
                   </Container>
                 </CardContent>

--- a/web-ui/src/pages/MemberProfilePage.jsx
+++ b/web-ui/src/pages/MemberProfilePage.jsx
@@ -153,8 +153,6 @@ const MemberProfilePage = () => {
                       <h4>Email: {selectedMember.workEmail || ""}</h4>
                       <h4>Location: {selectedMember.location || ""}</h4>
                       <h4>Bio: {selectedMember.bioText || ""}</h4>
-                      {console.log(supervisorInfo)}
-                      {console.log(pdlInfo)}
                       <h4>{(supervisorInfo && "Supervisor: " + supervisorInfo.firstName + " " + supervisorInfo.lastName) || ("")}</h4>
                       <h4>{(pdlInfo && "PDL: " + pdlInfo.firstName + " " + pdlInfo.lastName) || ("")}</h4>
                     </Typography>


### PR DESCRIPTION
The member profile page now displays supervisor and PDL in the name card per request. Please let me know if you want more information (like birthday) to be displayed or if the supervisor/PDL info should be moved.