### PR TITLE
Bugfix 1558/user is unauthorized to do this operation

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
@@ -13,8 +13,6 @@ import com.objectcomputing.checkins.services.role.RoleType;
 import com.objectcomputing.checkins.exceptions.BadArgException;
 
 import io.micronaut.core.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
@@ -33,8 +31,6 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
     private final MemberProfileServices memberProfileServices;
     private final CurrentUserServices currentUserServices;
     final String unauthorizedErrorMessage ="User is unauthorized to do this operation";
-
-    private static final Logger LOG = LoggerFactory.getLogger(PrivateNoteServicesImpl.class);
 
     public PrivateNoteServicesImpl(CheckInServices checkinServices, CheckInRepository checkinRepo, PrivateNoteRepository privateNoteRepository,
                                    MemberProfileRepository memberRepo, MemberProfileServices memberProfileServices,
@@ -95,19 +91,13 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
                 throw new NotFoundException(String.format("CheckIn %s doesn't exist", privateNoteResult.getCheckinid()));
             }
 
-            LOG.info("Check-in exists, determining if access is granted...");
-
             if (!checkinServices.accessGranted(checkinRecord.getId(), currentUser.getId())) {
                 throw new PermissionException("User is unauthorized to do this operation");
             }
 
-            LOG.info("Access granted");
-
             if(currentUser.getId().equals(checkinRecord.getTeamMemberId())) {
-                LOG.info("Team member is not permitted to read private note");
                 throw new PermissionException("User is unauthorized to do this operation");
             }
-
         }
 
         return privateNoteResult;

--- a/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
@@ -13,7 +13,6 @@ import com.objectcomputing.checkins.services.role.RoleType;
 import com.objectcomputing.checkins.exceptions.BadArgException;
 
 import io.micronaut.core.annotation.Nullable;
-
 import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
@@ -86,7 +85,6 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
 
         if (!isAdmin) {
             CheckIn checkinRecord = checkinServices.read(privateNoteResult.getCheckinid());
-
             if (checkinRecord == null) {
                 throw new NotFoundException(String.format("CheckIn %s doesn't exist", privateNoteResult.getCheckinid()));
             }

--- a/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
@@ -2,7 +2,6 @@ package com.objectcomputing.checkins.services.private_notes;
 
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
-import com.objectcomputing.checkins.services.checkin_notes.CheckinNote;
 import com.objectcomputing.checkins.services.checkins.CheckIn;
 import com.objectcomputing.checkins.services.checkins.CheckInRepository;
 import com.objectcomputing.checkins.services.checkins.CheckInServices;
@@ -14,6 +13,9 @@ import com.objectcomputing.checkins.services.role.RoleType;
 import com.objectcomputing.checkins.exceptions.BadArgException;
 
 import io.micronaut.core.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
@@ -31,6 +33,8 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
     private final MemberProfileServices memberProfileServices;
     private final CurrentUserServices currentUserServices;
     final String unauthorizedErrorMessage ="User is unauthorized to do this operation";
+
+    private static final Logger LOG = LoggerFactory.getLogger(PrivateNoteServicesImpl.class);
 
     public PrivateNoteServicesImpl(CheckInServices checkinServices, CheckInRepository checkinRepo, PrivateNoteRepository privateNoteRepository,
                                    MemberProfileRepository memberRepo, MemberProfileServices memberProfileServices,
@@ -86,17 +90,24 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
 
         if (!isAdmin) {
             CheckIn checkinRecord = checkinServices.read(privateNoteResult.getCheckinid());
+
             if (checkinRecord == null) {
                 throw new NotFoundException(String.format("CheckIn %s doesn't exist", privateNoteResult.getCheckinid()));
             }
+
+            LOG.info("Check-in exists, determining if access is granted...");
 
             if (!checkinServices.accessGranted(checkinRecord.getId(), currentUser.getId())) {
                 throw new PermissionException("User is unauthorized to do this operation");
             }
 
+            LOG.info("Access granted");
+
             if(currentUser.getId().equals(checkinRecord.getTeamMemberId())) {
+                LOG.info("Team member is not permitted to read private note");
                 throw new PermissionException("User is unauthorized to do this operation");
             }
+
         }
 
         return privateNoteResult;

--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -368,6 +368,51 @@ INSERT INTO checkins
 VALUES
 ('ff52e697-55a1-4a89-a13f-f3d6fb8f6b3d', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '6884ab96-2275-4af9-89d8-ad84254d8759', '2020-03-20 11:32:29.04' , true);
 
+INSERT INTO checkins
+(id, teammemberid, pdlid, checkindate, completed)
+VALUES
+('10184287-1746-4827-93fe-4e13cc0d2a6d', 'dfe2f986-fac0-11eb-9a03-0242ac130003', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', '2021-02-25 11:32:29.04', true);
+
+INSERT INTO checkins
+(id, teammemberid, pdlid, checkindate, completed)
+VALUES
+('bdea5de0-4358-4b33-9772-0cd953567540', 'dfe2f986-fac0-11eb-9a03-0242ac130003', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', '2021-03-05 11:32:29.04', true);
+
+INSERT INTO checkins
+(id, teammemberid, pdlid, checkindate, completed)
+VALUES
+('553aa528-d5f6-4d15-bfb6-b53738dc7954', 'dfe2f986-fac0-11eb-9a03-0242ac130003', '59b790d2-fabc-11eb-9a03-0242ac130003', '2022-01-16 11:32:29.04', true);
+
+INSERT INTO checkin_notes
+(id, checkinid, createdbyid, description)
+VALUES
+('226a2ab8-03cc-4f9e-96c8-55cf187df045', '10184287-1746-4827-93fe-4e13cc0d2a6d', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', PGP_SYM_ENCRYPT('Geetika''s first note for Ulysses', '${aeskey}'));
+
+INSERT INTO private_notes
+(id, checkinid, createdbyid, description)
+VALUES
+('444f6923-7b8e-4d03-8d33-021e7a72653c', '10184287-1746-4827-93fe-4e13cc0d2a6d', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', PGP_SYM_ENCRYPT('Geetika''s first private note for Ulysses', '${aeskey}'));
+
+INSERT INTO checkin_notes
+(id, checkinid, createdbyid, description)
+VALUES
+('c0d76e16-f96a-4598-8006-52b803e8b26d', 'bdea5de0-4358-4b33-9772-0cd953567540', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', PGP_SYM_ENCRYPT('Geetika''s second note for Ulysses', '${aeskey}'));
+
+INSERT INTO private_notes
+(id, checkinid, createdbyid, description)
+VALUES
+('cc47b557-ed78-45c4-b577-89c1c9e705bd', 'bdea5de0-4358-4b33-9772-0cd953567540', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', PGP_SYM_ENCRYPT('Geetika''s second private note for Ulysses', '${aeskey}'));
+
+INSERT INTO checkin_notes
+(id, checkinid, createdbyid, description)
+VALUES
+('73a5e7b5-9292-45c0-a605-5b5c63230892', '553aa528-d5f6-4d15-bfb6-b53738dc7954', '59b790d2-fabc-11eb-9a03-0242ac130003', PGP_SYM_ENCRYPT('Julia''s first note for Ulysses', '${aeskey}'));
+
+INSERT INTO private_notes
+(id, checkinid, createdbyid, description)
+VALUES
+('73a5e7b5-9292-45c0-a605-5b5c63230892', '553aa528-d5f6-4d15-bfb6-b53738dc7954', '59b790d2-fabc-11eb-9a03-0242ac130003', PGP_SYM_ENCRYPT('Julia''s first private note for Ulysses', '${aeskey}'));
+
 INSERT INTO checkin_notes
 (id, checkinid, createdbyid, description)
 VALUES

--- a/server/src/test/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteControllerTest.java
@@ -88,6 +88,29 @@ public class PrivateNoteControllerTest extends TestContainersSuite implements Me
     }
 
     @Test
+    void testCurrentPdlAbleToReadPreviousPrivateNotes() {
+        // Create a previously established PDL for the user
+        MemberProfile memberProfileOfPreviousPdl = createADefaultMemberProfile();
+        MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPreviousPdl);
+
+        // Create a check-in with a private note under the previous PDL
+        CheckIn checkIn = createADefaultCheckIn(memberProfileOfUser, memberProfileOfPreviousPdl);
+        PrivateNote privateNote = createADefaultPrivateNote(checkIn, memberProfileOfPreviousPdl);
+
+        // Assign the user a new PDL
+        MemberProfile memberProfileOfCurrentPdl = createASecondDefaultMemberProfile();
+        memberProfileOfUser.setPdlId(memberProfileOfCurrentPdl.getId());
+        getMemberProfileRepository().update(memberProfileOfUser);
+
+        // Ensure the new PDL can access the private note from the previous PDL
+        final HttpRequest<?> request = HttpRequest.GET(String.format("/%s", privateNote.getId())).basicAuth(memberProfileOfCurrentPdl.getWorkEmail(), PDL_ROLE);
+        final HttpResponse<PrivateNote> response = client.toBlocking().exchange(request, PrivateNote.class);
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertEquals(privateNote, response.body());
+    }
+
+    @Test
     void testAdminAbleToReadPdlsPrivateNotes() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);

--- a/web-ui/src/components/notes/Note.jsx
+++ b/web-ui/src/components/notes/Note.jsx
@@ -91,7 +91,7 @@ const Notes = (props) => {
   }, [csrf, checkinId, currentUserId, pdlId]);
 
   const handleNoteChange = (content, delta, source, editor) => {
-    if (Object.keys(note).length === 0 || !csrf) {
+    if (Object.keys(note).length === 0 || !csrf || currentCheckin?.completed) {
       return;
     }
     

--- a/web-ui/src/components/private-note/PrivateNote.jsx
+++ b/web-ui/src/components/private-note/PrivateNote.jsx
@@ -95,7 +95,7 @@ const PrivateNote = () => {
   }, [csrf, checkinId, currentUserId, pdlId]);
 
   const handleNoteChange = (content, delta, source, editor) => {
-    if (Object.keys(note).length === 0 || !csrf) {
+    if (Object.keys(note).length === 0 || !csrf || currentCheckin?.completed) {
       return;
     }
     


### PR DESCRIPTION
This is a potential fix for the "User is unauthorized to do this operation" error message found in issue #1558. 

To verify, log in as a PDL and view a development partner's check-in made (where the check-in was either made by yourself or the development partner's previous PDL). The error message mentioned above should not appear.

The problem causing this was the system attempting to update the note or private note for completed check-ins. Although the fields were marked as read-only if the check-in was completed, the `changed` event fired for the text fields when the page loaded, causing it to send a PUT request. Since the check-in is already completed, the back-end sends back an error message saying the action is not allowed (i.e. you cannot update notes for a check-in that has already been completed)