### PR TITLE
Bugfix 1559/Feedback search gives error

### DIFF
--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -158,7 +158,7 @@ const ViewFeedbackResponses = () => {
       if (searchText.trim()) {
         // Filter based on search text
         filteredAnswers = filteredAnswers.filter(({ answer }) =>
-          answer.toLowerCase().includes(searchText.trim().toLowerCase())
+          answer && answer.toLowerCase().includes(searchText.trim().toLowerCase())
         );
       }
       return { ...response, answers: filteredAnswers };


### PR DESCRIPTION
This fixes bug #1559 where using the search bar on the view feedback page would throw an error. This fix is dependent on PR #1671, as that PR fixes an authorization issue that prevents the page from loading.

For the answers that haven't been submitted yet, there needs to be an additional check to ensure the `answer` is defined. 