### PR TITLE
fix: include planned with in-progress

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -453,6 +453,16 @@ INSERT INTO checkins
 VALUES
 ('e60c3ca1-3894-4466-b418-9b743d058cc8', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '802cb1f5-a255-4236-8719-773fa53d79d9', '2020-06-20 11:32:29.04' , false);
 
+-- Julia Smith Check-ins
+-- NOW() + INTERVAL '1 week'
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  'b19a00d4-0225-412a-9456-d349ca293cdd',
+  '59b790d2-fabc-11eb-9a03-0242ac130003',
+  '6207b3fd-042d-49aa-9e28-dcc04f537c2d', -- pdl: Michael Kimberlin
+  CURRENT_DATE + INTERVAL '1 week', -- 1 week from current date
+  false
+);
 
 -- Unreal Ulysses Check-ins
 ---- 2021-02-25 - Completed

--- a/web-ui/src/components/reports-section/checkin-report/CheckinReport.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/CheckinReport.jsx
@@ -72,12 +72,12 @@ const CheckinsReport = ({ closed, pdl, planned, reportDate }) => {
 
     const isCheckinInProgress = (checkin, start, end) => {
       const checkinDate = getCheckinDate(checkin);
-      const now = new Date();
+      const endOfPeriod = new Date(end);
       return (
         checkinDate >= start &&
         checkinDate <= end &&
         !checkin.completed &&
-        checkinDate < now
+        checkinDate < endOfPeriod
       );
     };
 

--- a/web-ui/src/components/reports-section/checkin-report/checkin-utils.js
+++ b/web-ui/src/components/reports-section/checkin-report/checkin-utils.js
@@ -40,9 +40,13 @@ export const statusForPeriodByMemberScheduling = (
 ) => {
   if (checkins.length === 0) return 'Not Scheduled';
   const { startOfQuarter, endOfQuarter } = getQuarterBeginEnd(reportDate);
+  const endOfQuarterWithGrace = new Date(endOfQuarter);
+  endOfQuarterWithGrace.setMonth(endOfQuarter.getMonth() + 1);
   const scheduled = checkins.filter(checkin => {
     const checkinDate = getCheckinDate(checkin);
-    return checkinDate >= startOfQuarter && checkinDate <= endOfQuarter;
+    return (
+      checkinDate >= startOfQuarter && checkinDate <= endOfQuarterWithGrace // Include grace period
+    );
   });
   if (scheduled.length === 0) return 'Not Scheduled';
   const completed = scheduled.filter(checkin => checkin.completed);

--- a/web-ui/src/helpers/datetime.js
+++ b/web-ui/src/helpers/datetime.js
@@ -9,3 +9,13 @@ export const getQuarterBeginEnd = inputDate => ({
   startOfQuarter: startOfQuarter(inputDate),
   endOfQuarter: endOfQuarter(inputDate)
 });
+
+/**
+ * Return the current quarter number with year.
+ * @param {Date} date - The date to get the quarter number for.
+ * @returns {string} The quarter number with year.
+ */
+export const getQuarterDisplay = date => {
+  const quarter = Math.floor((date.getMonth() + 3) / 3);
+  return `Q${quarter} ${date.getFullYear()}`;
+};

--- a/web-ui/src/helpers/datetime.js
+++ b/web-ui/src/helpers/datetime.js
@@ -1,4 +1,4 @@
-import { startOfQuarter, endOfQuarter } from 'date-fns';
+import { startOfQuarter, endOfQuarter, getQuarter } from 'date-fns';
 
 /**
  * Returns the start and end dates of the quarter that the given date falls in.
@@ -15,7 +15,5 @@ export const getQuarterBeginEnd = inputDate => ({
  * @param {Date} date - The date to get the quarter number for.
  * @returns {string} The quarter number with year.
  */
-export const getQuarterDisplay = date => {
-  const quarter = Math.floor((date.getMonth() + 3) / 3);
-  return `Q${quarter} ${date.getFullYear()}`;
-};
+export const getQuarterDisplay = date =>
+  `Q${getQuarter(date)} ${date.getFullYear()}`;

--- a/web-ui/src/helpers/datetime.test.js
+++ b/web-ui/src/helpers/datetime.test.js
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { getQuarterBeginEnd } from './datetime';
+import { getQuarterBeginEnd, getQuarterDisplay } from './datetime';
 
 describe('getQuarterBeginEnd', () => {
   it('returns the start and end dates of the current quarter', () => {
@@ -66,5 +66,61 @@ describe('getQuarterBeginEnd', () => {
 
     expect(format(startOfQuarter, 'yyyy-MM-dd')).toBe(expectedStart);
     expect(format(endOfQuarter, 'yyyy-MM-dd')).toBe(expectedEnd);
+  });
+});
+
+describe('getQuarterDisplay', () => {
+  it('returns the current quarter number with year', () => {
+    const date = new Date('2024-04-15');
+    const expected = 'Q2 2024';
+
+    const result = getQuarterDisplay(date);
+
+    expect(result).toBe(expected);
+  });
+
+  it('returns the first quarter number with year', () => {
+    const date = new Date('2024-01-15');
+    const expected = 'Q1 2024';
+
+    const result = getQuarterDisplay(date);
+
+    expect(result).toBe(expected);
+  });
+
+  it('returns the fourth quarter number with year', () => {
+    const date = new Date('2023-10-20');
+    const expected = 'Q4 2023';
+
+    const result = getQuarterDisplay(date);
+
+    expect(result).toBe(expected);
+  });
+
+  it('returns the first quarter number with year in a leap year', () => {
+    const date = new Date('2020-02-15');
+    const expected = 'Q1 2020';
+
+    const result = getQuarterDisplay(date);
+
+    expect(result).toBe(expected);
+  });
+
+  it('returns the second quarter number with year in a non-leap year', () => {
+    const date = new Date('2021-05-20'); // Non-leap year (2021)
+    const expected = 'Q2 2021';
+
+    const result = getQuarterDisplay(date);
+
+    expect(result).toBe(expected);
+  });
+
+  it('returns the first quarter number with year in a different time zone', () => {
+    const date = new Date('2024-01-15T12:00:00-05:00'); // Eastern Standard Time (UTC-5)
+    const expected = 'Q1 2024';
+
+    const result = getQuarterDisplay(date);
+
+    expect(result).toBe(expected);
   });
 });

--- a/web-ui/src/pages/CheckinsReportPage.jsx
+++ b/web-ui/src/pages/CheckinsReportPage.jsx
@@ -126,10 +126,9 @@ const CheckinsReportPage = () => {
   useEffect(() => {
     if (!pdls) return;
     pdls.forEach(pdl => {
-      return (pdl.members = selectTeamMembersWithCheckinPDL(
-        state,
-        pdl.id
-      ).filter(member => member.pdlId === pdl.id));
+      pdl.members = selectTeamMembersWithCheckinPDL(state, pdl.id).filter(
+        member => member.pdlId === pdl.id
+      );
     });
     pdls.filter(pdl => pdl.members.length > 0);
   }, [pdls, state]);

--- a/web-ui/src/pages/CheckinsReportPage.jsx
+++ b/web-ui/src/pages/CheckinsReportPage.jsx
@@ -9,11 +9,11 @@ import {
 
 import {
   Grid,
-  Typography,
   IconButton,
   Box,
   ButtonGroup,
-  Tooltip
+  Tooltip,
+  Typography
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -24,7 +24,8 @@ import { FilterType } from '../components/member_selector/member_selector_dialog
 import {
   getQuarterBeginEnd,
   useQueryParameters,
-  isArrayPresent
+  isArrayPresent,
+  getQuarterDisplay
 } from '../helpers';
 
 import './CheckinsReportPage.css';
@@ -154,6 +155,12 @@ const CheckinsReportPage = () => {
               <ArrowBackIcon style={{ fontSize: '1.2em' }} />
             </IconButton>
           </Tooltip>
+          <Typography
+            variant="h6"
+            sx={{ fontSize: '1.5rem', alignContent: 'center', p: 1 }}
+          >
+            <nobr>{getQuarterDisplay(reportDate)}</nobr>
+          </Typography>
           <Tooltip title="Next quarter">
             <IconButton
               aria-label="Next quarter`"

--- a/web-ui/src/pages/CheckinsReportPage.jsx
+++ b/web-ui/src/pages/CheckinsReportPage.jsx
@@ -120,12 +120,16 @@ const CheckinsReportPage = () => {
     }
   }, [processedQPs.current]);
 
-  // Set the mapped PDLs to the PDLs with members
+  // Set the mapped PDLs to the PDLs with members attached
+  // filtering out data about check-ins under a different PDL.
   useEffect(() => {
     if (!pdls) return;
-    pdls.forEach(
-      pdl => (pdl.members = selectTeamMembersWithCheckinPDL(state, pdl.id))
-    );
+    pdls.forEach(pdl => {
+      return (pdl.members = selectTeamMembersWithCheckinPDL(
+        state,
+        pdl.id
+      ).filter(member => member.pdlId === pdl.id));
+    });
     pdls.filter(pdl => pdl.members.length > 0);
   }, [pdls, state]);
 


### PR DESCRIPTION
Ensure we're capturing planned check-ins when reporting quarterly check-in status by allowing a simple grace period. We also now filter out member who do not have a direct current relationship to the PDL and display the quarter number.

<img width="818" alt="Screenshot 2024-05-13 at 1 42 30 PM" src="https://github.com/objectcomputing/check-ins/assets/97140109/33aaabd2-0e71-4356-b9dc-609071894d6a">

