### PR TITLE
chore: remove icon title for idempotent builds

### DIFF
--- a/web-ui/src/components/guild-results/GuildSummaryCard.jsx
+++ b/web-ui/src/components/guild-results/GuildSummaryCard.jsx
@@ -143,7 +143,6 @@ const GuildSummaryCard = ({ guild, index, isOpen, onGuildSelect }) => {
         style={{
           color: guild.community ? 'var(--oci-orange)' : 'var(--oci-light-blue)'
         }}
-        title={`This is a ${guild.community ? 'Community' : 'Guild'}.`}
       />
       <CardHeader
         classes={{

--- a/web-ui/src/components/guild-results/__snapshots__/GuildResults.test.jsx.snap
+++ b/web-ui/src/components/guild-results/__snapshots__/GuildResults.test.jsx.snap
@@ -81,19 +81,15 @@ exports[`renders correctly 1`] = `
         class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root GuildSummaryCard-card css-1xtmct9-MuiPaper-root-MuiCard-root"
       >
         <svg
-          aria-labelledby="svg-inline--fa-title-pzb7NKWzNsFj"
+          aria-hidden="true"
           class="svg-inline--fa fa-hammer fa-2x "
           data-icon="hammer"
           data-prefix="fas"
+          focusable="false"
           role="img"
           viewBox="0 0 576 512"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="svg-inline--fa-title-pzb7NKWzNsFj"
-          >
-            This is a Guild.
-          </title>
           <path
             d="M413.5 237.5c-28.2 4.8-58.2-3.6-80-25.4l-38.1-38.1C280.4 159 272 138.8 272 117.6V105.5L192.3 62c-5.3-2.9-8.6-8.6-8.3-14.7s3.9-11.5 9.5-14l47.2-21C259.1 4.2 279 0 299.2 0h18.1c36.7 0 72 14 98.7 39.1l44.6 42c24.2 22.8 33.2 55.7 26.6 86L503 183l8-8c9.4-9.4 24.6-9.4 33.9 0l24 24c9.4 9.4 9.4 24.6 0 33.9l-88 88c-9.4 9.4-24.6 9.4-33.9 0l-24-24c-9.4-9.4-9.4-24.6 0-33.9l8-8-17.5-17.5zM27.4 377.1L260.9 182.6c3.5 4.9 7.5 9.6 11.8 14l38.1 38.1c6 6 12.4 11.2 19.2 15.7L134.9 484.6c-14.5 17.4-36 27.4-58.6 27.4C34.1 512 0 477.8 0 435.7c0-22.6 10.1-44.1 27.4-58.6z"
             fill="currentColor"
@@ -185,19 +181,15 @@ exports[`renders correctly 1`] = `
         class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root GuildSummaryCard-card css-1xtmct9-MuiPaper-root-MuiCard-root"
       >
         <svg
-          aria-labelledby="svg-inline--fa-title-KPj0zwBESM81"
+          aria-hidden="true"
           class="svg-inline--fa fa-hammer fa-2x "
           data-icon="hammer"
           data-prefix="fas"
+          focusable="false"
           role="img"
           viewBox="0 0 576 512"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="svg-inline--fa-title-KPj0zwBESM81"
-          >
-            This is a Guild.
-          </title>
           <path
             d="M413.5 237.5c-28.2 4.8-58.2-3.6-80-25.4l-38.1-38.1C280.4 159 272 138.8 272 117.6V105.5L192.3 62c-5.3-2.9-8.6-8.6-8.3-14.7s3.9-11.5 9.5-14l47.2-21C259.1 4.2 279 0 299.2 0h18.1c36.7 0 72 14 98.7 39.1l44.6 42c24.2 22.8 33.2 55.7 26.6 86L503 183l8-8c9.4-9.4 24.6-9.4 33.9 0l24 24c9.4 9.4 9.4 24.6 0 33.9l-88 88c-9.4 9.4-24.6 9.4-33.9 0l-24-24c-9.4-9.4-9.4-24.6 0-33.9l8-8-17.5-17.5zM27.4 377.1L260.9 182.6c3.5 4.9 7.5 9.6 11.8 14l38.1 38.1c6 6 12.4 11.2 19.2 15.7L134.9 484.6c-14.5 17.4-36 27.4-58.6 27.4C34.1 512 0 477.8 0 435.7c0-22.6 10.1-44.1 27.4-58.6z"
             fill="currentColor"

--- a/web-ui/src/components/guild-results/__snapshots__/GuildSummaryCard.test.jsx.snap
+++ b/web-ui/src/components/guild-results/__snapshots__/GuildSummaryCard.test.jsx.snap
@@ -6,19 +6,15 @@ exports[`renders correctly 1`] = `
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root GuildSummaryCard-card css-1xtmct9-MuiPaper-root-MuiCard-root"
   >
     <svg
-      aria-labelledby="svg-inline--fa-title-Y7IHphQv9qkY"
+      aria-hidden="true"
       class="svg-inline--fa fa-hammer fa-2x "
       data-icon="hammer"
       data-prefix="fas"
+      focusable="false"
       role="img"
       viewBox="0 0 576 512"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="svg-inline--fa-title-Y7IHphQv9qkY"
-      >
-        This is a Guild.
-      </title>
       <path
         d="M413.5 237.5c-28.2 4.8-58.2-3.6-80-25.4l-38.1-38.1C280.4 159 272 138.8 272 117.6V105.5L192.3 62c-5.3-2.9-8.6-8.6-8.3-14.7s3.9-11.5 9.5-14l47.2-21C259.1 4.2 279 0 299.2 0h18.1c36.7 0 72 14 98.7 39.1l44.6 42c24.2 22.8 33.2 55.7 26.6 86L503 183l8-8c9.4-9.4 24.6-9.4 33.9 0l24 24c9.4 9.4 9.4 24.6 0 33.9l-88 88c-9.4 9.4-24.6 9.4-33.9 0l-24-24c-9.4-9.4-9.4-24.6 0-33.9l8-8-17.5-17.5zM27.4 377.1L260.9 182.6c3.5 4.9 7.5 9.6 11.8 14l38.1 38.1c6 6 12.4 11.2 19.2 15.7L134.9 484.6c-14.5 17.4-36 27.4-58.6 27.4C34.1 512 0 477.8 0 435.7c0-22.6 10.1-44.1 27.4-58.6z"
         fill="currentColor"
@@ -74,19 +70,15 @@ exports[`renders correctly for ADMIN 1`] = `
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root GuildSummaryCard-card css-1xtmct9-MuiPaper-root-MuiCard-root"
   >
     <svg
-      aria-labelledby="svg-inline--fa-title-x5fZO7fok7Wg"
+      aria-hidden="true"
       class="svg-inline--fa fa-hammer fa-2x "
       data-icon="hammer"
       data-prefix="fas"
+      focusable="false"
       role="img"
       viewBox="0 0 576 512"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="svg-inline--fa-title-x5fZO7fok7Wg"
-      >
-        This is a Guild.
-      </title>
       <path
         d="M413.5 237.5c-28.2 4.8-58.2-3.6-80-25.4l-38.1-38.1C280.4 159 272 138.8 272 117.6V105.5L192.3 62c-5.3-2.9-8.6-8.6-8.3-14.7s3.9-11.5 9.5-14l47.2-21C259.1 4.2 279 0 299.2 0h18.1c36.7 0 72 14 98.7 39.1l44.6 42c24.2 22.8 33.2 55.7 26.6 86L503 183l8-8c9.4-9.4 24.6-9.4 33.9 0l24 24c9.4 9.4 9.4 24.6 0 33.9l-88 88c-9.4 9.4-24.6 9.4-33.9 0l-24-24c-9.4-9.4-9.4-24.6 0-33.9l8-8-17.5-17.5zM27.4 377.1L260.9 182.6c3.5 4.9 7.5 9.6 11.8 14l38.1 38.1c6 6 12.4 11.2 19.2 15.7L134.9 484.6c-14.5 17.4-36 27.4-58.6 27.4C34.1 512 0 477.8 0 435.7c0-22.6 10.1-44.1 27.4-58.6z"
         fill="currentColor"
@@ -183,19 +175,15 @@ exports[`renders correctly for guild lead 1`] = `
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root GuildSummaryCard-card css-1xtmct9-MuiPaper-root-MuiCard-root"
   >
     <svg
-      aria-labelledby="svg-inline--fa-title-pYattfh7bDnS"
+      aria-hidden="true"
       class="svg-inline--fa fa-hammer fa-2x "
       data-icon="hammer"
       data-prefix="fas"
+      focusable="false"
       role="img"
       viewBox="0 0 576 512"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="svg-inline--fa-title-pYattfh7bDnS"
-      >
-        This is a Guild.
-      </title>
       <path
         d="M413.5 237.5c-28.2 4.8-58.2-3.6-80-25.4l-38.1-38.1C280.4 159 272 138.8 272 117.6V105.5L192.3 62c-5.3-2.9-8.6-8.6-8.3-14.7s3.9-11.5 9.5-14l47.2-21C259.1 4.2 279 0 299.2 0h18.1c36.7 0 72 14 98.7 39.1l44.6 42c24.2 22.8 33.2 55.7 26.6 86L503 183l8-8c9.4-9.4 24.6-9.4 33.9 0l24 24c9.4 9.4 9.4 24.6 0 33.9l-88 88c-9.4 9.4-24.6 9.4-33.9 0l-24-24c-9.4-9.4-9.4-24.6 0-33.9l8-8-17.5-17.5zM27.4 377.1L260.9 182.6c3.5 4.9 7.5 9.6 11.8 14l38.1 38.1c6 6 12.4 11.2 19.2 15.7L134.9 484.6c-14.5 17.4-36 27.4-58.6 27.4C34.1 512 0 477.8 0 435.7c0-22.6 10.1-44.1 27.4-58.6z"
         fill="currentColor"


### PR DESCRIPTION
Removes the `title` attribute from the `FontAwesomeIcon` in the GuildSummaryCard component as the presence of this attribute was causing the icon to invalidate its snapshot value with each test run.