### PR TITLE
Hotfix 1923/inform user of session expiration

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/currentuser/CurrentUserController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/currentuser/CurrentUserController.java
@@ -3,10 +3,8 @@ package com.objectcomputing.checkins.services.memberprofile.currentuser;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileUtils;
 import com.objectcomputing.checkins.services.permissions.Permission;
-import com.objectcomputing.checkins.services.permissions.PermissionRepository;
 import com.objectcomputing.checkins.services.permissions.PermissionServices;
 import com.objectcomputing.checkins.services.role.Role;
-import com.objectcomputing.checkins.services.role.RoleRepository;
 import com.objectcomputing.checkins.services.role.RoleServices;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
@@ -55,9 +53,9 @@ public class CurrentUserController {
 
         String workEmail = authentication.getAttributes().get("email").toString();
         String imageUrl = authentication.getAttributes().get("picture") != null ? authentication.getAttributes().get("picture").toString() : "";
-        String name = authentication.getAttributes().get("name").toString().trim();
-        String firstName = name.substring(0, name.indexOf(' '));
-        String lastName = name.substring(name.indexOf(' ') + 1).trim();
+        String name = authentication.getAttributes().get("name") != null ? authentication.getAttributes().get("name").toString().trim() : null;
+        String firstName = name != null ? name.substring(0, name.indexOf(' ')) : "";
+        String lastName = name != null ? name.substring(name.indexOf(' ') + 1).trim() : "";
 
         MemberProfile user = currentUserServices.findOrSaveUser(firstName, lastName, workEmail);
         List<Permission> permissions = permissionServices.findUserPermissions(user.getId());


### PR DESCRIPTION
Closes #1923 

To reproduce:
1. Set the access token expiration to be low (e.g. 60 seconds) in `application-local.yml`
2. Log in and wait for the access token to expire
3. Monitor the network calls being made to ensure there is a GET request for `access_token` with a response status of 303
4. Open another tab, visit Check-Ins, and ensure you can make POST/GET/PUT requests.