### PR TITLE
Feature 1532/create service to retrieve all associated roles and members

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/role/MemberRoleDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/MemberRoleDTO.java
@@ -1,0 +1,55 @@
+package com.objectcomputing.checkins.services.role;
+
+import io.micronaut.core.annotation.Introspected;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+@Introspected
+public class MemberRoleDTO {
+
+    @Schema(description = "The id of the role", required = true)
+    private UUID roleId;
+
+    @Schema(description = "The name of the role", required = true)
+    private String role;
+
+    @Schema(description = "The description of the role")
+    private String description;
+
+    @Schema(description = "List of member ids with the role")
+    private List<UUID> memberIds;
+
+    public UUID getRoleId() {
+        return roleId;
+    }
+
+    public void setRoleId(UUID roleId) {
+        this.roleId = roleId;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<UUID> getMemberIds() {
+        return memberIds;
+    }
+
+    public void setMemberIds(List<UUID> memberIds) {
+        this.memberIds = memberIds;
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleController.java
@@ -1,5 +1,6 @@
 package com.objectcomputing.checkins.services.role.member_roles;
 
+import com.objectcomputing.checkins.services.role.MemberRoleDTO;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
@@ -25,6 +26,12 @@ public class MemberRoleController {
     @Get
     HttpResponse<List<MemberRole>> getAllAssignedRoles() {
         return HttpResponse.ok(memberRoleServices.findAll());
+    }
+
+    @Get("/groupedByRole")
+    HttpResponse<List<MemberRoleDTO>> getMembersGroupedByRole() {
+        List<MemberRoleDTO> membersGroupedByRole = memberRoleServices.getAllMembersGroupedByRole();
+        return HttpResponse.ok(membersGroupedByRole);
     }
 
     @Delete("/{roleId}/{memberId}")

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleRepository.java
@@ -1,26 +1,22 @@
 package com.objectcomputing.checkins.services.role.member_roles;
 
-import com.objectcomputing.checkins.services.checkins.CheckIn;
-import com.objectcomputing.checkins.services.role.Role;
-import com.objectcomputing.checkins.services.team.Team;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-
 
 @JdbcRepository(dialect = Dialect.POSTGRES)
 public interface MemberRoleRepository extends CrudRepository<MemberRole, MemberRoleId> {
 
     List<MemberRole> findAll();
 
+    @Query("SELECT memberid " +
+            "FROM member_roles " +
+            "WHERE member_roles.roleid = :roleId")
+    List<UUID> findAllMembersWithRole(String roleId);
 
     @Query("INSERT INTO member_roles " +
             "    (roleid, memberid) " +
@@ -28,12 +24,10 @@ public interface MemberRoleRepository extends CrudRepository<MemberRole, MemberR
             "    (:roleid, :memberid)")
     MemberRole saveByIds(UUID memberid, UUID roleid);
 
-//
 //    @Query("DELETE FROM " +
 //            "member_roles " +
 //            "WHERE (memberid, roleid) = (:memberid, :roleid)")
 //    void deleteById(String memberid, String roleid);
-
 
     @Query("DELETE FROM " +
             "member_roles " +

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleServices.java
@@ -1,6 +1,7 @@
 package com.objectcomputing.checkins.services.role.member_roles;
 
 
+import com.objectcomputing.checkins.services.role.MemberRoleDTO;
 import io.micronaut.core.annotation.NonNull;
 
 import javax.validation.constraints.NotNull;
@@ -12,18 +13,16 @@ public interface MemberRoleServices {
 
     List<MemberRole> findAll();
 
+    List<MemberRoleDTO> getAllMembersGroupedByRole();
+
     MemberRole saveByIds(UUID memberid, UUID roleid);
 
     void delete(@NotNull MemberRoleId id);
 
     void removeMemberFromRoles(UUID memberid);
 
-
     @NonNull
     Optional<MemberRole> findById(@NotNull MemberRoleId memberRoleId);
 
     void removeAllByRoleId(UUID roleId);
-
-
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/member_roles/MemberRoleServicesImpl.java
@@ -1,24 +1,48 @@
 package com.objectcomputing.checkins.services.role.member_roles;
 
+import com.objectcomputing.checkins.services.role.MemberRoleDTO;
+import com.objectcomputing.checkins.services.role.Role;
+import com.objectcomputing.checkins.services.role.RoleRepository;
+
 import javax.inject.Singleton;
-import java.lang.reflect.Member;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
 public class MemberRoleServicesImpl implements MemberRoleServices {
 
     private final MemberRoleRepository memberRoleRepository;
+    private final RoleRepository roleRepository;
 
-    public MemberRoleServicesImpl(MemberRoleRepository memberRoleRepository) {
+    public MemberRoleServicesImpl(MemberRoleRepository memberRoleRepository, RoleRepository roleRepository) {
         this.memberRoleRepository = memberRoleRepository;
+        this.roleRepository = roleRepository;
     }
 
     public List<MemberRole> findAll() {
         return memberRoleRepository.findAll();
     }
 
+    public List<MemberRoleDTO> getAllMembersGroupedByRole() {
+        List<MemberRoleDTO> groupedMemberRoles = new ArrayList<>();
+        Iterable<Role> allRoles = roleRepository.findAll();
+
+        for (Role role : allRoles) {
+            List<UUID> memberIds = memberRoleRepository.findAllMembersWithRole(nullSafeUUIDToString(role.getId()));
+            MemberRoleDTO memberRoleDTO = new MemberRoleDTO();
+            memberRoleDTO.setRoleId(role.getId());
+            memberRoleDTO.setRole(role.getRole());
+            memberRoleDTO.setDescription(role.getDescription());
+            memberRoleDTO.setMemberIds(memberIds);
+            groupedMemberRoles.add(memberRoleDTO);
+        }
+
+        return groupedMemberRoles;
+    }
 
     public void delete(MemberRoleId id){
         memberRoleRepository.deleteById(id);
@@ -33,7 +57,6 @@ public class MemberRoleServicesImpl implements MemberRoleServices {
     public MemberRole saveByIds(UUID memberId, UUID roleId){
         return memberRoleRepository.save(new MemberRole(memberId, roleId));
     }
-
 
     public Optional<MemberRole> findById(MemberRoleId memberRoleId) {
         return memberRoleRepository.findById(memberRoleId);

--- a/web-ui/src/api/roles.js
+++ b/web-ui/src/api/roles.js
@@ -10,7 +10,6 @@ export const getAllRoles = async (cookie) => {
   });
 };
 
-
 export const getAllUserRoles = async (cookie) => {
   return resolve({
     url: roleURL + '/members',
@@ -18,6 +17,14 @@ export const getAllUserRoles = async (cookie) => {
     headers: { "X-CSRF-Header": cookie },
   });
 };
+
+export const getAllMembersGroupedByRole = async (cookie) => {
+  return resolve({
+    url: `${roleURL}/members/groupedByRole`,
+    responseType: "json",
+    headers: { "X-CSRF-Header": cookie }
+  });
+}
 
 export const removeUserFromRole = async (roleId, memberId, cookie) => {
   return resolve({

--- a/web-ui/src/components/admin/roles/RoleUserCards.jsx
+++ b/web-ui/src/components/admin/roles/RoleUserCards.jsx
@@ -11,44 +11,43 @@ import {
   Typography,
 } from "@mui/material";
 
-const RoleUserCards = ({ role, roleToMemberMap, removeFromRole }) => {
-  roleToMemberMap[role].sort((a, b) => a.name.localeCompare(b.name));
-  return roleToMemberMap[role].map(
-    (member) =>
-      member && (
-        <div key={member.id}>
-          <ListItem className="roles-list-item">
-            <ListItemAvatar>
-              <Avatar
-                alt={`${member.name}'s avatar`}
-                className="large"
-                src={getAvatarURL(member.workEmail)}
-              />
-            </ListItemAvatar>
-            <ListItemText
-              primary={
-                <Typography variant="h5" component="h2">
-                  {member.name}
-                </Typography>
-              }
-              secondary={
-                <Typography color="textSecondary" component="h3">
-                  {member.title}
-                </Typography>
-              }
+const RoleUserCards = ({ role, roleMembers, removeFromRole }) => {
+  roleMembers.sort((a, b) => a.name.localeCompare(b.name));
+  return roleMembers.map((member) =>
+    member && (
+      <div key={member.id}>
+        <ListItem className="roles-list-item">
+          <ListItemAvatar>
+            <Avatar
+              alt={`${member.name}'s avatar`}
+              className="large"
+              src={getAvatarURL(member.workEmail)}
             />
-            <div
-              className="icon"
-              onClick={() => {
-                removeFromRole(member, role);
-              }}
-            >
-              <DeleteIcon />
-            </div>
-          </ListItem>
-          <Divider variant="inset" component="li" />
-        </div>
-      )
+          </ListItemAvatar>
+          <ListItemText
+            primary={
+              <Typography variant="h5" component="h2">
+                {member.name}
+              </Typography>
+            }
+            secondary={
+              <Typography color="textSecondary" component="h3">
+                {member.title}
+              </Typography>
+            }
+          />
+          <div
+            className="icon"
+            onClick={() => {
+              removeFromRole(member, role);
+            }}
+          >
+            <DeleteIcon />
+          </div>
+        </ListItem>
+        <Divider variant="inset" component="li" />
+      </div>
+    )
   );
 };
 

--- a/web-ui/src/components/admin/roles/RoleUserCards.jsx
+++ b/web-ui/src/components/admin/roles/RoleUserCards.jsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 
-const RoleUserCards = ({ role, roleMembers, removeFromRole }) => {
+const RoleUserCards = ({ roleMembers, onRemove }) => {
   roleMembers.sort((a, b) => a.name.localeCompare(b.name));
   return roleMembers.map((member) =>
     member && (
@@ -38,9 +38,7 @@ const RoleUserCards = ({ role, roleMembers, removeFromRole }) => {
           />
           <div
             className="icon"
-            onClick={() => {
-              removeFromRole(member, role);
-            }}
+            onClick={() => onRemove(member)}
           >
             <DeleteIcon />
           </div>


### PR DESCRIPTION
Closes #1532 

This introduces a new method to the MemberRole service for retrieving all members in all roles, grouped by role:
```
[ { roleId: UUID, role: String, description: String, memberIds: [ UUID ] } ]
```

There are also some refactors on the front-end of the Roles page to accommodate this change.

To test, log in as an admin and go to http://localhost:3000/admin/roles. Try adding and removing members to/from roles.