### PR TITLE
Bugfix 1715/terminated members included in skill reports

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -869,3 +869,18 @@ INSERT INTO skills
 (id, name, pending, description, extraneous)
 VALUES
 ('84682de9-85a7-4bf7-b74b-e9054311a61a', 'Git', true, 'Version control system', false);
+
+INSERT INTO member_skills
+(id, memberid, skillid, skilllevel, lastuseddate)
+VALUES
+('99b7b700-bba3-440b-8df5-c1b668e9e7e0', '72655c4f-1fb8-4514-b31e-7f7e19fa9bd7', 'f057af45-e627-499c-8a71-1e6b4ab2fcd2', '5', '2022-06-01');
+
+INSERT INTO member_skills
+(id, memberid, skillid, skilllevel, lastuseddate)
+VALUES
+('daad16fa-2268-4e72-a2ad-e13aa8b8665b', '72655c4f-1fb8-4514-b31e-7f7e19fa9bd7', '6b56f0aa-09aa-4b09-bb81-03481af7e49f', '4', '2022-06-01');
+
+INSERT INTO member_skills
+(id, memberid, skillid, skilllevel, lastuseddate)
+VALUES
+('e2de59a8-71be-4972-86be-608538503195', '105f2968-a182-45a3-892c-eeff76383fe0', 'f057af45-e627-499c-8a71-1e6b4ab2fcd2', '3', '2022-05-01');

--- a/web-ui/src/components/member-directory/MemberModal.jsx
+++ b/web-ui/src/components/member-directory/MemberModal.jsx
@@ -266,7 +266,7 @@ const MemberModal = ({ member, open, onSave, onClose }) => {
           }
         />
         <Autocomplete
-          options={sortedPdls && ["", ...sortedPdls]}
+          options={sortedPdls}
           value={
             (sortedPdls &&
               sortedPdls.find((pdl) => pdl?.id === editedMember.pdlId)) ||

--- a/web-ui/src/context/selectors.js
+++ b/web-ui/src/context/selectors.js
@@ -126,10 +126,17 @@ export const selectPdlRoles = createSelector(selectRoles, (roles) =>
   roles?.filter((role) => role.role?.includes("PDL"))
 );
 
+export const selectCurrentUserRoles = createSelector(
+  selectUserRoles,
+  selectCurrentMemberIds,
+  (userRoles, memberIds) =>
+    userRoles?.filter((userRole) => memberIds.includes(userRole.memberRoleId.memberId))
+);
+
 export const selectMappedPdls = createSelector(
   selectProfileMap,
   selectPdlRoles,
-  selectUserRoles,
+  selectCurrentUserRoles,
   (memberProfileMap, roles, userRoles) =>
     userRoles?.filter((userRole) => roles.find((role) => role.id === userRole?.memberRoleId?.roleId ) !== undefined)?.map((userRole) =>
       userRole?.memberRoleId?.memberId in memberProfileMap ? memberProfileMap[userRole?.memberRoleId?.memberId] : {}

--- a/web-ui/src/context/selectors.js
+++ b/web-ui/src/context/selectors.js
@@ -152,6 +152,12 @@ export const selectOrderedMemberProfiles = createSelector(
     mappedMemberProfiles.sort((a, b) => a.lastName.localeCompare(b.lastName))
 );
 
+export const selectOrderedCurrentMemberProfiles = createSelector(
+  selectCurrentMembers,
+  (mappedMemberProfiles) =>
+    mappedMemberProfiles.sort((a, b) => a.lastName.localeCompare(b.lastName))
+);
+
 export const selectOrderedMemberFirstName = createSelector(
   selectMemberProfiles,
   (mappedMemberProfiles) =>

--- a/web-ui/src/context/selectors.test.js
+++ b/web-ui/src/context/selectors.test.js
@@ -140,15 +140,6 @@ describe("Selectors", () => {
         role: "PDL",
       },
     ];
-    const testMemberRoles = [
-      {
-        id: "11",
-        memberid: "1",
-        role: "MEMBER",
-      },
-      matchingRoles[0],
-      matchingRoles[1],
-    ];
     const testState = {
       roles: [
         {
@@ -173,51 +164,9 @@ describe("Selectors", () => {
   });
 
   it("selectMappedPdls should return an array of all member PDL profiles", () => {
-    const testMemberProfiles = [
-      {
-        id: 1,
-        bioText: "foo",
-        employeeId: 11,
-        name: "A Person",
-        firstName: "A",
-        lastName: "PersonA",
-        location: "St Louis",
-        title: "engineer",
-        workEmail: "employee@sample.com",
-        pdlId: 9,
-        startDate: [2012, 9, 29],
-      },
-      {
-        id: 2,
-        bioText: "foo",
-        employeeId: 12,
-        name: "B Person",
-        firstName: "B",
-        lastName: "PersonB",
-        location: "St Louis",
-        title: "engineer",
-        workEmail: "employee@sample.com",
-        pdlId: 9,
-        startDate: [2012, 9, 29],
-      },
-      {
-        id: 3,
-        bioText: "foo",
-        employeeId: 13,
-        name: "C Person",
-        firstName: "C",
-        lastName: "PersonC",
-        location: "St Louis",
-        title: "engineer",
-        workEmail: "employee@sample.com",
-        pdlId: 9,
-        startDate: [2012, 9, 29],
-      },
-    ];
-
     const matchingMembers = [
       {
-        id: 2,
+        id: "2",
         bioText: "foo",
         employeeId: 12,
         name: "B Person",
@@ -230,7 +179,7 @@ describe("Selectors", () => {
         startDate: [2012, 9, 29],
       },
       {
-        id: 3,
+        id: "3",
         bioText: "foo",
         employeeId: 13,
         name: "C Person",
@@ -284,7 +233,7 @@ describe("Selectors", () => {
     const testState = {
       memberProfiles: [
         {
-          id: 1,
+          id: "1",
           bioText: "foo",
           employeeId: 11,
           name: "A Person",
@@ -297,7 +246,7 @@ describe("Selectors", () => {
           startDate: [2012, 9, 29],
         },
         {
-          id: 2,
+          id: "2",
           bioText: "foo",
           employeeId: 12,
           name: "B Person",
@@ -310,7 +259,7 @@ describe("Selectors", () => {
           startDate: [2012, 9, 29],
         },
         {
-          id: 3,
+          id: "3",
           bioText: "foo",
           employeeId: 13,
           name: "C Person",
@@ -330,51 +279,9 @@ describe("Selectors", () => {
   });
 
   it("selectOrderedPdls should return an array of all member PDL profiles ordered by last name", () => {
-    const testMemberProfiles = [
-      {
-        id: 1,
-        bioText: "foo",
-        employeeId: 11,
-        name: "A PersonA",
-        firstName: "A",
-        lastName: "PersonA",
-        location: "St Louis",
-        title: "engineer",
-        workEmail: "employee@sample.com",
-        pdlId: 9,
-        startDate: [2012, 9, 29],
-      },
-      {
-        id: 2,
-        bioText: "foo",
-        employeeId: 12,
-        name: "C PersonC",
-        firstName: "C",
-        lastName: "PersonC",
-        location: "St Louis",
-        title: "engineer",
-        workEmail: "employee@sample.com",
-        pdlId: 9,
-        startDate: [2012, 9, 29],
-      },
-      {
-        id: 3,
-        bioText: "foo",
-        employeeId: 13,
-        name: "B PersonB",
-        firstName: "B",
-        lastName: "PersonB",
-        location: "St Louis",
-        title: "engineer",
-        workEmail: "employee@sample.com",
-        pdlId: 9,
-        startDate: [2012, 9, 29],
-      },
-    ];
-
     const matchingMembers = [
       {
-        id: 3,
+        id: "3",
         bioText: "foo",
         employeeId: 13,
         name: "B PersonB",
@@ -387,7 +294,7 @@ describe("Selectors", () => {
         startDate: [2012, 9, 29],
       },
       {
-        id: 2,
+        id: "2",
         bioText: "foo",
         employeeId: 12,
         name: "C PersonC",
@@ -441,7 +348,7 @@ describe("Selectors", () => {
     const testState = {
       memberProfiles: [
         {
-          id: 1,
+          id: "1",
           bioText: "foo",
           employeeId: 11,
           name: "A PersonA",
@@ -454,7 +361,7 @@ describe("Selectors", () => {
           startDate: [2012, 9, 29],
         },
         {
-          id: 2,
+          id: "2",
           bioText: "foo",
           employeeId: 12,
           name: "C PersonC",
@@ -467,7 +374,7 @@ describe("Selectors", () => {
           startDate: [2012, 9, 29],
         },
         {
-          id: 3,
+          id: "3",
           bioText: "foo",
           employeeId: 13,
           name: "B PersonB",

--- a/web-ui/src/pages/SkillReportPage.jsx
+++ b/web-ui/src/pages/SkillReportPage.jsx
@@ -7,7 +7,7 @@ import SearchResults from "../components/search-results/SearchResults";
 import {
   selectOrderedSkills,
   selectCsrfToken,
-  selectOrderedMemberProfiles,
+  selectCurrentMemberIds,
 } from "../context/selectors";
 
 import { Button, TextField } from "@mui/material";
@@ -19,7 +19,7 @@ const SkillReportPage = (props) => {
   const { state } = useContext(AppContext);
   const csrf = selectCsrfToken(state);
   const skills = selectOrderedSkills(state);
-  const memberProfiles = selectOrderedMemberProfiles(state);
+  const memberIds = selectCurrentMemberIds(state);
   const [searchResults, setSearchResults] = useState([]);
   const [searchRequestDTO] = useState([]);
   const [searchSkills, setSearchSkills] = useState([]);
@@ -36,7 +36,9 @@ const SkillReportPage = (props) => {
           ? res.payload.data.teamMembers
           : undefined;
     }
-    if (memberSkillsFound && memberProfiles) {
+    // Filter out skills of terminated members
+    memberSkillsFound = memberSkillsFound.filter(memberSkill => memberIds.includes(memberSkill.id));
+    if (memberSkillsFound && memberIds) {
       setSearchResults(memberSkillsFound);
     } else {
       setSearchResults(undefined);

--- a/web-ui/src/pages/SkillReportPage.jsx
+++ b/web-ui/src/pages/SkillReportPage.jsx
@@ -80,10 +80,8 @@ const SkillReportPage = (props) => {
         <Autocomplete
           id="skillSelect"
           multiple
-          options={skills.filter(
-            (skill) =>
-              !searchSkills.map((sSkill) => sSkill.id).includes(skill.id)
-          )}
+          options={skills}
+          filterSelectedOptions
           value={searchSkills ? searchSkills : []}
           onChange={onSkillsChange}
           getOptionLabel={(option) => option.name}

--- a/web-ui/src/pages/TeamSkillReportPage.jsx
+++ b/web-ui/src/pages/TeamSkillReportPage.jsx
@@ -8,7 +8,7 @@ import { AppContext } from "../context/AppContext";
 import {
   selectOrderedSkills,
   selectCsrfToken,
-  selectOrderedMemberProfiles,
+  selectOrderedCurrentMemberProfiles,
   selectSkill,
 } from "../context/selectors";
 import { levelMap } from "../context/util";
@@ -27,7 +27,7 @@ const TeamSkillReportPage = () => {
 
   const csrf = selectCsrfToken(state);
   const skills = selectOrderedSkills(state);
-  const memberProfiles = selectOrderedMemberProfiles(state);
+  const memberProfiles = selectOrderedCurrentMemberProfiles(state);
 
   const [selectedMembers, setSelectedMembers] = useState([]);
   const [selectedTeam, setSelectedTeam] = useState(null);


### PR DESCRIPTION
Closes #1715 
- Fixes bug where terminated members were included in skill reports (skills and team skills)
- Fixes bug where blank options appeared when choosing PDL on user modal