### PR TITLE
feat: add role-based filtering to member selector

### DIFF
--- a/web-ui/src/components/member_selector/__snapshots__/MemberSelector.test.jsx.snap
+++ b/web-ui/src/components/member_selector/__snapshots__/MemberSelector.test.jsx.snap
@@ -607,7 +607,9 @@ exports[`MemberSelector > renders correctly with default props 1`] = `
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-et1ao3-MuiTypography-root"
                 >
-                  No members selected
+                  No 
+                  members
+                   selected
                 </span>
               </div>
             </li>

--- a/web-ui/src/components/member_selector/member_selector_dialog/MemberSelectorDialog.jsx
+++ b/web-ui/src/components/member_selector/member_selector_dialog/MemberSelectorDialog.jsx
@@ -130,7 +130,9 @@ const MemberSelectorDialog = ({
       // If the dialog is opened with initial filters, set the initial filter
       if (initialFilter && initialFilter.type === FilterType.ROLE) {
         setFilterType(initialFilter.type);
-        setFilter(selectRoles(state).find(role => role.role === 'PDL'));
+        setFilter(
+          selectRoles(state).find(role => role.role === initialFilter.value)
+        );
       }
     }
   }, [open]);

--- a/web-ui/src/components/member_selector/member_selector_dialog/__snapshots__/MemberSelectorDialog.test.jsx.snap
+++ b/web-ui/src/components/member_selector/member_selector_dialog/__snapshots__/MemberSelectorDialog.test.jsx.snap
@@ -64,7 +64,8 @@ exports[`MemberSelectorDialog > renders correctly 1`] = `
               <h5
                 class="MuiTypography-root MuiTypography-h5 toolbar-title css-ag7rrr-MuiTypography-root"
               >
-                Select Members
+                Select 
+                Members
               </h5>
               <p
                 class="MuiTypography-root MuiTypography-body1 selected-count-label css-ahj2mt-MuiTypography-root"

--- a/web-ui/src/pages/EmailPage.jsx
+++ b/web-ui/src/pages/EmailPage.jsx
@@ -424,7 +424,9 @@ const EmailPage = () => {
       if (res && res.payload && res.payload.status === 201 && !res.error) {
         setEmailSent(true);
         toastStatus = 'success';
-        toastMessage = `Sent email to ${recipients.length} member${recipients.length === 1 ? '' : 's'}`;
+        toastMessage = `Sent email to ${recipients.length} member${
+          recipients.length === 1 ? '' : 's'
+        }`;
       } else {
         toastStatus = 'error';
         toastMessage = 'Failed to send email';

--- a/web-ui/src/pages/__snapshots__/TeamSkillReportPage.test.jsx.snap
+++ b/web-ui/src/pages/__snapshots__/TeamSkillReportPage.test.jsx.snap
@@ -135,7 +135,9 @@ exports[`renders correctly 1`] = `
                   <span
                     class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-et1ao3-MuiTypography-root"
                   >
-                    No members selected
+                    No 
+                    members
+                     selected
                   </span>
                 </div>
               </li>


### PR DESCRIPTION
closes: #2211

Allows the MemberSelector component to accept an `initialFilter` prop which it passes to MemberSelectorDialog, allowing for the dialog-based member filters to clamp on role based on filter passed like:

```js
initialFilters={[{ type: FilterType.ROLE, value: 'PDL' }]}
```

Demoed experience with Michael to be sure this met the criteria.
Note this change is inert at the moment as it will be built upon in #2212.

To test, add the above `initalFilters` prop to the `MemberSelector` component in `EmailPage` component, where `FilterType.ROLE` is imported from the `MemberSelectorDialog` component.

