### PR TITLE
Step 1 - Add ability to retrieve feedback requests for multiple requestees

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestController.java
@@ -126,8 +126,8 @@ public class FeedbackRequestController {
      */
     @RequiredPermission(Permissions.CAN_VIEW_FEEDBACK_REQUEST)
     @Get("/{?creatorId,requesteeId,recipientId,oldestDate,reviewPeriodId,templateId}")
-    public Mono<HttpResponse<List<FeedbackRequestResponseDTO>>> findByValues(@Nullable UUID creatorId, @Nullable UUID requesteeId, @Nullable UUID recipientId, @Nullable @Format("yyyy-MM-dd") LocalDate oldestDate, @Nullable UUID reviewPeriodId, @Nullable UUID templateId) {
-        return Mono.fromCallable(() -> feedbackReqServices.findByValues(creatorId, requesteeId, recipientId, oldestDate, reviewPeriodId, templateId))
+    public Mono<HttpResponse<List<FeedbackRequestResponseDTO>>> findByValues(@Nullable UUID creatorId, @Nullable UUID requesteeId, @Nullable UUID recipientId, @Nullable @Format("yyyy-MM-dd") LocalDate oldestDate, @Nullable UUID reviewPeriodId, @Nullable UUID templateId, @Nullable List<UUID> requesteeIds) {
+        return Mono.fromCallable(() -> feedbackReqServices.findByValues(creatorId, requesteeId, recipientId, oldestDate, reviewPeriodId, templateId, requesteeIds))
                 .publishOn(Schedulers.fromExecutor(eventLoopGroup))
                 .map(feedbackReqs -> {
                     List<FeedbackRequestResponseDTO> dtoList = feedbackReqs.stream()

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestRepository.java
@@ -3,7 +3,9 @@ package com.objectcomputing.checkins.services.feedback_request;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
 
@@ -24,12 +26,23 @@ public interface FeedbackRequestRepository extends CrudRepository<FeedbackReques
     @Query(value = "SELECT * " +
             "FROM feedback_requests " +
             "WHERE (:creatorId IS NULL OR creator_id = :creatorId) " +
+            "AND (:recipientId IS NULL OR recipient_id = :recipientId) " +
+            "AND (CAST(:oldestDate as date) IS NULL OR send_date >= :oldestDate) " +
+            "AND (:reviewPeriodId IS NULL OR review_period_id = :reviewPeriodId) " +
+            "AND (:templateId IS NULL OR template_id = :templateId) " +
+            "AND (requestee_id = ANY(:requesteeIds)) "
+            , nativeQuery = true)
+    List<FeedbackRequest> findByValues(@Nullable String creatorId, @Nullable String recipientId, @Nullable LocalDate oldestDate, @Nullable String reviewPeriodId, @Nullable String templateId, @TypeDef(type = DataType.STRING_ARRAY) List<String> requesteeIds);
+
+    @Query(value = "SELECT * " +
+            "FROM feedback_requests " +
+            "WHERE (:creatorId IS NULL OR creator_id = :creatorId) " +
             "AND (:requesteeId IS NULL OR requestee_id = :requesteeId) " +
             "AND (:recipientId IS NULL OR recipient_id = :recipientId) " +
             "AND (CAST(:oldestDate as date) IS NULL OR send_date >= :oldestDate) " +
             "AND (:reviewPeriodId IS NULL OR review_period_id = :reviewPeriodId) " +
             "AND (:templateId IS NULL OR template_id = :templateId) "
-            ,nativeQuery = true)
+            , nativeQuery = true)
     List<FeedbackRequest> findByValues(@Nullable String creatorId, @Nullable String requesteeId, @Nullable String recipientId, @Nullable LocalDate oldestDate, @Nullable String reviewPeriodId, @Nullable String templateId);
 
     List<FeedbackRequest> findBySendDateAfter(@Nullable LocalDate sendDate);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServices.java
@@ -13,5 +13,5 @@ public interface FeedbackRequestServices {
 
     FeedbackRequest getById(UUID id);
 
-    List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, UUID recipientId, LocalDate oldestDate, UUID reviewPeriodId, UUID templateId);
+    List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, UUID recipientId, LocalDate oldestDate, UUID reviewPeriodId, UUID templateId, List<UUID> requesteeIds);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/util/Util.java
+++ b/server/src/main/java/com/objectcomputing/checkins/util/Util.java
@@ -1,6 +1,8 @@
 package com.objectcomputing.checkins.util;
 
 import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.UUID;
 
 public class Util {
@@ -14,5 +16,19 @@ public class Util {
 
     public static UUID nullSafeUUIDFromString(String id) {
         return id == null ? null : UUID.fromString(id);
+    }
+
+    public static List<String> nullSafeUUIDListToStringList(List<UUID> uuidList) {
+        LinkedList<String> stringsList = null;
+        if(uuidList != null) {
+            stringsList = new LinkedList<>();
+            for(UUID uuid: uuidList) {
+                String uuidString = nullSafeUUIDToString(uuid);
+                if(uuidString != null) {
+                    stringsList.add(uuidString);
+                }
+            }
+        }
+        return stringsList;
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsControllerTest.java
@@ -45,7 +45,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         createAndAssignRole(RoleType.PDL, pdlProfile);
         MemberProfile supervisor = createADefaultSupervisor();
         createAndAssignRole(RoleType.ADMIN, supervisor);
-        MemberProfile requestee = createASupervisedAndPDLUser(supervisor, pdlProfile);
+        MemberProfile requestee = createAProfileWithSupervisorAndPDL(supervisor, pdlProfile);
         MemberProfile requesteeTeamLead = createAnUnrelatedUser();
         TeamMember requesteeTeamLeadMember = createLeadTeamMember(team, requesteeTeamLead);
         TeamMember requesteeTeamMember = createDefaultTeamMember(team, requestee);
@@ -73,7 +73,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         createAndAssignRole(RoleType.PDL, pdlProfile);
         MemberProfile supervisor = createADefaultSupervisor();
         createAndAssignRole(RoleType.ADMIN, supervisor);
-        MemberProfile requestee = createASupervisedAndPDLUser(supervisor, pdlProfile);
+        MemberProfile requestee = createAProfileWithSupervisorAndPDL(supervisor, pdlProfile);
         MemberProfile requesteeTeamLead = createAnUnrelatedUser();
         TeamMember requesteeTeamLeadMember = createLeadTeamMember(team, requesteeTeamLead);
         TeamMember requesteeTeamMember = createDefaultTeamMember(team, requestee);
@@ -103,7 +103,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         createAndAssignRole(RoleType.PDL, pdlProfile);
         MemberProfile supervisor = createADefaultSupervisor();
         createAndAssignRole(RoleType.ADMIN, supervisor);
-        MemberProfile requestee = createASupervisedAndPDLUser(supervisor, pdlProfile);
+        MemberProfile requestee = createAProfileWithSupervisorAndPDL(supervisor, pdlProfile);
         MemberProfile requesteeTeamLead = createAnUnrelatedUser();
         TeamMember requesteeTeamLeadMember = createLeadTeamMember(team, requesteeTeamLead);
         TeamMember requesteeTeamMember = createDefaultTeamMember(team, requestee);
@@ -132,7 +132,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         createAndAssignRole(RoleType.PDL, pdlProfile);
         MemberProfile supervisor = createADefaultSupervisor();
         createAndAssignRole(RoleType.ADMIN, supervisor);
-        MemberProfile requestee = createASupervisedAndPDLUser(supervisor, pdlProfile);
+        MemberProfile requestee = createAProfileWithSupervisorAndPDL(supervisor, pdlProfile);
         MemberProfile requesteeTeamLead = createAnUnrelatedUser();
         MemberProfile teamMemberofRequestee = createASecondDefaultMemberProfile();
         createLeadTeamMember(team, requesteeTeamLead);

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/MemberProfileFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/MemberProfileFixture.java
@@ -88,11 +88,34 @@ public interface MemberProfileFixture extends RepositoryFixture {
                 LocalDate.now().minusDays(3).minusYears(5), "is such like a bro dude, you know?",
                 null, null,null,null,null));
     }
-    default MemberProfile createASupervisedAndPDLUser(MemberProfile supervisorProfile, MemberProfile pdlProfile) {
+
+    default MemberProfile createAnotherSupervisor() {
+        return getMemberProfileRepository().save(new MemberProfile("dudette", null, "gal",
+                null, "Supervisor Lady", null, "New York, New York",
+                "dudettegal@objectcomputing.com", "dudette-gal-supervisor",
+                LocalDate.now().minusDays(5).minusYears(7), "is such like a gal dudette, you know?",
+                null, null,null,null,null));
+    }
+
+    default MemberProfile createAProfileWithSupervisorAndPDL(MemberProfile supervisorProfile, MemberProfile pdlProfile) {
         return getMemberProfileRepository().save(new MemberProfile("Charizard", null, "Char",
                 null, "Local fire hazard", pdlProfile.getId(), "New York, New York",
                 "charizard@objectcomputing.com", "local-kaiju",
                 LocalDate.now().minusDays(3).minusYears(5), "Needs a lot of supervision due to building being ultra flammable",
+                supervisorProfile.getId(), null,null,null,null));
+    }
+    default MemberProfile createAnotherProfileWithSupervisorAndPDL(MemberProfile supervisorProfile, MemberProfile pdlProfile) {
+        return getMemberProfileRepository().save(new MemberProfile("Pikachu", null, "Pika",
+                null, "Local lightning hazard", pdlProfile.getId(), "New York, New York",
+                "pikachu@objectcomputing.com", "local-lightning-kaiju",
+                LocalDate.now().minusDays(5).minusYears(3), "Pretty sparky",
+                supervisorProfile.getId(), null,null,null,null));
+    }
+    default MemberProfile createYetAnotherProfileWithSupervisorAndPDL(MemberProfile supervisorProfile, MemberProfile pdlProfile) {
+        return getMemberProfileRepository().save(new MemberProfile("Squirtle", null, "Squirt",
+                null, "Local water hazard", pdlProfile.getId(), "New York, New York",
+                "squirtle@objectcomputing.com", "local-water-kaiju",
+                LocalDate.now().minusDays(4).minusYears(6), "Rather moist",
                 supervisorProfile.getId(), null,null,null,null));
     }
     // this user is not connected to other users in the system

--- a/web-ui/src/api/feedback.js
+++ b/web-ui/src/api/feedback.js
@@ -209,3 +209,15 @@ export const getFeedbackRequestsByRequestee = async(requesteeId, oldestDate, coo
     headers: { "X-CSRF-Header": cookie }
   });
 }
+
+export const getFeedbackRequestsByRequestees = async(requesteeIds, oldestDate, cookie) => {
+  return resolve({
+    url: feedbackRequestURL,
+    params: {
+      requesteeIds,
+      oldestDate
+    },
+    responseType: "json",
+    headers: { "X-CSRF-Header": cookie }
+  });
+}

--- a/web-ui/src/api/feedback.js
+++ b/web-ui/src/api/feedback.js
@@ -6,13 +6,26 @@ const feedbackRequestURL = "/services/feedback/requests";
 const answerURL = "/services/feedback/answers";
 const questionAndAnswerURL = "/services/feedback/questions-and-answers"
 
-export const findReviewRequestsByPeriodAndTeamMember =  async (period, teamMemberId, cookie) => {
+export const findReviewRequestsByPeriodAndTeamMembers =  async (period, teamMemberIds, cookie) => {
   return resolve({
     url: feedbackRequestURL,
     params: {
       reviewPeriodId: period?.id,
       templateId: period?.reviewTemplateId,
-      requesteeId: teamMemberId,
+      requesteeIds: teamMemberIds,
+    },
+    responseType: "json",
+    headers: { "X-CSRF-Header": cookie }
+  });
+};
+
+export const findSelfReviewRequestsByPeriodAndTeamMembers =  async (period, teamMemberIds, cookie) => {
+  return resolve({
+    url: feedbackRequestURL,
+    params: {
+      reviewPeriodId: period?.id,
+      templateId: period?.selfReviewTemplateId,
+      requesteeIds: teamMemberIds,
     },
     responseType: "json",
     headers: { "X-CSRF-Header": cookie }

--- a/web-ui/src/components/reviews/TeamReviews.jsx
+++ b/web-ui/src/components/reviews/TeamReviews.jsx
@@ -261,7 +261,7 @@ const TeamReviews = ({ periodId }) => {
           : null;
       if (data && data.length > 0) {
         data = data.filter((review)=>"canceled".toUpperCase() !== review?.status?.toUpperCase());
-        newSelfReviews[data[0].requesteeId] = data[0];
+        data.forEach(selfReview => newSelfReviews[selfReview.requesteeId] = selfReview);
       }
     };
 
@@ -278,7 +278,12 @@ const TeamReviews = ({ periodId }) => {
           : null;
       if (data && data.length > 0) {
         data = data.filter((review)=>"canceled".toUpperCase() !== review?.status?.toUpperCase());
-        newReviews[data[0].requesteeId] = data;
+        data.forEach(review => {
+            if(!newReviews[review.requesteeId]) {
+                newReviews[review.requesteeId] = [];
+            }
+            newReviews[review.requesteeId].push(review);
+        });
       }
     };
 
@@ -286,10 +291,10 @@ const TeamReviews = ({ periodId }) => {
       loadingReviews.current = true;
       setSelfReviews({});
       setReviews(null);
-      loadingReviews.current = false;
-      loadedReviews.current = true;
       await getSelfReviewRequests(teamMembers);
       await getReviewRequests(teamMembers);
+      loadingReviews.current = false;
+      loadedReviews.current = true;
       setSelfReviews({...newSelfReviews});
       setReviews({...newReviews});
     }


### PR DESCRIPTION
This approach wasn't my first choice, TBH. I ended up here because of the desire to not break existing code and discovering that I couldn't do a `is NULL` check in the `@Query` on either an expanded `List<String>` or with the `STRING_ARRAY` type.  As I type this, I wonder if I couldn't have explicitly cast it and done the check...but that may have had its own quirks. So, I'll go with this unless you have a better idea. ;-)