### PR TITLE
Feature 2212/enhanced checkin warranty

### DIFF
--- a/web-ui/src/components/member_selector/MemberSelector.jsx
+++ b/web-ui/src/components/member_selector/MemberSelector.jsx
@@ -1,19 +1,14 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Avatar,
+  Box,
   Card,
   CardHeader,
-  Divider,
   IconButton,
-  List,
-  ListItemIcon,
-  ListItemText,
   Tooltip,
   Typography
 } from '@mui/material';
 import { Add, FileDownload } from '@mui/icons-material';
-import { getAvatarURL } from '../../api/api';
 
 import MemberSelectorDialog, {
   FilterType
@@ -156,7 +151,7 @@ const MemberSelector = ({
             </div>
           }
           action={
-            <>
+            <Box sx={{ mr: 2 }}>
               <Tooltip title={`Change ${memberDescriptor}`} arrow>
                 <IconButton
                   style={{ margin: '4px 8px 0 0' }}
@@ -177,7 +172,7 @@ const MemberSelector = ({
                   </IconButton>
                 </Tooltip>
               )}
-            </>
+            </Box>
           }
         />
       </Card>

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.css
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.css
@@ -16,6 +16,10 @@
       width: 100%;
       margin: 0 0.75rem;
     }
+
+    .team-member-map-summmary-latest-activity {
+      color: var(--muted);
+    }
   }
 }
 

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
@@ -64,8 +64,9 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
                     component={'time'}
                     dateTime={getLastCheckinDate(checkins).toISOString()}
                     sx={{ display: { xs: 'none', sm: 'flex' } }}
+                    className="team-member-map-summmary-latest-activity"
                   >
-                    Activity:{' '}
+                    Latest Activity:{' '}
                     {getLastCheckinDate(checkins).toLocaleDateString(
                       navigator.language,
                       {

--- a/web-ui/src/pages/CheckinsReportPage.jsx
+++ b/web-ui/src/pages/CheckinsReportPage.jsx
@@ -97,7 +97,7 @@ const CheckinsReportPage = () => {
           const newPdls = ids
             .map(id => pdls.find(pdl => pdl.id === id))
             .filter(Boolean);
-          setSelectedPdls(newPdls);
+          newPdls.length > 0 && setSelectedPdls(newPdls);
         },
         toQP(newPdls) {
           if (isArrayPresent(newPdls)) {
@@ -113,12 +113,12 @@ const CheckinsReportPage = () => {
     processedQPs
   );
 
-  // Set the selected PDLs to the mapped PDLs unless they are already set
+  // Update selected PDLs when processedQPs is updated
   useEffect(() => {
-    if (pdls.length > 0) return;
-    const mapped = selectMappedPdls(state);
-    setSelectedPdls(mapped);
-  }, [state]);
+    if (selectedPdls.length === 0 && processedQPs.current) {
+      setSelectedPdls(selectMappedPdls(state));
+    }
+  }, [processedQPs.current]);
 
   // Set the mapped PDLs to the PDLs with members
   useEffect(() => {

--- a/web-ui/src/styles/variables.css
+++ b/web-ui/src/styles/variables.css
@@ -36,6 +36,7 @@
   --primary-link-dark-hover: #4f5f8c;
   --action: color-mix(in oklab, var(--black), var(--white) 50%);
   --action-disabled: color-mix(in oklab, var(--black), var(--white) 5%);
+  --muted: color-mix(in oklab, var(--black), var(--white) 47%);
 
   --checkins-palette-action-disabledOpacity: 0.58;
 
@@ -66,6 +67,7 @@
     --primary-text: color-mix(in oklab, var(--white), var(--black) 10%);
     --action: var(--white);
     --action-disabled: color-mix(in oklab, var(--white), var(--black) 30%);
+    --muted: color-mix(in oklab, var(--black), var(--white) 53%);
 
     --primary-main: var(--oci-light-blue);
     --primary-light: color-mix(


### PR DESCRIPTION
Page now properly selects all PDLs when the user navigates to the enhanced Check-Ins Report

Also updates card treatment to display Latest Activity using a new `--muted` utility compatible with AA conformance in contrast ratio measured using Firefox dev tools, and as close to `4.5:1` contrast as possible using whole numbers.

