### PR TITLE
Bugfix 2165/member export report not working

### DIFF
--- a/web-ui/src/api/api.js
+++ b/web-ui/src/api/api.js
@@ -88,7 +88,9 @@ export const resolve = async (payload) => {
   } else {
     const contentType = resolved.payload.headers.get("Content-Type");
     const contentLength = resolved.payload.headers.get("Content-Length");
-    if(contentLength && contentLength > 0) {
+    if (contentType && contentType.indexOf("text/csv") !== -1) {
+      resolved.payload.data = await resolved.payload.blob();
+    } else if (contentLength && contentLength > 0) {
       if (contentType && contentType.indexOf("application/json") !== -1) {
         resolved.payload.data = await resolved.payload.json();
       } else {


### PR DESCRIPTION
Closes #2165

After testing out the front-end APIs, I determined that the problem originated from transitioning from axios to fetch. In axios, specifying a `responseType` of `blob` would convert the response payload to a Blob object, which is then passed to the file downloader. With fetch, this conversion has to be done manually, but the implementation was only handling JSON and text responses. This modifies the `resolve` method to return a blob in the payload if the "Content-Type" header is "text/csv".

An alternative fix could be to include `responseType` in the request payload and determine the datatype for the response payload based on that, similar to axios.