### PR TITLE
Bugfix 2212/rewire report display

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -401,9 +401,29 @@ Values('0ead3434-82e7-47b4-a0ef-d1f44d01732b', '1343411e-26bf-4274-81ca-1b46ba3f
 -- Mohit Bhatia Check-ins
 ---- 2020-09-29 - Active
 INSERT INTO checkins
-(id, teammemberid, pdlid, checkindate, completed) -- pdl: Michael Kimberlin
+(id, teammemberid, pdlid, checkindate, completed) -- pdl: Michael Kimberlin (reassigned to Geetika Sharma)
 VALUES
 ('8aa38f8c-2169-41b1-8548-1c2472fab7ff', 'b2d35288-7f1e-4549-aa2b-68396b162490', '6207b3fd-042d-49aa-9e28-dcc04f537c2d', '2020-09-29 15:40:29.04' , false);
+
+---- NOW() - INTERVAL '2 weeks' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  'ce666f85-4289-4fcd-b3c2-365ab965e30a',
+  'b2d35288-7f1e-4549-aa2b-68396b162490',
+  '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', -- pdl: Geetika Sharma
+  CURRENT_DATE - INTERVAL '2 weeks', -- 2 weeks ago
+  true
+);
+
+---- NOW() - INTERVAL '3 months' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  '13d76100-a6a4-4d87-82e3-9faac4ea1a09',
+  'b2d35288-7f1e-4549-aa2b-68396b162490',
+  '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', -- pdl: Geetika Sharma
+  CURRENT_DATE - INTERVAL '3 months', -- 3 months ago
+  true
+);
 
 
 -- Zack Brown Check-ins
@@ -453,8 +473,30 @@ INSERT INTO checkins
 VALUES
 ('e60c3ca1-3894-4466-b418-9b743d058cc8', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '802cb1f5-a255-4236-8719-773fa53d79d9', '2020-06-20 11:32:29.04' , false);
 
+-- Suman Maroju Check-ins
+---- NOW() - INTERVAL '2 days' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  '34a48fe2-7db9-4e39-927c-ffe32467df71',
+  '1b4f99da-ef70-4a76-9b37-8bb783b749ad',
+  '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', -- pdl: Geetika Sharma
+  CURRENT_DATE - INTERVAL '2 days', -- 2 days ago
+  true
+);
+
+---- NOW() - INTERVAL '5 months' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  'e70524e2-3f81-4f94-afae-a638aca0d3b5',
+  '1b4f99da-ef70-4a76-9b37-8bb783b749ad',
+  '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', -- pdl: Geetika Sharma
+  CURRENT_DATE - INTERVAL '5 months', -- 5 months ago
+  true
+);
+
+
 -- Julia Smith Check-ins
--- NOW() + INTERVAL '1 week'
+---- NOW() + INTERVAL '1 week' - Active
 INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
 VALUES (
   'b19a00d4-0225-412a-9456-d349ca293cdd',
@@ -463,6 +505,17 @@ VALUES (
   CURRENT_DATE + INTERVAL '1 week', -- 1 week from current date
   false
 );
+
+---- NOW() - INTERVAL '3 months' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  '30026234-c228-48f5-aa93-53eab4b4dcef',
+  '59b790d2-fabc-11eb-9a03-0242ac130003',
+  '6207b3fd-042d-49aa-9e28-dcc04f537c2d', -- pdl: Michael Kimberlin
+  CURRENT_DATE - INTERVAL '3 months', -- 3 months ago from current date
+  true
+);
+
 
 -- Unreal Ulysses Check-ins
 ---- 2021-02-25 - Completed
@@ -512,6 +565,50 @@ INSERT INTO private_notes
 (id, checkinid, createdbyid, description) -- created by: Julia Smith
 VALUES
 ('73a5e7b5-9292-45c0-a605-5b5c63230892', '553aa528-d5f6-4d15-bfb6-b53738dc7954', '59b790d2-fabc-11eb-9a03-0242ac130003', PGP_SYM_ENCRYPT('Julia''s first private note for Ulysses', '${aeskey}'));
+
+
+-- Joe Warner Check-ins
+---- NOW() - INTERVAL '1 day' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  'f5254f0d-97ba-4e5b-9c16-9a83bb545124',
+  '066b186f-1425-45de-89f2-4ddcc6ebe237',
+  '2c1b77e2-e2fc-46d1-92f2-beabbd28ee3d', -- pdl: Mark Volkmann
+  CURRENT_DATE - INTERVAL '1 day', -- 1 day ago
+  true
+);
+
+---- NOW() - INTERVAL '3 months' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  '962fa088-cf7d-476f-8d8d-625ce190de84',
+  '066b186f-1425-45de-89f2-4ddcc6ebe237',
+  '2c1b77e2-e2fc-46d1-92f2-beabbd28ee3d', -- pdl: Mark Volkmann
+  CURRENT_DATE - INTERVAL '3 months', -- 3 months ago
+  true
+);
+
+
+-- Holly Williams Check-ins
+---- NOW() + INTERVAL '1 month' - Active
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  '1490caa7-1856-4c08-b287-5aa3684952e6',
+  '8fa673c0-ca19-4271-b759-41cb9db2e83a',
+  '802cb1f5-a255-4236-8719-773fa53d79d9', -- pdl: John Meyerin
+  CURRENT_DATE + INTERVAL '1 month', -- 1 month from now
+  false
+);
+
+---- NOW() - INTERVAL '3 months' - Completed
+INSERT INTO checkins (id, teammemberid, pdlid, checkindate, completed)
+VALUES (
+  'a41d9472-69b7-412a-9f76-8d41dae2b165',
+  '8fa673c0-ca19-4271-b759-41cb9db2e83a', -- Holly Williams
+  '802cb1f5-a255-4236-8719-773fa53d79d9', -- pdl: John Meyerin
+  CURRENT_DATE - INTERVAL '3 months', -- 3 months ago
+  true
+);
 
 
 -- Guilds

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
@@ -1,11 +1,12 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   Accordion,
   AccordionSummary,
   Avatar,
   Chip,
   Typography,
-  AccordionDetails
+  AccordionDetails,
+  Box
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { getAvatarURL } from '../../../api/api.js';
@@ -21,21 +22,10 @@ import './TeamMemberMap.css';
 const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
   const { state } = useContext(AppContext);
 
-  const filteredMembers = members?.filter(member => {
-    const checkins = selectFilteredCheckinsForTeamMemberAndPDL(
-      state,
-      member.id,
-      id,
-      closed,
-      planned
-    );
-    return checkins && checkins.length > 0;
-  });
-
   return (
-    <>
-      {filteredMembers?.length > 0 ? (
-        filteredMembers.map(member => {
+    <Box className="team-member-map">
+      {members?.length > 0 ? (
+        members.map(member => {
           const checkins = selectFilteredCheckinsForTeamMemberAndPDL(
             state,
             member.id,
@@ -66,14 +56,20 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
                     sx={{ display: { xs: 'none', sm: 'flex' } }}
                     className="team-member-map-summmary-latest-activity"
                   >
-                    Latest Activity:{' '}
-                    {getLastCheckinDate(checkins).toLocaleDateString(
-                      navigator.language,
-                      {
-                        year: 'numeric',
-                        month: '2-digit',
-                        day: 'numeric'
-                      }
+                    {getLastCheckinDate(checkins).getFullYear() === 1969 ? (
+                      <p>No activity available.</p>
+                    ) : (
+                      <>
+                        Latest Activity:{' '}
+                        {getLastCheckinDate(checkins).toLocaleDateString(
+                          navigator.language,
+                          {
+                            year: 'numeric',
+                            month: '2-digit',
+                            day: 'numeric'
+                          }
+                        )}
+                      </>
                     )}
                   </Typography>
                   <Chip
@@ -93,13 +89,15 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
                 </div>
               </AccordionSummary>
               <AccordionDetails id="accordion-checkin-date">
-                {checkins.map(checkin => (
-                  <LinkSection
-                    key={checkin.id}
-                    checkin={checkin}
-                    member={member}
-                  />
-                ))}
+                {checkins.length === 0
+                  ? 'No check-in activity found for this member and PDL.'
+                  : checkins.map(checkin => (
+                      <LinkSection
+                        key={checkin.id}
+                        checkin={checkin}
+                        member={member}
+                      />
+                    ))}
               </AccordionDetails>
             </Accordion>
           );
@@ -109,7 +107,7 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
           <Typography>No team members associated with this PDL.</Typography>
         </div>
       )}
-    </>
+    </Box>
   );
 };
 

--- a/web-ui/src/pages/CheckinsReportPage.jsx
+++ b/web-ui/src/pages/CheckinsReportPage.jsx
@@ -135,6 +135,21 @@ const CheckinsReportPage = () => {
     pdls.filter(pdl => pdl.members.length > 0);
   }, [pdls, state]);
 
+  // Keyboard navigation for changing quarters.
+  useEffect(() => {
+    const handleKeyDown = evt => {
+      if (evt.key === 'ArrowLeft') {
+        document
+          .querySelector('button[aria-label="Previous quarter`"]')
+          .click();
+      } else if (evt.key === 'ArrowRight') {
+        document.querySelector('button[aria-label="Next quarter`"]').click();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   return (
     <div className="checkins-report-page">
       <MemberSelector

--- a/web-ui/src/pages/CheckinsReportPage.jsx
+++ b/web-ui/src/pages/CheckinsReportPage.jsx
@@ -3,8 +3,8 @@ import React, { useContext, useEffect, useState, useRef } from 'react';
 import { AppContext } from '../context/AppContext';
 import {
   selectCheckinPDLS,
-  selectTeamMembersWithCheckinPDL,
-  selectMappedPdls
+  selectMappedPdls,
+  selectNormalizedMembers
 } from '../context/selectors';
 
 import {
@@ -65,6 +65,8 @@ const CheckinsReportPage = () => {
   const [planned, setPlanned] = useState(true);
   const [closed, setClosed] = useState(true);
 
+  const [searchText, setSearchText] = useState('');
+
   const [reportDate, setReportDate] = useState(new Date());
   const { startOfQuarter, endOfQuarter } = getQuarterBeginEnd(reportDate);
 
@@ -121,14 +123,14 @@ const CheckinsReportPage = () => {
     }
   }, [processedQPs.current]);
 
-  // Set the mapped PDLs to the PDLs with members attached
-  // filtering out data about check-ins under a different PDL.
+  // Set the mapped PDLs to a full list of their members
   useEffect(() => {
     if (!pdls) return;
     pdls.forEach(pdl => {
-      pdl.members = selectTeamMembersWithCheckinPDL(state, pdl.id).filter(
+      const allMembers = selectNormalizedMembers(state, searchText).filter(
         member => member.pdlId === pdl.id
       );
+      pdl.members = allMembers;
     });
     pdls.filter(pdl => pdl.members.length > 0);
   }, [pdls, state]);


### PR DESCRIPTION
As discovered the previous page selector used in the Check-Ins was filtering out members without Check-Ins activity. Existing report logic is now replaced as expected per ACs in #2212 to report the expected PDL and team members.

Also updates our data load script to provide additional check-ins info to test reporting edge cases.

Finally, adds a keyboard listener to the Check-Ins report page for navigating quarters. This is especially helpful while making comparisons between quarters when the user's viewport has scrolled below the fold.