### PR TITLE
feature-1728/filter-existing-role-members

### DIFF
--- a/web-ui/src/components/admin/roles/Roles.jsx
+++ b/web-ui/src/components/admin/roles/Roles.jsx
@@ -153,7 +153,7 @@ const Roles = () => {
   };
 
   const roleContainsMember = (member) => {
-    return !roleToMemberMap[selectedRole].find((currentMember) => {
+    return selectedRole && roleToMemberMap[selectedRole].find((currentMember) => {
       return currentMember.id === member.id;
     });
   };
@@ -225,7 +225,7 @@ const Roles = () => {
                     <div className="role-modal">
                       <Autocomplete
                         options={memberProfiles.filter((member) =>
-                          roleContainsMember(member)
+                          !roleContainsMember(member)
                         )}
                         value={selectedMember}
                         onChange={(event, newValue) =>

--- a/web-ui/src/components/admin/roles/Roles.jsx
+++ b/web-ui/src/components/admin/roles/Roles.jsx
@@ -26,7 +26,7 @@ import {
   Typography,
 } from "@mui/material";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
-import Autocomplete from '@mui/material/Autocomplete';
+import Autocomplete from "@mui/material/Autocomplete";
 
 import "./Roles.css";
 
@@ -37,7 +37,6 @@ const Roles = () => {
   const [showAddUser, setShowAddUser] = useState(false);
   const [showAddRole, setShowAddRole] = useState(false);
   const [newRole, setNewRole] = useState("");
-  // const [editRole, setEditRole] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [selectedMember, setSelectedMember] = useState({});
   const [roleToMemberMap, setRoleToMemberMap] = useState({});
@@ -46,26 +45,31 @@ const Roles = () => {
   memberProfiles.sort((a, b) => a.name.localeCompare(b.name));
 
   useEffect(() => {
-      const memberMap = {};
-      for (const member of memberProfiles) {
-        memberMap[member.id] = member;
-      }
+    const memberMap = {};
+    for (const member of memberProfiles) {
+      memberMap[member.id] = member;
+    }
 
-      const newRoleToMemberMap = {};
-      for (const userRole of userRoles || []) {
-        const role = roles.find((role) => role.id === userRole?.memberRoleId?.roleId);
-        if(role) {
-          let memberList = newRoleToMemberMap[role.role];
-          if (!memberList) {
-            memberList = newRoleToMemberMap[role.role] = [];
-          }
-          if (memberMap[userRole?.memberRoleId?.memberId] !== undefined) {
-            memberList.push({ ...memberMap[userRole?.memberRoleId?.memberId], roleId: role.id });
-          }
+    const newRoleToMemberMap = {};
+    for (const userRole of userRoles || []) {
+      const role = roles.find(
+        (role) => role.id === userRole?.memberRoleId?.roleId
+      );
+      if (role) {
+        let memberList = newRoleToMemberMap[role.role];
+        if (!memberList) {
+          memberList = newRoleToMemberMap[role.role] = [];
+        }
+        if (memberMap[userRole?.memberRoleId?.memberId] !== undefined) {
+          memberList.push({
+            ...memberMap[userRole?.memberRoleId?.memberId],
+            roleId: role.id,
+          });
         }
       }
-      setRoleToMemberMap(newRoleToMemberMap);
-    }, [userRoles, memberProfiles, roles]);
+    }
+    setRoleToMemberMap(newRoleToMemberMap);
+  }, [userRoles, memberProfiles, roles]);
 
   const uniqueRoles = Object.keys(roleToMemberMap);
 
@@ -78,8 +82,12 @@ const Roles = () => {
         ? res.payload
         : null;
     if (data) {
-// TODO: Remove role from map....
-      const filtered = userRoles.filter((userRole) => userRole?.memberRoleId?.roleId !== roleId || userRole?.memberRoleId?.memberId !== member.id);
+      // TODO: Remove role from map....
+      const filtered = userRoles.filter(
+        (userRole) =>
+          userRole?.memberRoleId?.roleId !== roleId ||
+          userRole?.memberRoleId?.memberId !== member.id
+      );
       dispatch({
         type: SET_USER_ROLES,
         payload: filtered,
@@ -116,7 +124,7 @@ const Roles = () => {
     setSelectedMember({});
   };
 
-  const addRole = async (member, role) => {
+  const addRole = async (member) => {
     let res = await addNewRole(selectedRole, member.id, csrf);
     let data =
       res.payload && res.payload.data && !res.error ? res.payload.data : null;
@@ -144,9 +152,11 @@ const Roles = () => {
     setShowAddRole(false);
   };
 
-  // const closeEditRole = () => {
-  //   setEditRole(false);
-  // };
+  const roleContainsMember = (member) => {
+    return !roleToMemberMap[selectedRole].find((currentMember) => {
+      return currentMember.id === member.id;
+    });
+  };
 
   return (
     <div className="roles-content">
@@ -165,9 +175,6 @@ const Roles = () => {
               }}
             />
           </div>
-          {/* <Button color="primary" onClick={() => setShowAddRole(true)}>
-            Add New Role
-          </Button> */}
         </div>
         <div className="roles-bot">
           {uniqueRoles.map((role) =>
@@ -198,9 +205,6 @@ const Roles = () => {
                           <span>Add User</span>
                           <PersonAddIcon />
                         </Button>
-                        {/* <Button className="role-edit" color="primary">
-                        <span>Edit Role</span> <EditIcon />
-                      </Button> */}
                       </div>
                     </div>
                   }
@@ -220,8 +224,8 @@ const Roles = () => {
                   <Modal open={showAddUser} onClose={closeAddUser}>
                     <div className="role-modal">
                       <Autocomplete
-                        options={memberProfiles.filter(
-                          (member) => !roleToMemberMap[role].includes(member.id)
+                        options={memberProfiles.filter((member) =>
+                          roleContainsMember(member)
                         )}
                         value={selectedMember}
                         onChange={(event, newValue) =>
@@ -260,29 +264,6 @@ const Roles = () => {
                       </Button>
                     </div>
                   </Modal>
-                  {/* <Modal open={} onClose={closeEditRole}>
-                  <div className="edit-role-modal">
-                    <TextField
-                      id="role-description"
-                      label="description"
-                      required
-                      className="halfWidth"
-                      placeholder="Pdl Description"
-                      value={
-                        editedMember.firstName ? editedMember.firstName : ""
-                      }
-                      onChange={(e) =>
-                        setMember({
-                          ...editedMember,
-                          firstName: e.target.value,
-                        })
-                      }
-                    />
-                    <Button onClick={() => addToRole(selectedMember)}>
-                      Save
-                    </Button>
-                  </div>
-                </Modal> */}
                 </CardActions>
               </Card>
             ) : null


### PR DESCRIPTION
When adding a user to a role, the drop-down list of users will now no longer include users that are already assigned to that role.