### PR TITLE
Bugfix 2227/fixing serialization of local date time

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewPeriod.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewPeriod.java
@@ -1,5 +1,8 @@
 package com.objectcomputing.checkins.services.reviews;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.annotation.AutoPopulated;
@@ -57,14 +60,20 @@ public class ReviewPeriod {
 
     @Nullable
     @Column(name = "launch_date")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime launchDate;
 
     @Nullable
     @Column(name = "self_review_close_date")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime selfReviewCloseDate;
 
     @Nullable
     @Column(name = "close_date")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime closeDate;
 
     public ReviewPeriod(String name, ReviewStatus reviewStatus, @Nullable UUID reviewTemplateId,

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodCreateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodCreateDTO.java
@@ -1,5 +1,8 @@
 package com.objectcomputing.checkins.services.reviews;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,12 +35,18 @@ public class ReviewPeriodCreateDTO {
     private UUID selfReviewTemplateId;
 
     @Nullable
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime launchDate;
 
     @Nullable
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime selfReviewCloseDate;
 
     @Nullable
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime closeDate;
 
     public ReviewPeriod convertToEntity(){

--- a/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodControllerTest.java
@@ -1,5 +1,8 @@
 package com.objectcomputing.checkins.services.reviews;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.objectcomputing.checkins.services.TestContainersSuite;
 import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
 import com.objectcomputing.checkins.services.fixture.ReviewPeriodFixture;
@@ -125,6 +128,40 @@ public class ReviewPeriodControllerTest extends TestContainersSuite implements R
         assertEquals(reviewPeriodCreateDTO.getName(), body.getName());
         assertEquals(reviewPeriodCreateDTO.getReviewStatus(), body.getReviewStatus());
         assertEquals(String.format("%s/%s", request.getPath(), body.getId()), response.getHeaders().get("location"));
+    }
+
+    @Test
+    public void mattExampleJsonSerialization() throws JsonProcessingException {
+        ReviewPeriodCreateDTO reviewPeriodCreateDTO = new ReviewPeriodCreateDTO();
+        reviewPeriodCreateDTO.setName("reincarnation");
+        reviewPeriodCreateDTO.setReviewStatus(ReviewStatus.OPEN);
+        reviewPeriodCreateDTO.setLaunchDate(LocalDateTime.now());
+        reviewPeriodCreateDTO.setSelfReviewCloseDate(LocalDateTime.now());
+        reviewPeriodCreateDTO.setCloseDate(LocalDateTime.now());
+
+        final HttpRequest<ReviewPeriodCreateDTO> request = HttpRequest.
+                POST("/", reviewPeriodCreateDTO).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
+        final HttpResponse<String> response = client.toBlocking().exchange(request, String.class);
+
+        assertNotNull(response);
+        var actualJson = response.body();
+        assertNotNull(actualJson);
+        assertEquals(HttpStatus.CREATED, response.getStatus());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String expectedJson = objectMapper.writeValueAsString(reviewPeriodCreateDTO);
+
+        String expectedLaunchDateFormat = objectMapper.readTree(expectedJson).get("launchDate").asText();
+        String actualLaunchDateFormat = objectMapper.readTree(actualJson).get("launchDate").asText();
+        assertEquals(expectedLaunchDateFormat, actualLaunchDateFormat);
+
+        String expectedSelfReviewCloseDateFormat = objectMapper.readTree(expectedJson).get("selfReviewCloseDate").asText();
+        String actualSelfReviewCloseDateFormat = objectMapper.readTree(actualJson).get("selfReviewCloseDate").asText();
+        assertEquals(expectedSelfReviewCloseDateFormat, actualSelfReviewCloseDateFormat);
+
+        String expectedCloseDateFormat = objectMapper.readTree(expectedJson).get("closeDate").asText();
+        String actualCloseDateFormat = objectMapper.readTree(actualJson).get("closeDate").asText();
+        assertEquals(expectedCloseDateFormat, actualCloseDateFormat);
     }
 
     @Test


### PR DESCRIPTION
Fixing LocalDateTime serialization issue that was found here: https://github.com/objectcomputing/check-ins/pull/2277

In the future it is probably simpler to set this format globally using jackson.date-format configuration setting, but that has the potential to cause issues across other APIs and would require more extensive testing. I think this path is good for now to get Syd unblocked, then maybe write up a ticket to look into that.