### PR TITLE
Feature 1713/filter email recipients

### DIFF
--- a/web-ui/src/api/guild.js
+++ b/web-ui/src/api/guild.js
@@ -17,7 +17,7 @@ export const getMembersByGuild = async (id, cookie) => {
     url: guildMemberUrl,
     responseType: "json",
     params: {
-      guildId: id,
+      guildid: id,
     },
     withCredentials: true,
     headers: { "X-CSRF-Header": cookie },

--- a/web-ui/src/components/transfer_list/TransferList.css
+++ b/web-ui/src/components/transfer_list/TransferList.css
@@ -2,7 +2,7 @@
     display: grid;
     grid-template-columns: minmax(270px, 1fr) 7rem minmax(270px, 1fr);
     justify-content: center;
-    align-items: center;
+    align-items: start;
 }
 
 .transfer-list .empty-list-message-container {
@@ -19,4 +19,19 @@
     background-color: #e8e8e8;
     border: 1px dashed #c2c2c2;
     border-radius: 4px;
+}
+
+.transfer-list-filter-container {
+    display: grid;
+    grid-template-columns: 1fr 150px;
+    grid-column-gap: 10px;
+    padding: 8px 16px 16px 16px;
+}
+
+.transfer-list-filter-container .transfer-list-filter-field {
+    width: 100%;
+}
+
+.transfer-list-filter-container .transfer-list-filter {
+    width: 100%;
 }

--- a/web-ui/src/components/transfer_list/TransferList.jsx
+++ b/web-ui/src/components/transfer_list/TransferList.jsx
@@ -243,9 +243,7 @@ const TransferList = ({ leftList, rightList, leftLabel, rightLabel, onListsChang
                   disablePortal
                   options={filterOptions[recipientFilter]}
                   getOptionLabel={(option) => option.name}
-                  isOptionEqualToValue={(option, value) => {
-                    return option.name === value;
-                  }}
+                  isOptionEqualToValue={(option, value) => option.name === value.name}
                   value={recipientQuery}
                   onChange={(event, value) => setRecipientQuery(value)}
                   renderInput={(params) => (

--- a/web-ui/src/components/transfer_list/TransferList.jsx
+++ b/web-ui/src/components/transfer_list/TransferList.jsx
@@ -318,7 +318,7 @@ const TransferList = ({ leftList, rightList, leftLabel, rightLabel, onListsChang
                 />
               }
             >
-              <ListItemButton disableTouchRipple={disabled}>
+              <ListItemButton selected={checked.indexOf(member) !== -1} disableTouchRipple={disabled}>
                 <ListItemAvatar>
                   <Avatar src={getAvatarURL(member?.workEmail)}/>
                 </ListItemAvatar>


### PR DESCRIPTION
Closes #1713
- Adds a filter for selecting email recipients
- Filter options: name, guild, team, title, location

Should checked items in the left list remain visible even if they are not included by the filter?