### PR TITLE
Feature 1570/do not provide default check in date

### DIFF
--- a/web-ui/src/components/checkin/CheckinHistory.jsx
+++ b/web-ui/src/components/checkin/CheckinHistory.jsx
@@ -1,55 +1,70 @@
-import React, { useContext } from "react";
+import React, {useContext, useState} from "react";
 import { useHistory, useParams } from "react-router-dom";
-import {
-  UPDATE_CHECKIN,
-} from "../../context/actions";
 import { AppContext } from "../../context/AppContext";
-import { updateCheckin } from "../../api/checkins";
-import { selectCsrfToken, selectCheckinsForMember, selectProfile } from "../../context/selectors";
+import {
+  selectCheckinsForMember,
+  selectCsrfToken,
+  selectCurrentUser,
+  selectIsAdmin, selectIsPDL,
+  selectProfile
+} from "../../context/selectors";
 import IconButton from "@mui/material/IconButton";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
-import {MobileDateTimePicker} from "@mui/lab";
+import {StaticDateTimePicker} from "@mui/lab";
 import TextField from "@mui/material/TextField";
 
 import "./Checkin.css";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle, Tooltip
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import {updateCheckin} from "../../api/checkins";
+import {UPDATE_CHECKIN, UPDATE_TOAST} from "../../context/actions";
+import {createNewCheckinWithDate} from "../../context/thunks";
+
+const PREFIX = "CheckinsPage";
+const classes = {
+  addButton: `${PREFIX}-addButton`
+};
 
 const CheckinsHistory = () => {
   const { state, dispatch } = useContext(AppContext);
   const { checkinId, memberId } = useParams();
   const history = useHistory();
   const csrf = selectCsrfToken(state);
-  const selectedProfile = selectProfile(state, memberId);
+  const [checkinDatetime, setCheckinDatetime] = useState(null);
+  const [defaultDatetimeChanged, setDefaultDatetimeChanged] = useState(false);
+  const [datetimeDialogOpen, setDatetimeDialogOpen] = useState(false);
+  const [tooltipIsOpen, setTooltipIsOpen] = useState(false);
+
+  const memberProfile = selectCurrentUser(state);
+  const currentUserId = memberProfile?.id;
 
   const checkins = selectCheckinsForMember(state, memberId);
   const index = checkins.findIndex(checkin => checkin.id === checkinId);
 
-  const getCheckinDate = () => {
-    if (checkins && checkins[index]?.checkInDate) {
-      const [year, month, day, hour, minute] = checkins[index].checkInDate;
-      return new Date(year, month - 1, day, hour, minute, 0);
-    }
-    // return new date unless you are running a Jest test
-    return process.env.JEST_WORKER_ID ? new Date(2020, 9, 21) : new Date();
-  };
+  const selectedProfile = selectProfile(state, memberId);
+  const memberCheckins = selectCheckinsForMember(
+    state,
+    selectedProfile ? selectedProfile.id : currentUserId
+  );
+  const hasOpenCheckins = memberCheckins.some((checkin) => !checkin.completed);
 
-  const leftArrowClass = "arrow " + (index > 0 ? "enabled" : "disabled");
-  const rightArrowClass =
-    "arrow " + (index < checkins.length - 1 ? "enabled" : "disabled");
+  const isAdmin = selectIsAdmin(state);
+  const isPdl = selectIsPDL(state);
 
-  const previousCheckin = () => {
-    if (index > 0) {
-      history.push(`/checkins/${memberId}/${checkins[index - 1].id}`);
-    }
-  };
+  const createCheckIn = async (date) => {
+    const newId = await createNewCheckinWithDate(selectedProfile, date, dispatch, csrf);
+    if (newId) history.push(`/checkins/${memberId}/${newId}`);
+  }
 
-  const nextCheckin = () => {
-    if (index < checkins.length - 1) {
-      history.push(`/checkins/${memberId}/${checkins[index + 1].id}`);
-    }
-  };
-
-  const pickDate = async (date) => {
+  const updateCheckInDate = async (date) => {
     if (csrf) {
       const year = date.getFullYear();
       const month = date.getMonth() + 1;
@@ -69,43 +84,172 @@ const CheckinsHistory = () => {
     }
   };
 
+  const handleSave = () => {
+    setDatetimeDialogOpen(false);
+    if (checkins) {
+      if (checkins[index]) {
+        updateCheckInDate(checkinDatetime);
+      } else {
+        console.log("creating new...");
+        createCheckIn(checkinDatetime);
+      }
+    }
+  }
+
+  const handleCreateClick = async () => {
+    if (!selectedProfile.pdlId) {
+      window.snackDispatch({
+        type: UPDATE_TOAST,
+        payload: {
+          severity: "error",
+          toast: "You must have an assigned PDL in order to create a Check In",
+        },
+      });
+    } else {
+      // Default date is 30 days in the future
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 30);
+      setCheckinDatetime(futureDate);
+      setDatetimeDialogOpen(true);
+    }
+  };
+
+  const getCheckinDate = () => {
+    if (checkins && checkins[index]?.checkInDate) {
+      const [year, month, day, hour, minute] = checkins[index].checkInDate;
+      return new Date(year, month - 1, day, hour, minute, 0);
+    }
+    // return new date unless you are running a Jest test
+    return process.env.JEST_WORKER_ID ? new Date(2020, 9, 21) : new Date();
+  };
+
+  const getFormattedCheckinDate = () => {
+    let checkinDate = new Date();
+    if (checkins && checkins[index]?.checkInDate) {
+      const [year, month, day, hour, minute] = checkins[index].checkInDate;
+      checkinDate = new Date(year, month - 1, day, hour, minute, 0);
+    } else {
+      return "No check-in selected";
+    }
+    const dateString = checkinDate.toDateString();
+    const timeString = checkinDate.toLocaleTimeString([], {hour: "numeric", minute: "2-digit"});
+    return `${dateString}, ${timeString}`;
+  }
+
+  const leftArrowClass = "arrow " + (index > 0 ? "enabled" : "disabled");
+  const rightArrowClass =
+    "arrow " + (index < checkins.length - 1 ? "enabled" : "disabled");
+
+  const previousCheckin = () => {
+    if (index > 0) {
+      history.push(`/checkins/${memberId}/${checkins[index - 1].id}`);
+    }
+  };
+
+  const nextCheckin = () => {
+    if (index < checkins.length - 1) {
+      history.push(`/checkins/${memberId}/${checkins[index + 1].id}`);
+    }
+  };
+
   return (
-      getCheckinDate() && (
-          <div className="date-picker">
-            <IconButton
-              disabled={index <= 0}
-              aria-label="Previous Check-in`"
-              onClick={previousCheckin}
-              size="large">
-              <ArrowBackIcon
-                className={leftArrowClass}
-                style={{ fontSize: "1.2em" }}
-              />
-            </IconButton>
-            <MobileDateTimePicker
-              renderInput={props => <TextField style={{width: '18em'}} {...props}/>}
+    <>
+      {getCheckinDate() && (
+      <div className="date-picker">
+        <IconButton
+          disabled={index <= 0}
+          aria-label="Previous Check-in`"
+          onClick={previousCheckin}
+          size="large">
+          <ArrowBackIcon
+            className={leftArrowClass}
+            style={{ fontSize: "1.2em" }}
+          />
+        </IconButton>
+        <Dialog className="check-in-datetime-dialog" open={datetimeDialogOpen}>
+          <DialogTitle>Check-In Date</DialogTitle>
+          <DialogContent>
+            {(checkins && checkins[index]?.checkInDate ? false : !defaultDatetimeChanged) &&
+              <Alert severity="info" style={{width: "300px"}}>By default, this check-in is set 30 days in the future</Alert>
+            }
+            <StaticDateTimePicker
+              onChange={(datetime) => {
+                setCheckinDatetime(datetime);
+                setDefaultDatetimeChanged(true);
+              }}
+              value={checkinDatetime}
+              ampm
+              hideTabs
               format="MMMM dd, yyyy @hh:mm aaaa"
-              value={getCheckinDate()}
-              onChange={pickDate}
-              label="Check-In Date"
-              showTodayButton
-              disabled={
-                !checkins?.length ||
-                checkins[index]?.completed
-              }
+              minDate={new Date()}
+              disablePast
+              displayStaticWrapperAs="mobile"
+              label=" "
+              renderInput={(props) => (
+                <TextField fullWidth {...props} />
+              )}
             />
-            <IconButton
-              disabled={index >= checkins.length - 1}
-              aria-label="Next Check-in`"
-              onClick={nextCheckin}
-              size="large">
-              <ArrowForwardIcon
-                className={rightArrowClass}
-                style={{ fontSize: "1.2em" }}
-              />
-            </IconButton>
-      </div>
-    )
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => {
+              setCheckinDatetime(null);
+              setDefaultDatetimeChanged(false);
+              setDatetimeDialogOpen(false);
+            }} style={{color: "gray"}}>Cancel</Button>
+            <Button onClick={() => handleSave()} color="primary">Save</Button>
+          </DialogActions>
+        </Dialog>
+        <TextField
+          placeholder="testing"
+          value={getFormattedCheckinDate()}
+          label="Check-In Date"
+          onClick={() => {
+            if (checkins?.length && !checkins[index]?.completed) {
+              setDatetimeDialogOpen(true);
+            }
+          }}
+          style={{width: "18em"}}
+          disabled={!checkins?.length || checkins[index]?.completed}
+          focused={false}
+        />
+        <IconButton
+          disabled={index >= checkins.length - 1}
+          aria-label="Next Check-in`"
+          onClick={nextCheckin}
+          size="large">
+          <ArrowForwardIcon
+            className={rightArrowClass}
+            style={{ fontSize: "1.2em" }}
+          />
+        </IconButton>
+      </div>)}
+      <Tooltip
+        open={tooltipIsOpen && hasOpenCheckins}
+        onOpen={() => setTooltipIsOpen(true)}
+        onClose={() => setTooltipIsOpen(false)}
+        enterTouchDelay={0}
+        placement="top-start"
+        title={
+          "This is disabled because there is already an open Check-In"
+        }
+      >
+        <div
+          aria-describedby="checkin-tooltip-wrapper"
+          className="create-checkin-tooltip-wrapper"
+        >
+          {(isAdmin || isPdl || currentUserId === memberId) && (
+            <Button
+              disabled={hasOpenCheckins}
+              className={classes.addButton}
+              startIcon={<CheckCircleIcon />}
+              onClick={handleCreateClick}
+            >
+              Create Check-In
+            </Button>
+          )}
+        </div>
+      </Tooltip>
+    </>
   );
 };
 

--- a/web-ui/src/components/checkin/__snapshots__/CheckinHistory.test.js.snap
+++ b/web-ui/src/components/checkin/__snapshots__/CheckinHistory.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-.emotion-0 {
+Array [
+  .emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -366,136 +367,291 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-5:focus::-ms-input-p
 }
 
 <div
-  className="date-picker"
->
-  <button
-    aria-label="Previous Check-in\`"
-    className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge emotion-0"
-    disabled={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={-1}
-    type="button"
+    className="date-picker"
   >
-    <svg
-      aria-hidden={true}
-      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium arrow disabled emotion-1"
-      data-testid="ArrowBackIcon"
-      focusable="false"
-      style={
-        Object {
-          "fontSize": "1.2em",
-        }
-      }
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-      />
-    </svg>
-  </button>
-  <div
-    className="MuiFormControl-root MuiTextField-root emotion-2"
-    style={
-      Object {
-        "width": "18em",
-      }
-    }
-  >
-    <label
-      className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary emotion-3"
-      data-shrink={false}
-      htmlFor="mui-1"
-      id="mui-1-label"
-    >
-      Check-In Date
-    </label>
-    <div
-      className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-4"
+    <button
+      aria-label="Previous Check-in\`"
+      className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge emotion-0"
+      disabled={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={-1}
+      type="button"
     >
-      <input
-        aria-invalid={false}
-        aria-label="Choose date, selected date is Oct 21, 2020"
-        aria-readonly={true}
-        autoFocus={false}
-        className="MuiOutlinedInput-input MuiInputBase-input emotion-5"
-        id="mui-1"
-        onAnimationStart={[Function]}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        readOnly={true}
-        required={false}
-        type="text"
-        value="10/21/2020 12:00 am"
-      />
-      <fieldset
+      <svg
         aria-hidden={true}
-        className="MuiOutlinedInput-notchedOutline emotion-6"
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium arrow disabled emotion-1"
+        data-testid="ArrowBackIcon"
+        focusable="false"
+        style={
+          Object {
+            "fontSize": "1.2em",
+          }
+        }
+        viewBox="0 0 24 24"
       >
-        <legend
-          className="emotion-7"
-        >
-          <span>
-            Check-In Date
-          </span>
-        </legend>
-      </fieldset>
-    </div>
-  </div>
-  <button
-    aria-label="Next Check-in\`"
-    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge emotion-0"
-    disabled={false}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium arrow enabled emotion-1"
-      data-testid="ArrowForwardIcon"
-      focusable="false"
+        <path
+          d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+        />
+      </svg>
+    </button>
+    <div
+      className="MuiFormControl-root MuiTextField-root emotion-2"
+      onClick={[Function]}
       style={
         Object {
-          "fontSize": "1.2em",
+          "width": "18em",
         }
       }
-      viewBox="0 0 24 24"
     >
-      <path
-        d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+      <label
+        className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary emotion-3"
+        data-shrink={false}
+        htmlFor="mui-2"
+        id="mui-2-label"
+      >
+        Check-In Date
+      </label>
+      <div
+        className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-4"
+        onClick={[Function]}
+      >
+        <input
+          aria-invalid={false}
+          autoFocus={false}
+          className="MuiOutlinedInput-input MuiInputBase-input emotion-5"
+          disabled={false}
+          id="mui-2"
+          onAnimationStart={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder="testing"
+          required={false}
+          type="text"
+          value="No check-in selected"
+        />
+        <fieldset
+          aria-hidden={true}
+          className="MuiOutlinedInput-notchedOutline emotion-6"
+        >
+          <legend
+            className="emotion-7"
+          >
+            <span>
+              Check-In Date
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+    <button
+      aria-label="Next Check-in\`"
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge emotion-0"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium arrow enabled emotion-1"
+        data-testid="ArrowForwardIcon"
+        focusable="false"
+        style={
+          Object {
+            "fontSize": "1.2em",
+          }
+        }
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+        />
+      </svg>
+      <span
+        className="MuiTouchRipple-root emotion-10"
       />
-    </svg>
-    <span
-      className="MuiTouchRipple-root emotion-10"
-    />
-  </button>
-</div>
+    </button>
+  </div>,
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #1976d2;
+}
+
+.emotion-0::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-0.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-0 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(25, 118, 210, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-0:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-0.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-1 {
+  display: inherit;
+  margin-right: 8px;
+  margin-left: -4px;
+}
+
+.emotion-1>*:nth-of-type(1) {
+  font-size: 20px;
+}
+
+.emotion-2 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.5rem;
+}
+
+<div
+    aria-describedby="checkin-tooltip-wrapper"
+    aria-label="This is disabled because there is already an open Check-In"
+    aria-labelledby={null}
+    className="create-checkin-tooltip-wrapper"
+    data-mui-internal-clone-element={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+  >
+    <button
+      className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root Mui-disabled CheckinsPage-addButton emotion-0"
+      disabled={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={-1}
+      type="button"
+    >
+      <span
+        className="MuiButton-startIcon MuiButton-iconSizeMedium emotion-1"
+      >
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-2"
+          data-testid="CheckCircleIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+          />
+        </svg>
+      </span>
+      Create Check-In
+    </button>
+  </div>,
+]
 `;

--- a/web-ui/src/context/thunks.js
+++ b/web-ui/src/context/thunks.js
@@ -58,3 +58,30 @@ export const createNewCheckin = async (memberProfile, dispatch, csrf) => {
     return checkin?.id;
   }
 };
+
+export const createNewCheckinWithDate = async (memberProfile, date, dispatch, csrf) => {
+  if (memberProfile) {
+    const dateTimeArray = [
+      date.getFullYear(),
+      date.getMonth() + 1,
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+    ];
+    const res = await createCheckin(
+      {
+        teamMemberId: memberProfile.id,
+        pdlId: memberProfile.pdlId,
+        checkInDate: dateTimeArray,
+        completed: false,
+      },
+      csrf
+    );
+    const checkin =
+      res.payload && res.payload.data && !res.error ? res.payload.data : null;
+
+    dispatch({ type: ADD_CHECKIN, payload: checkin });
+    return checkin?.id;
+  }
+}

--- a/web-ui/src/pages/CheckinsPage.jsx
+++ b/web-ui/src/pages/CheckinsPage.jsx
@@ -12,10 +12,9 @@ import {
   selectCsrfToken,
   selectCheckin,
   selectProfile,
-  selectCheckinsForMember,
 } from "../context/selectors";
-import { getCheckins, createNewCheckin } from "../context/thunks";
-import { UPDATE_CHECKIN, UPDATE_TOAST } from "../context/actions";
+import { getCheckins } from "../context/thunks";
+import { UPDATE_CHECKIN } from "../context/actions";
 import CheckinDocs from "../components/checkin/documents/CheckinDocs";
 import CheckinsHistory from "../components/checkin/CheckinHistory";
 import Profile from "../components/profile/Profile";
@@ -24,8 +23,7 @@ import PDLGuidesPanel from "../components/guides/PDLGuidesPanel";
 import Note from "../components/notes/Note";
 import PrivateNote from "../components/private-note/PrivateNote";
 import Personnel from "../components/personnel/Personnel";
-import { Button, Grid, Modal, Tooltip } from "@mui/material";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { Button, Grid, Modal } from "@mui/material";
 
 import "./CheckinsPage.css";
 import { updateCheckin } from "../api/checkins";
@@ -33,8 +31,7 @@ import { updateCheckin } from "../api/checkins";
 const PREFIX = 'CheckinsPage';
 const classes = {
   root: `${PREFIX}-root`,
-  navigate: `${PREFIX}-navigate`,
-  addButton: `${PREFIX}-addButton`
+  navigate: `${PREFIX}-navigate`
 };
 
 const Root = styled('div')(() => ({
@@ -64,12 +61,6 @@ const CheckinsPage = () => {
   const mostRecent = selectMostRecentCheckin(state, memberId);
 
   const selectedProfile = selectProfile(state, memberId);
-  const memberCheckins = selectCheckinsForMember(
-    state,
-    selectedProfile ? selectedProfile.id : currentUserId
-  );
-  const hasOpenCheckins = memberCheckins.some((checkin) => !checkin.completed);
-  const [tooltipIsOpen, setTooltipIsOpen] = useState(false);
 
   useEffect(() => {
     if (selectedProfile) {
@@ -110,21 +101,6 @@ const CheckinsPage = () => {
     handleClose();
   };
 
-  const handleCreate = async () => {
-    if (!selectedProfile.pdlId) {
-      window.snackDispatch({
-        type: UPDATE_TOAST,
-        payload: {
-          severity: "error",
-          toast: "You must have an assigned PDL in order to create a Check In",
-        },
-      });
-      return;
-    }
-    const newId = await createNewCheckin(selectedProfile, dispatch, csrf);
-    if (newId) history.push(`/checkins/${memberId}/${newId}`);
-  };
-
   return (
     <Root className={classes.root} >
       <Grid container spacing={3}>
@@ -140,32 +116,6 @@ const CheckinsPage = () => {
               memberId={memberId}
               checkinId={checkinId}
             />
-            <Tooltip
-              open={tooltipIsOpen && hasOpenCheckins}
-              onOpen={() => setTooltipIsOpen(true)}
-              onClose={() => setTooltipIsOpen(false)}
-              enterTouchDelay={0}
-              placement="top-start"
-              title={
-                "This is disabled because there is already an open Check-In"
-              }
-            >
-              <div
-                aria-describedby="checkin-tooltip-wrapper"
-                className="create-checkin-tooltip-wrapper"
-              >
-                {(isAdmin || isPdl || currentUserId === memberId) && (
-                  <Button
-                    disabled={hasOpenCheckins}
-                    className={classes.addButton}
-                    startIcon={<CheckCircleIcon />}
-                    onClick={handleCreate}
-                  >
-                    Create Check-In
-                  </Button>
-                )}
-              </div>
-            </Tooltip>
           </div>
           {currentCheckin && currentCheckin.id && (
             <React.Fragment>

--- a/web-ui/src/pages/__snapshots__/CheckinsPage.test.js.snap
+++ b/web-ui/src/pages/__snapshots__/CheckinsPage.test.js.snap
@@ -22,7 +22,7 @@ exports[`renders correctly 1`] = `
   align-items: baseline;
 }
 
-.emotion-0 .CheckinsPage-addButton {
+.emotion-0 .undefined {
   height: 3em;
 }
 
@@ -1169,6 +1169,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
           </button>
           <div
             className="MuiFormControl-root MuiTextField-root emotion-13"
+            onClick={[Function]}
             style={
               Object {
                 "width": "18em",
@@ -1178,8 +1179,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
             <label
               className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary emotion-14"
               data-shrink={false}
-              htmlFor="mui-1"
-              id="mui-1-label"
+              htmlFor="mui-2"
+              id="mui-2-label"
             >
               Check-In Date
             </label>
@@ -1189,21 +1190,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
             >
               <input
                 aria-invalid={false}
-                aria-label="Choose date, selected date is Oct 21, 2020"
-                aria-readonly={true}
                 autoFocus={false}
                 className="MuiOutlinedInput-input MuiInputBase-input emotion-16"
-                id="mui-1"
+                disabled={false}
+                id="mui-2"
                 onAnimationStart={[Function]}
                 onBlur={[Function]}
                 onChange={[Function]}
-                onClick={[Function]}
                 onFocus={[Function]}
-                onKeyDown={[Function]}
-                readOnly={true}
+                placeholder="testing"
                 required={false}
                 type="text"
-                value="10/21/2020 12:00 am"
+                value="No check-in selected"
               />
               <fieldset
                 aria-hidden={true}


### PR DESCRIPTION
Closes #1570 

Features:
- When creating a check-in, the default date used to be the current date. Now this is 30 days in the future from the current date.
- Before, clicking the "create check-in" button instantly created the check-in with the default date. This has been changed so that the user is prompted with a datetime picker before the check-in is created.
- An info blurb appears on the datetime picker whenever the user creates a new check-in, informing them that the pre-selected date is 30 days in the future.
- This maintains the same behavior where clicking on the datetime text field will open up the datetime picker and allow the user to edit the date and time. This does not occur for completed check-ins.