### PR TITLE
Feature 1711/simplify stepper for sending emails

### DIFF
--- a/web-ui/src/pages/EmailPage.css
+++ b/web-ui/src/pages/EmailPage.css
@@ -67,7 +67,7 @@
     border-top-left-radius: 0;
 }
 
-.send-email-to-all-confirmation-dialog {
+.send-email-to-all-confirmation-dialog, .change-email-format-confirmation-dialog {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/web-ui/src/pages/EmailPage.css
+++ b/web-ui/src/pages/EmailPage.css
@@ -11,18 +11,26 @@
     margin-top: 1rem;
 }
 
-.email-page .current-step-content-card .file-preview-container {
-    margin-top: 2rem;
+.email-page .email-format-container {
+    width: 100%;
+    text-align: center;
 }
 
-.email-page .current-step-content-card .file-preview-container .file-preview {
-    background-color: #282c34;
-    color: white;
-    width: 100%;
-    border: none;
-    outline: none;
-    resize: vertical;
-    min-height: 70px;
+.email-page .email-format-container .email-format-button {
+    color: #313131;
+    border: 2px solid #313131;
+    text-align: center;
+    margin: 0.5rem 3rem;
+}
+
+.email-page .email-format-container .email-format-button .email-format-button-content {
+    width: 250px;
+    height: 250px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }
 
 .email-page .current-step-content-card .email-subject-container {
@@ -45,7 +53,8 @@
     display: flex;
     flex-direction: row;
     align-items: flex-start;
-    margin-top: 2rem;
+    margin-top: 0.5rem;
+    margin-bottom: 2rem;
 }
 
 .email-page .current-step-content-card .send-test-email-input {

--- a/web-ui/src/pages/EmailPage.jsx
+++ b/web-ui/src/pages/EmailPage.jsx
@@ -35,39 +35,76 @@ const Root = styled("div")({
   margin: "2rem"
 });
 
-const ChooseEmailFormatStep = ({ emailFormat, onEmailFormatChange, emailSent }) => {
+const ChooseEmailFormatStep = ({ emailFormat, onEmailFormatChange, emailContents, emailSent }) => {
+
+  const [formatDialog, setFormatDialog] = useState({open: false, format: null});
+
+  const handleFormatButtonClick = (format) => {
+    // Do nothing if the same button is clicked again
+    if (format === emailFormat) {
+      return;
+    }
+
+    // If the user tries to change the email format after composing an email, warn with dialog
+    if (emailFormat && emailContents.length > 0 && format !== emailFormat) {
+      setFormatDialog({open: true, format: format});
+    } else {
+      onEmailFormatChange(format);
+    }
+  }
 
   return (
-    <div className="email-format-container">
-      <Button
-        className="email-format-button"
-        style={emailFormat === "file" ? { borderColor: "green", backgroundColor: "#f7fff7" } : {}}
-        disabled={emailSent}
-        onClick={() => onEmailFormatChange("file")}>
-        <div className="email-format-button-content">
-          {emailFormat === "file" &&
-            <CheckIcon style={{ position: "absolute", right: "1rem", top: "1rem", color: "green" }}/>
-          }
-          <UploadFileIcon sx={{ fontSize: "80px", marginBottom: "1rem" }}/>
-          <Typography variant="h6" fontWeight="bold">MJML File</Typography>
-          <Typography variant="body2" color="gray">Create an email with a custom format using MJML</Typography>
-        </div>
-      </Button>
-      <Button
-        className="email-format-button"
-        style={emailFormat === "text" ? { borderColor: "green", backgroundColor: "#f7fff7" } : {}}
-        disabled={emailSent}
-        onClick={() => onEmailFormatChange("text")}>
-        <div className="email-format-button-content">
-          {emailFormat === "text" &&
-            <CheckIcon style={{position: "absolute", right: "1rem", top: "1rem", color: "green"}}/>
-          }
-          <EditIcon sx={{ fontSize: "80px", marginBottom: "1rem" }} />
-          <Typography variant="h6" fontWeight="bold">Text</Typography>
-          <Typography variant="body2" color="gray">Write a simple email with no formatting</Typography>
-        </div>
-      </Button>
-    </div>
+    <>
+      <div className="email-format-container">
+        <Button
+          className="email-format-button"
+          style={emailFormat === "file" ? { borderColor: "green", backgroundColor: "#f7fff7" } : {}}
+          disabled={emailSent}
+          onClick={() => handleFormatButtonClick("file")}>
+          <div className="email-format-button-content">
+            {emailFormat === "file" &&
+              <CheckIcon style={{ position: "absolute", right: "1rem", top: "1rem", color: "green" }}/>
+            }
+            <UploadFileIcon sx={{ fontSize: "80px", marginBottom: "1rem" }}/>
+            <Typography variant="h6" fontWeight="bold">MJML File</Typography>
+            <Typography variant="body2" color="gray">Create an email with a custom format using MJML</Typography>
+          </div>
+        </Button>
+        <Button
+          className="email-format-button"
+          style={emailFormat === "text" ? { borderColor: "green", backgroundColor: "#f7fff7" } : {}}
+          disabled={emailSent}
+          onClick={() => handleFormatButtonClick("text")}>
+          <div className="email-format-button-content">
+            {emailFormat === "text" &&
+              <CheckIcon style={{position: "absolute", right: "1rem", top: "1rem", color: "green"}}/>
+            }
+            <EditIcon sx={{ fontSize: "80px", marginBottom: "1rem" }} />
+            <Typography variant="h6" fontWeight="bold">Text</Typography>
+            <Typography variant="body2" color="gray">Write a simple email with no formatting</Typography>
+          </div>
+        </Button>
+      </div>
+      <Modal open={formatDialog.open}>
+        <Card className="change-email-format-confirmation-dialog">
+          <CardHeader title={<Typography variant="h5" fontWeight="bold">Change Email Format</Typography>}/>
+          <CardContent>
+            <Typography>You are attempting to change the format of this email, but you have already written a draft in the following step. Changing the format will reset this draft.</Typography>
+          </CardContent>
+          <CardActions>
+            <Button style={{ color: "gray" }} onClick={() => setFormatDialog({open: false, format: null})}>
+              Cancel
+            </Button>
+            <Button color="secondary" onClick={() => {
+              onEmailFormatChange(formatDialog.format);
+              setFormatDialog({open: false, format: null});
+            }}>
+              Discard Email Draft
+            </Button>
+          </CardActions>
+        </Card>
+      </Modal>
+    </>
   );
 }
 
@@ -168,6 +205,7 @@ const ComposeEmailStep = ({ emailFormat, emailContents, emailSubject, onSubjectC
           fullWidth
           multiline
           minRows={3}
+          maxRows={20}
           placeholder="Write your email here..."
           value={emailContents}
           onChange={(event) => onEmailContentsChange(event.target.value)}
@@ -381,7 +419,11 @@ const EmailPage = () => {
           {currentStep === 0 && (
             <ChooseEmailFormatStep
               emailFormat={emailFormat}
-              onEmailFormatChange={(format) => setEmailFormat(format)}
+              onEmailFormatChange={(format) => {
+                setEmailFormat(format);
+                setEmailContents("");
+              }}
+              emailContents={emailContents}
               emailSent={emailSent}
             />
           )}

--- a/web-ui/src/pages/EmailPage.jsx
+++ b/web-ui/src/pages/EmailPage.jsx
@@ -10,7 +10,6 @@ import {
   Step,
   StepLabel,
   Stepper,
-  TextareaAutosize,
   TextField, Tooltip,
   Typography,
 } from "@mui/material";
@@ -19,6 +18,8 @@ import LeftArrowIcon from "@mui/icons-material/KeyboardArrowLeft";
 import RightArrowIcon from "@mui/icons-material/KeyboardArrowRight";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import SendIcon from "@mui/icons-material/Send";
+import EditIcon from "@mui/icons-material/Edit";
+import CheckIcon from "@mui/icons-material/CheckCircle";
 import {AppContext} from "../context/AppContext";
 import mjml2html from "mjml-browser";
 import ReactHtmlParser from "react-html-parser";
@@ -34,103 +35,153 @@ const Root = styled("div")({
   margin: "2rem"
 });
 
-const UploadFileStep = ({ emailFile, emailContents, onEmailFileChange, onEmailContentsChange, emailSent }) => {
+const ChooseEmailFormatStep = ({ emailFormat, onEmailFormatChange, emailSent }) => {
+
+  return (
+    <div className="email-format-container">
+      <Button
+        className="email-format-button"
+        style={emailFormat === "file" ? { borderColor: "green", backgroundColor: "#f7fff7" } : {}}
+        disabled={emailSent}
+        onClick={() => onEmailFormatChange("file")}>
+        <div className="email-format-button-content">
+          {emailFormat === "file" &&
+            <CheckIcon style={{ position: "absolute", right: "1rem", top: "1rem", color: "green" }}/>
+          }
+          <UploadFileIcon sx={{ fontSize: "80px", marginBottom: "1rem" }}/>
+          <Typography variant="h6" fontWeight="bold">MJML File</Typography>
+          <Typography variant="body2" color="gray">Create an email with a custom format using MJML</Typography>
+        </div>
+      </Button>
+      <Button
+        className="email-format-button"
+        style={emailFormat === "text" ? { borderColor: "green", backgroundColor: "#f7fff7" } : {}}
+        disabled={emailSent}
+        onClick={() => onEmailFormatChange("text")}>
+        <div className="email-format-button-content">
+          {emailFormat === "text" &&
+            <CheckIcon style={{position: "absolute", right: "1rem", top: "1rem", color: "green"}}/>
+          }
+          <EditIcon sx={{ fontSize: "80px", marginBottom: "1rem" }} />
+          <Typography variant="h6" fontWeight="bold">Text</Typography>
+          <Typography variant="body2" color="gray">Write a simple email with no formatting</Typography>
+        </div>
+      </Button>
+    </div>
+  );
+}
+
+const ComposeEmailStep = ({ emailFormat, emailContents, emailSubject, onSubjectChange, onEmailContentsChange, emailSent }) => {
+
+  const [emailPreview, setEmailPreview] = useState(null);
 
   const handleFileUpload = (event) => {
     if (event.target.files && event.target.files[0]) {
       const fileReader = new FileReader();
       fileReader.onload = (e) => {
-        const content = e.target.result.toString();
-        onEmailContentsChange(content);
+        const mjmlContent = e.target.result.toString();
+        const { html } = mjml2html(mjmlContent);
+        onEmailContentsChange(html);
       }
 
       const file = event.target.files[0];
-      onEmailFileChange(file);
       fileReader.readAsText(file);
     }
   }
 
-  return (
-    <>
-      <Typography variant="body1">Select a MJML file to render the email. The file must have a .mjml extension.</Typography>
-      <Button variant="contained" component="label" startIcon={<UploadFileIcon/>} disableElevation disabled={emailSent}>
-        Choose File
-        <input
-          type="file"
-          accept=".mjml"
-          hidden
-          onChange={handleFileUpload}
-        />
-      </Button>
-      <div className="file-preview-container">
-        <Typography variant="body1" fontWeight={emailFile ? "bold" : "normal"}>{emailFile ? emailFile.name : "No file uploaded"}</Typography>
-        {emailContents &&
-          <TextareaAutosize
-            className="file-preview"
-            style={{overflow: "auto"}}
-            value={emailContents}
-            minRows={3}
-            maxRows={emailContents.split("\n").length}
-            readOnly/>
-        }
-      </div>
-    </>
-  );
-}
+  useEffect(() => {
+    if (emailContents && emailFormat === "file") {
+      const preview = ReactHtmlParser(emailContents);
+      setEmailPreview(preview);
+    }
+  }, [emailFormat, emailContents]);
 
-const PreviewEmailStep = ({ emailContents, emailSubjectError, emailSubject, onSubjectChange }) => {
-
-  if (!emailContents) {
+  if (emailFormat === "file") {
     return (
-      <div className="missing-preview-message">
-        <Typography variant="h6">Preview not available</Typography>
-      </div>
+      <>
+        <div className="email-subject-container">
+          <Typography
+            variant="body1"
+            fontWeight="bold"
+            style={{marginRight: "1rem", marginTop: "6px"}}>
+            Subject:
+          </Typography>
+          <TextField
+            fullWidth
+            placeholder="Write a subject for the email"
+            disabled={emailSent}
+            value={emailSubject}
+            onChange={(event) => {
+              onSubjectChange(event.target.value);
+            }}
+          />
+        </div>
+
+        {emailContents
+          ? emailPreview
+          : <>
+            <Typography variant="body1">Select a MJML file to render the email. The file must have a .mjml extension.</Typography>
+            <Button
+              variant="contained"
+              component="label"
+              startIcon={<UploadFileIcon/>}
+              style={{ marginBottom: "2rem" }}
+              disableElevation
+              disabled={emailSent}>
+              Choose File
+              <input
+                type="file"
+                accept=".mjml"
+                hidden
+                onChange={handleFileUpload}
+              />
+            </Button>
+            <div className="missing-preview-message">
+              <Typography variant="h6">Preview not available</Typography>
+            </div>
+          </>
+        }
+      </>
+    );
+  } else if (emailFormat === "text") {
+    return (
+      <>
+        <div className="email-subject-container">
+          <Typography
+            variant="body1"
+            fontWeight="bold"
+            style={{marginRight: "1rem", marginTop: "6px"}}>
+            Subject:
+          </Typography>
+          <TextField
+            fullWidth
+            placeholder="Write a subject for the email"
+            disabled={emailSent}
+            value={emailSubject}
+            onChange={(event) => {
+              onSubjectChange(event.target.value);
+            }}
+          />
+        </div>
+        <TextField
+          variant="outlined"
+          fullWidth
+          multiline
+          minRows={3}
+          placeholder="Write your email here..."
+          value={emailContents}
+          onChange={(event) => onEmailContentsChange(event.target.value)}
+        />
+      </>
     );
   }
 
-  const { html } = mjml2html(emailContents);
-  const emailPreview = ReactHtmlParser(html);
-
-  return (
-    <>
-      <div className="email-subject-container">
-        <Typography
-          variant="body1"
-          fontWeight="bold"
-          style={{marginRight: "1rem", marginTop: "6px"}}>
-          Subject:
-        </Typography>
-        <TextField
-          fullWidth
-          placeholder="Write a subject for the email"
-          error={emailSubjectError}
-          helperText={emailSubjectError ? "Email is missing subject" : ""}
-          value={emailSubject}
-          onChange={(event) => {
-            onSubjectChange(event.target.value);
-          }}
-        />
-      </div>
-      {emailPreview}
-    </>
-  );
+  return <></>
 }
 
-const SelectRecipientsStep = ({ recipientOptions, recipients, onRecipientsChange, emailSent }) => {
-  return (
-    <TransferList
-      leftList={recipientOptions}
-      rightList={recipients}
-      leftLabel="Select Recipients"
-      rightLabel="Recipients"
-      onListsChanged={(lists) => onRecipientsChange(lists)}
-      disabled={emailSent}
-    />
-  );
-}
+const SelectRecipientsStep = ({ testEmail, onTestEmailChange, onSendTestEmail, recipientOptions, recipients, onRecipientsChange, emailSent }) => {
 
-const SendEmailStep = ({ testEmail, onTestEmailChange, onSendTestEmail, emailFile, emailSent }) => {
-  const [emailError, setEmailError] = useState(false)
+  const [emailError, setEmailError] = useState(false);
 
   const handleSendButtonClick = () => {
     let regEmail = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/
@@ -141,15 +192,9 @@ const SendEmailStep = ({ testEmail, onTestEmailChange, onSendTestEmail, emailFil
     }
   }
 
-  if (emailSent) {
-    return (
-      <Typography>The email <b>{emailFile}</b> has been sent.</Typography>
-    )
-  }
-
   return (
     <>
-      <Typography variant="body1">To test this email and see how it will appear in an inbox, you can send it to an email address you have access to. If you are satisfied with the email, click the send button at the bottom of the page to send to everyone.</Typography>
+      <Typography variant="body1">To test this email and see how it will appear in an inbox, you can send it to an email address you have access to. If you are satisfied with this email, then select recipients from the list below.</Typography>
       <div className="send-test-email-container">
         <TextField
           className="send-test-email-input"
@@ -178,6 +223,14 @@ const SendEmailStep = ({ testEmail, onTestEmailChange, onSendTestEmail, emailFil
           Send Test Email
         </Button>
       </div>
+      <TransferList
+        leftList={recipientOptions}
+        rightList={recipients}
+        leftLabel="Select Recipients"
+        rightLabel="Recipients"
+        onListsChanged={(lists) => onRecipientsChange(lists)}
+        disabled={emailSent}
+      />
     </>
   );
 }
@@ -186,10 +239,9 @@ const EmailPage = () => {
   const { state } = useContext(AppContext);
   const { memberProfiles, csrf } = state;
   const [currentStep, setCurrentStep] = useState(0);
-  const [emailFile, setEmailFile] = useState(null);
+  const [emailFormat, setEmailFormat] = useState(null);
   const [emailContents, setEmailContents] = useState("");
   const [emailSubject, setEmailSubject] = useState("");
-  const [emailSubjectError, setEmailSubjectError] = useState(false);
   const [recipientOptions, setRecipientOptions] = useState([]);
   const [recipients, setRecipients] = useState([]);
   const [testEmail, setTestEmail] = useState("");
@@ -197,7 +249,7 @@ const EmailPage = () => {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
   const [activeMembers, setActiveMembers] = useState([]);
   const [emailSent, setEmailSent] = useState(false);
-  const steps = ["Upload File", "Preview Email", "Select Recipients", "Send Email"];
+  const steps = ["Choose Email Format", "Compose Email", "Select Recipients"];
 
   useEffect(() => {
     const unterminatedMembers = memberProfiles.filter(member => member.terminationDate === null);
@@ -208,13 +260,17 @@ const EmailPage = () => {
     setRecipientOptions(activeMembers);
   }, [activeMembers]);
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [currentStep]);
+
   const sendTestEmail = () => {
 
     if (!emailSubject.trim() || !emailContents || !csrf) {
       return;
     }
 
-    sendEmail(`Test Email - ${emailSubject}`, mjml2html(emailContents)?.html, [testEmail], csrf).then(res => {
+    sendEmail(`Test Email - ${emailSubject}`, emailContents, [testEmail], csrf).then(res => {
       let toastMessage, toastStatus;
       if (res && res.payload && res.payload.status === 201 && !res.error) {
         setTestEmailSent(true);
@@ -243,12 +299,12 @@ const EmailPage = () => {
 
     const recipientEmails = recipients.map((member) => member.workEmail);
 
-    sendEmail(emailSubject, mjml2html(emailContents)?.html, recipientEmails, csrf).then(res => {
+    sendEmail(emailSubject, emailContents, recipientEmails, csrf).then(res => {
       let toastMessage, toastStatus;
       if (res && res.payload && res.payload.status === 201 && !res.error) {
         setEmailSent(true);
         toastStatus = "success";
-        toastMessage = `Sent email to ${activeMembers.length} member${activeMembers.length === 1 ? "" : "s"}`;
+        toastMessage = `Sent email to ${recipients.length} member${recipients.length === 1 ? "" : "s"}`;
       } else {
         toastStatus = "error";
         toastMessage = "Failed to send email";
@@ -264,36 +320,30 @@ const EmailPage = () => {
   }
 
   const handleNextClick = () => {
-    window.scrollTo(0, 0);
     switch (currentStep) {
       case 0:
+      case 1:
         setCurrentStep(currentStep + 1);
         break;
-      case 1:
-        if (emailSubject.trim().length > 0 || !emailFile) {
-          setCurrentStep(currentStep + 1);
-        } else {
-          setEmailSubjectError(true);
-        }
-        break;
       case 2:
-        if (recipients.length > 0) {
-          setCurrentStep(currentStep + 1);
-        } else {
-          window.snackDispatch({
-            type: UPDATE_TOAST,
-            payload: {
-              severity: "error",
-              toast: "You must select at least one recipient"
-            }
-          });
-        }
-        break;
-      case 3:
         setConfirmationDialogOpen(true);
         break;
       default:
         console.warn(`Invalid step in stepper: ${currentStep}`);
+    }
+  }
+
+  const nextButtonEnabled = () => {
+    switch (currentStep) {
+      case 0:
+        return !!emailFormat;
+      case 1:
+        return emailSubject.trim().length > 0 && !!emailContents;
+      case 2:
+        return !!emailContents && recipients.length > 0 && !emailSent;
+      default:
+        console.warn(`Invalid step in stepper: ${currentStep}`);
+        return false;
     }
   }
 
@@ -304,13 +354,11 @@ const EmailPage = () => {
 
     switch (step) {
       case 0:
-        return !!emailFile && currentStep > 0;
+        return emailFormat && currentStep > 0;
       case 1:
-        return !!emailFile && currentStep > 1;
+        return !!emailContents && !!emailSubject && currentStep > 1;
       case 2:
-        return recipients.length > 0 && currentStep > 2;
-      case 3:
-        return emailSent;
+        return recipients.length > 0 && emailSent;
       default:
         console.warn(`Invalid step in stepper: ${currentStep}`);
     }
@@ -331,27 +379,27 @@ const EmailPage = () => {
         <CardHeader title={steps[currentStep]}/>
         <CardContent>
           {currentStep === 0 && (
-            <UploadFileStep
-              emailFile={emailFile}
-              emailContents={emailContents}
-              onEmailFileChange={(file) => setEmailFile(file)}
-              onEmailContentsChange={(content) => setEmailContents(content)}
+            <ChooseEmailFormatStep
+              emailFormat={emailFormat}
+              onEmailFormatChange={(format) => setEmailFormat(format)}
               emailSent={emailSent}
             />
           )}
           {currentStep === 1 && (
-            <PreviewEmailStep
+            <ComposeEmailStep
+              emailFormat={emailFormat}
               emailContents={emailContents}
-              emailSubjectError={emailSubjectError}
+              onEmailContentsChange={(content) => setEmailContents(content)}
               emailSubject={emailSubject}
-              onSubjectChange={(subject) => {
-                setEmailSubject(subject);
-                setEmailSubjectError(false);
-              }}
+              onSubjectChange={(subject) => setEmailSubject(subject)}
+              emailSent={emailSent}
             />
           )}
           {currentStep === 2 && (
             <SelectRecipientsStep
+              testEmail={testEmail}
+              onTestEmailChange={(address) => setTestEmail(address)}
+              onSendTestEmail={sendTestEmail}
               recipientOptions={recipientOptions}
               recipients={recipients}
               emailSent={emailSent}
@@ -359,15 +407,6 @@ const EmailPage = () => {
                 setRecipientOptions(left);
                 setRecipients(right);
               }}
-            />
-          )}
-          {currentStep === 3 && (
-            <SendEmailStep
-              testEmail={testEmail}
-              onTestEmailChange={(address) => setTestEmail(address)}
-              onSendTestEmail={sendTestEmail}
-              emailFile={emailFile?.name}
-              emailSent={emailSent}
             />
           )}
         </CardContent>
@@ -378,7 +417,11 @@ const EmailPage = () => {
           variant="outlined"
           startIcon={<LeftArrowIcon/>}
           disabled={currentStep === 0}
-          onClick={() => currentStep > 0 ? setCurrentStep(currentStep - 1) : null}>
+          onClick={() => {
+            if (currentStep > 0) {
+              setCurrentStep(currentStep - 1);
+            }
+          }}>
           Back
         </Button>
         <Button
@@ -386,7 +429,7 @@ const EmailPage = () => {
           variant="contained"
           color={currentStep === steps.length - 1 ? "success" : "primary"}
           endIcon={currentStep === steps.length - 1 ? <SendIcon/> : <RightArrowIcon/>}
-          disabled={currentStep === steps.length - 1 && (!emailFile || emailSent)}
+          disabled={!nextButtonEnabled()}
           onClick={handleNextClick}>
           {currentStep === steps.length - 1 ? "Send" : "Next"}
         </Button>
@@ -396,7 +439,7 @@ const EmailPage = () => {
           <CardHeader title={<Typography variant="h5" fontWeight="bold">Send Email</Typography>}/>
           <CardContent>
             <Typography variant="body1">
-              You are about to send the email <b>{emailFile?.name}</b> to {recipients.length} member{recipients.length === 1 ? "" : "s"} in Check-Ins. Are you sure?
+              You are about to send this email to {recipients.length} member{recipients.length === 1 ? "" : "s"} in Check-Ins. Are you sure?
             </Typography>
             <div className="recipient-group-container">
               <AvatarGroup max={16}>
@@ -417,7 +460,7 @@ const EmailPage = () => {
             <Button style={{ color: "gray" }} onClick={() => setConfirmationDialogOpen(false)}>
               Cancel
             </Button>
-            <Button color="primary" onClick={emailFile && sendEmailToAllRecipients} disabled={!emailFile}>
+            <Button color="primary" onClick={emailContents && sendEmailToAllRecipients} disabled={!emailContents}>
               Send
             </Button>
           </CardActions>


### PR DESCRIPTION
Closes #1711 

- Remove the preview of the text of the MJML file (only the formatted email is useful to show)
- Merge the uploading a file and previewing the email into one step
- Merge sending test email with selecting recipients into one step
- Add step for selecting whether the email is a file upload or plaintext
- Add text field for the email content if the user chooses plaintext
- Adjust text on toast to accurately reflect the number of recipients
- Rework validations to prevent moving to next step until criteria are met