### PR TITLE
Feature 1336/cancellation of feedback requests

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerServicesImpl.java
@@ -42,6 +42,8 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
         FeedbackRequest relatedFeedbackRequest = getRelatedFeedbackRequest(feedbackAnswer);
         if (!createIsPermitted(relatedFeedbackRequest)) {
             throw new PermissionException("You are not authorized to do this operation");
+        } else if (relatedFeedbackRequest.getStatus().equals("canceled")) {
+            throw new BadArgException("Attempted to save an answer for a canceled feedback request");
         }
         if (feedbackAnswer.getId() != null) {
             return update(feedbackAnswer);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -131,7 +131,11 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         boolean dueDateUpdateAttempted = !Objects.equals(originalFeedback.getDueDate(), feedbackRequest.getDueDate());
         boolean submitDateUpdateAttempted = !Objects.equals(originalFeedback.getSubmitDate(), feedbackRequest.getSubmitDate());
 
-        if(dueDateUpdateAttempted && !updateDueDateIsPermitted(feedbackRequest)) {
+        if (feedbackRequest.getStatus().equals("canceled") && originalFeedback.getStatus().equals("submitted")) {
+            throw new BadArgException("Attempted to cancel a feedback request that was already submitted");
+        }
+
+        if (dueDateUpdateAttempted && !updateDueDateIsPermitted(feedbackRequest)) {
             throw new PermissionException("You are not authorized to do this operation");
         }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.memberprofile.MemberProfileTestUtil.mkMemberProfile;
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1051,6 +1050,67 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
     }
 
     @Test
+    void testAdminCancelsFeedbackRequest() {
+        MemberProfile pdlMemberProfile = createADefaultMemberProfile();
+        MemberProfile employeeMemberProfile = createADefaultMemberProfileForPdl(pdlMemberProfile);
+        MemberProfile recipient = createADefaultRecipient();
+        MemberProfile admin = createASecondDefaultMemberProfile();
+        assignAdminRole(admin);
+
+        final FeedbackRequest feedbackReq = saveFeedbackRequest(pdlMemberProfile, employeeMemberProfile, recipient);
+        feedbackReq.setStatus("canceled");
+        feedbackReq.setDueDate(null);
+        final FeedbackRequestUpdateDTO dto = updateDTO(feedbackReq);
+
+        final HttpRequest<?> request = HttpRequest.PUT("", dto)
+                .basicAuth(admin.getWorkEmail(), RoleType.Constants.ADMIN_ROLE);
+        final HttpResponse<FeedbackRequestResponseDTO> response = client.toBlocking().exchange(request, FeedbackRequestResponseDTO.class);
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertTrue(response.getBody().isPresent());
+        assertResponseEqualsEntity(feedbackReq, response.getBody().get());
+    }
+
+    @Test
+    void testCreatorCancelsFeedbackRequest() {
+        MemberProfile pdlMemberProfile = createADefaultMemberProfile();
+        MemberProfile employeeMemberProfile = createADefaultMemberProfileForPdl(pdlMemberProfile);
+        MemberProfile recipient = createADefaultRecipient();
+
+        final FeedbackRequest feedbackReq = saveFeedbackRequest(pdlMemberProfile, employeeMemberProfile, recipient);
+        feedbackReq.setStatus("canceled");
+        feedbackReq.setDueDate(null);
+        final FeedbackRequestUpdateDTO dto = updateDTO(feedbackReq);
+
+        final HttpRequest<?> request = HttpRequest.PUT("", dto)
+                .basicAuth(pdlMemberProfile.getWorkEmail(), RoleType.Constants.PDL_ROLE);
+        final HttpResponse<FeedbackRequestResponseDTO> response = client.toBlocking().exchange(request, FeedbackRequestResponseDTO.class);
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertTrue(response.getBody().isPresent());
+        assertResponseEqualsEntity(feedbackReq, response.getBody().get());
+    }
+
+    @Test
+    void testUnauthorizedCancelsFeedbackRequest() {
+        MemberProfile pdlMemberProfile = createADefaultMemberProfile();
+        MemberProfile employeeMemberProfile = createADefaultMemberProfileForPdl(pdlMemberProfile);
+        MemberProfile recipient = createADefaultRecipient();
+
+        final FeedbackRequest feedbackReq = saveFeedbackRequest(pdlMemberProfile, employeeMemberProfile, recipient);
+        feedbackReq.setStatus("canceled");
+        feedbackReq.setDueDate(null);
+        final FeedbackRequestUpdateDTO dto = updateDTO(feedbackReq);
+
+        final HttpRequest<?> request = HttpRequest.PUT("", dto)
+                .basicAuth(employeeMemberProfile.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
+        final HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () ->
+                client.toBlocking().exchange(request, Map.class));
+
+        assertUnauthorized(responseException);
+    }
+
+    @Test
     void testDeleteFeedbackRequestByMember() {
         MemberProfile pdlMemberProfile = createADefaultMemberProfile();
         MemberProfile employeeMemberProfile = createADefaultMemberProfileForPdl(pdlMemberProfile);
@@ -1058,7 +1118,7 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
         MemberProfile recipient = createADefaultRecipient();
         FeedbackRequest feedbackReq = saveFeedbackRequest(pdlMemberProfile, employeeMemberProfile, recipient);
         getFeedbackRequestRepository().save(feedbackReq);
-        final MutableHttpRequest<?> request = HttpRequest.DELETE(String.format("/%s", feedbackReq.getId())).basicAuth(memberTwo.getWorkEmail(), MEMBER_ROLE);
+        final MutableHttpRequest<?> request = HttpRequest.DELETE(String.format("/%s", feedbackReq.getId())).basicAuth(memberTwo.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () ->
                 client.toBlocking().exchange(request, Map.class));
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackRequestFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackRequestFixture.java
@@ -34,6 +34,11 @@ public interface FeedbackRequestFixture extends RepositoryFixture {
         return getFeedbackRequestRepository().save(new FeedbackRequest(creator.getId(), requestee.getId(), recipient.getId(), templateId, testDate, null, "pending", null));
     }
 
+    default FeedbackRequest saveSampleFeedbackRequestWithStatus(MemberProfile creator, MemberProfile requestee, MemberProfile recipient, UUID templateId, String status) {
+        LocalDate testDate = LocalDate.of(2010, 10, 8);
+        return getFeedbackRequestRepository().save(new FeedbackRequest(creator.getId(), requestee.getId(), recipient.getId(), templateId, testDate, null, status, null));
+    }
+
     default MemberProfile createADefaultRecipient() {
         return getMemberProfileRepository().save(new MemberProfile("Ron", null, "Swanson",
                 null, "Parks Director", null, "Pawnee, Indiana",

--- a/web-ui/src/api/feedback.js
+++ b/web-ui/src/api/feedback.js
@@ -34,6 +34,21 @@ export const updateFeedbackRequest = async (feedbackRequest, cookie) => {
   });
 };
 
+export const cancelFeedbackRequest = async (feedbackRequest, cookie) => {
+  return resolve({
+    method: "put",
+    url: feedbackRequestURL,
+    responseType: "json",
+    data: {
+      ...feedbackRequest,
+      status: "canceled",
+      dueDate: null
+    },
+    headers: { "X-CSRF-Header": cookie }
+  });
+}
+
+
 export const deleteFeedbackRequestById = async (id, cookie) => {
   return resolve({
     method: "delete",

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.css
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.css
@@ -1,0 +1,8 @@
+.cancel-feedback-request-modal {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 700px;
+    padding: 0.5rem;
+}

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
@@ -17,6 +17,10 @@ exports[`renders correctly 1`] = `
   color: #333333;
 }
 
+.emotion-0 .FeedbackRequestSubcard-lightGrayTypography {
+  color: gray;
+}
+
 .emotion-1 {
   margin: 0;
   -webkit-flex-shrink: 0;

--- a/web-ui/src/components/received_request_card/ReceivedRequestCard.jsx
+++ b/web-ui/src/components/received_request_card/ReceivedRequestCard.jsx
@@ -16,7 +16,8 @@ const classes = {
   redTypography: `${PREFIX}-redTypography`,
   yellowTypography: `${PREFIX}-yellowTypography`,
   greenTypography: `${PREFIX}-greenTypography`,
-  darkGrayTypography: `${PREFIX}-darkGrayTypography`
+  darkGrayTypography: `${PREFIX}-darkGrayTypography`,
+  grayTypography: `${PREFIX}-grayTypography`
 };
 
 const StyledCard = styled(Card)({
@@ -31,7 +32,10 @@ const StyledCard = styled(Card)({
   },
   [`& .${classes.darkGrayTypography}`]: {
     color: "#333333",
-  }
+  },
+  [`& .${classes.grayTypography}`]: {
+    color: "gray",
+  },
 });
 
 const propTypes = {
@@ -65,6 +69,12 @@ const ReceivedRequestCard = ({ request }) => {
       return (
         <Typography className={classes.greenTypography}>
           Submitted {submitDate}
+        </Typography>
+      );
+    } else if (request.status === "canceled") {
+      return (
+        <Typography className={classes.grayTypography}>
+          Canceled
         </Typography>
       );
     } else
@@ -128,7 +138,7 @@ const ReceivedRequestCard = ({ request }) => {
             <Submitted />
           </div>
           <div className="submission-link-container">
-            {request && !request.submitDate && request.id ? (
+            {request && !request.submitDate && request.id && request.status !== "canceled" ? (
               <Link
                 to={`/feedback/submit?request=${request.id}`}
                 style={{ textDecoration: "none" }}

--- a/web-ui/src/pages/FeedbackSubmitPage.jsx
+++ b/web-ui/src/pages/FeedbackSubmitPage.jsx
@@ -39,8 +39,8 @@ const FeedbackSubmitPage = () => {
   const [feedbackRequest, setFeedbackRequest] = useState(null);
   const [requestee, setRequestee] = useState(null);
   const [requestSubmitted, setRequestSubmitted] = useState(false);
+  const [requestCanceled, setRequestCanceled] = useState(false);
   const feedbackRequestFetched = useRef(false);
-
   
   useEffect(() => {
     if (!requestQuery) {
@@ -84,6 +84,8 @@ const FeedbackSubmitPage = () => {
             });
           } else if (request.status.toLowerCase() === "submitted" || request.submitDate) {
             setRequestSubmitted(true);
+          } else if (request.status.toLowerCase() === "canceled") {
+            setRequestCanceled(true);
           } else {
               setFeedbackRequest(request);
           }
@@ -114,14 +116,17 @@ const FeedbackSubmitPage = () => {
 
   return (
     <Root className="feedback-submit-page">
-      {requestSubmitted ?
-        <Typography className={classes.announcement} variant="h3">You have already submitted this feedback form. Thank you!</Typography> :
-        <>
-          {feedbackRequestFetched.current && (showTips ?
-            <FeedbackSubmissionTips onNextClick={() => setShowTips(false)}/> :
-            <FeedbackSubmitForm requesteeName={requestee?.name} requestId={requestQuery} request={feedbackRequest}/>
-          )}
-        </>
+      {requestCanceled ?
+        <Typography className={classes.announcement} variant="h3">This feedback request has been canceled.</Typography> :
+        (requestSubmitted ?
+          <Typography className={classes.announcement} variant="h3">You have already submitted this feedback form. Thank you!</Typography> :
+          <>
+            {feedbackRequestFetched.current && (showTips ?
+              <FeedbackSubmissionTips onNextClick={() => setShowTips(false)}/> :
+              <FeedbackSubmitForm requesteeName={requestee?.name} requestId={requestQuery} request={feedbackRequest}/>
+            )}
+          </>
+        )
       }
     </Root>
   );


### PR DESCRIPTION
Closes #1336 and closes #1335

This replaces the existing functionality of deleting feedback requests with canceling them. This includes both front-end and back-end changes.