### PR TITLE
Feature 1636/add guild links frontend

### DIFF
--- a/web-ui/src/components/guild-results/EditGuildModal.jsx
+++ b/web-ui/src/components/guild-results/EditGuildModal.jsx
@@ -168,6 +168,16 @@ const EditGuildModal = ({ guild = {}, open, onSave, onClose, headerText }) => {
             setGuild({ ...editedGuild, description: e.target.value })
           }
         />
+        <TextField
+          id="guild-link-input"
+          label="Link to Compass Page"
+          className="fullWidth"
+          placeholder="https://www.compass.objectcomputing.com/guilds/..."
+          value={editedGuild.link ? editedGuild.link: ""}
+          onChange={(e) =>
+            setGuild({ ...editedGuild, link: e.target.value })
+          }
+        />
         <Autocomplete
           id="guildLeadSelect"
           multiple

--- a/web-ui/src/components/guild-results/GuildSummaryCard.jsx
+++ b/web-ui/src/components/guild-results/GuildSummaryCard.jsx
@@ -5,6 +5,7 @@ import { AppContext } from "../../context/AppContext";
 import { UPDATE_GUILDS, UPDATE_TOAST } from "../../context/actions";
 import EditGuildModal from "./EditGuildModal";
 import { Link } from "react-router-dom";
+import { Link as StyledLink } from "@mui/material";
 
 import {
   Button,
@@ -142,6 +143,13 @@ const GuildSummaryCard = ({ guild, index }) => {
         }
       />
       <CardContent>
+        {guild?.link ? 
+        <React.Fragment>
+          <div>
+          <StyledLink href={guild.link}>Link to Guild Page on Compass</StyledLink>
+          </div>
+        </React.Fragment>
+          :null}
         {guild.guildMembers == null ? (
           <React.Fragment>
             <strong>Guild Leads: </strong>None Assigned

--- a/web-ui/src/components/guild-results/GuildSummaryCard.jsx
+++ b/web-ui/src/components/guild-results/GuildSummaryCard.jsx
@@ -146,7 +146,7 @@ const GuildSummaryCard = ({ guild, index }) => {
         {guild?.link ? 
         <React.Fragment>
           <div>
-          <StyledLink href={guild.link}>Link to Guild Page on Compass</StyledLink>
+          <StyledLink href={guild.link}>Link to Guild Homepage</StyledLink>
           </div>
         </React.Fragment>
           :null}


### PR DESCRIPTION
PLEASE MERGE 1635 FIRST
Guild links can now be added and edited from guild modal. Guild links displayed on guild summary cards.