### PR TITLE
chore: update icon snapshot tests

### DIFF
--- a/web-ui/src/components/member_selector/__snapshots__/MemberSelector.test.jsx.snap
+++ b/web-ui/src/components/member_selector/__snapshots__/MemberSelector.test.jsx.snap
@@ -36,51 +36,55 @@ exports[`MemberSelector > renders correctly as a controlled component 1`] = `
       <div
         class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
       >
-        <button
-          aria-label="Change Members"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
-          data-mui-internal-clone-element="true"
-          style="margin: 4px 8px 0px 0px;"
-          tabindex="0"
-          type="button"
+        <div
+          class="MuiBox-root css-1ay9vb9"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-            data-testid="AddIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="Change Members"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            style="margin: 4px 8px 0px 0px;"
+            tabindex="0"
+            type="button"
           >
-            <path
-              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          aria-label="Download"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1yq5fb3-MuiButtonBase-root-MuiIconButton-root"
-          data-mui-internal-clone-element="true"
-          tabindex="0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-            data-testid="FileDownloadIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          </button>
+          <button
+            aria-label="Download"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1yq5fb3-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
           >
-            <path
-              d="M19 9h-4V3H9v6H5l7 7zM5 18v2h14v-2z"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="FileDownloadIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 9h-4V3H9v6H5l7 7zM5 18v2h14v-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -122,27 +126,31 @@ exports[`MemberSelector > renders correctly when disabled 1`] = `
       <div
         class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
       >
-        <button
-          aria-label="Change Members"
-          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
-          data-mui-internal-clone-element="true"
-          disabled=""
-          style="margin: 4px 8px 0px 0px;"
-          tabindex="-1"
-          type="button"
+        <div
+          class="MuiBox-root css-1ay9vb9"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-            data-testid="AddIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="Change Members"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            disabled=""
+            style="margin: 4px 8px 0px 0px;"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -184,29 +192,33 @@ exports[`MemberSelector > renders correctly with default props 1`] = `
       <div
         class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
       >
-        <button
-          aria-label="Change Members"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
-          data-mui-internal-clone-element="true"
-          style="margin: 4px 8px 0px 0px;"
-          tabindex="0"
-          type="button"
+        <div
+          class="MuiBox-root css-1ay9vb9"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-            data-testid="AddIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="Change Members"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            style="margin: 4px 8px 0px 0px;"
+            tabindex="0"
+            type="button"
           >
-            <path
-              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/web-ui/src/pages/__snapshots__/TeamSkillReportPage.test.jsx.snap
+++ b/web-ui/src/pages/__snapshots__/TeamSkillReportPage.test.jsx.snap
@@ -38,29 +38,33 @@ exports[`renders correctly 1`] = `
         <div
           class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
         >
-          <button
-            aria-label="Change Members"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
-            data-mui-internal-clone-element="true"
-            style="margin: 4px 8px 0px 0px;"
-            tabindex="0"
-            type="button"
+          <div
+            class="MuiBox-root css-1ay9vb9"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <button
+              aria-label="Change Members"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin: 4px 8px 0px 0px;"
+              tabindex="0"
+              type="button"
             >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="AddIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
               />
-            </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </button>
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Markup changed, causing the snapshot to invalidate in the MemberSelector when presentation updated in #2359.