### PR TITLE
feat: add detailed check-ins report cards

### DIFF
--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.css
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.css
@@ -4,14 +4,15 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 1.5rem;
     margin-top: 0.5rem;
     cursor: pointer;
 
     .team-member-map-summmary-content {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: 2fr 2fr 1fr;
+      gap: 1rem;
+
       align-items: center;
       width: 100%;
       margin: 0 0.75rem;

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.css
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.css
@@ -12,7 +12,6 @@
       display: grid;
       grid-template-columns: 2fr 2fr 1fr;
       gap: 1rem;
-
       align-items: center;
       width: 100%;
       margin: 0 0.75rem;

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
@@ -22,6 +22,7 @@ import './TeamMemberMap.css';
 
 const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
   const { state } = useContext(AppContext);
+  const epoch = new Date(0);
 
   return (
     <Box className="team-member-map">
@@ -69,7 +70,7 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
                       {getCheckinDateForPeriod(
                         checkins,
                         reportDate
-                      ).getFullYear() === 1969 ? (
+                      ).getFullYear() === epoch.getFullYear() ? (
                         <Typography component="nobr" variant="h6">
                           No activity yet{' '}
                           <span role="img" aria-label="unscheduled">

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
@@ -72,7 +72,7 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
                       ).getFullYear() === 1969 ? (
                         <Typography component="nobr" variant="h6">
                           No activity yet{' '}
-                          <span role="img" aria-label="scheduled">
+                          <span role="img" aria-label="unscheduled">
                             🚫
                           </span>
                         </Typography>

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
@@ -13,6 +13,7 @@ import { getAvatarURL } from '../../../api/api.js';
 import { AppContext } from '../../../context/AppContext.jsx';
 import { selectFilteredCheckinsForTeamMemberAndPDL } from '../../../context/selectors.js';
 import {
+  getCheckinDateForPeriod,
   getLastCheckinDate,
   statusForPeriodByMemberScheduling
 } from './checkin-utils.js';
@@ -44,33 +45,64 @@ const TeamMemberMap = ({ members, id, closed, planned, reportDate }) => {
                 className="team-member-map-accordion-summary"
               >
                 <Avatar
-                  className={'large'}
+                  sx={{ width: 54, height: 54 }}
                   src={getAvatarURL(member.workEmail)}
                 />
                 <div className="team-member-map-summmary-content">
-                  <Typography>{member.name}</Typography>
+                  <hgroup>
+                    <Typography variant="h6">{member.name}</Typography>
+                    <Typography sx={{ color: 'var(--muted)' }} variant="body2">
+                      {member.title}
+                    </Typography>
+                  </hgroup>
                   <Typography
                     variant="caption"
                     component={'time'}
                     dateTime={getLastCheckinDate(checkins).toISOString()}
-                    sx={{ display: { xs: 'none', sm: 'flex' } }}
+                    sx={{ display: { xs: 'none', sm: 'grid' } }}
                     className="team-member-map-summmary-latest-activity"
                   >
-                    {getLastCheckinDate(checkins).getFullYear() === 1969 ? (
-                      <p>No activity available.</p>
-                    ) : (
-                      <>
-                        Latest Activity:{' '}
-                        {getLastCheckinDate(checkins).toLocaleDateString(
-                          navigator.language,
-                          {
-                            year: 'numeric',
-                            month: '2-digit',
-                            day: 'numeric'
-                          }
-                        )}
-                      </>
-                    )}
+                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                      <Typography variant="overline" sx={{ mb: -1 }}>
+                        Check-In date:
+                      </Typography>
+                      {getCheckinDateForPeriod(
+                        checkins,
+                        reportDate
+                      ).getFullYear() === 1969 ? (
+                        <Typography component="nobr" variant="h6">
+                          No activity yet{' '}
+                          <span role="img" aria-label="scheduled">
+                            🚫
+                          </span>
+                        </Typography>
+                      ) : (
+                        <>
+                          <Typography component="nobr" variant="h6">
+                            {getCheckinDateForPeriod(
+                              checkins,
+                              reportDate
+                            ).toLocaleDateString(navigator.language, {
+                              year: 'numeric',
+                              month: '2-digit',
+                              day: 'numeric'
+                            })}{' '}
+                            {getCheckinDateForPeriod(
+                              checkins,
+                              reportDate
+                            ).getTime() > new Date().getTime() ? (
+                              <span role="img" aria-label="scheduled">
+                                📆
+                              </span>
+                            ) : (
+                              <span role="img" aria-label="completed">
+                                ✅
+                              </span>
+                            )}
+                          </Typography>
+                        </>
+                      )}
+                    </Box>
                   </Typography>
                   <Chip
                     label={statusForPeriodByMemberScheduling(

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.test.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import TeamMemberMap from './TeamMemberMap';
+
+import { AppContextProvider } from '../../../context/AppContext';
+
+const members = [
+  {
+    id: 'fb5b1f62-f945-4b74-9f10-2247fcde3ddd',
+    name: 'John Doe',
+    description: 'Test data for John Doe'
+  },
+  {
+    id: '09251b3b-d54f-4b3d-b3a1-d3cfb3b9a1e5',
+    name: 'Jane Doe',
+    description: 'Test data for Jane Doe'
+  }
+];
+
+const initialState = {
+  state: {
+    userProfile: {
+      name: 'holmes',
+      memberProfile: {
+        id: '3fa4-5717-4562-b3fc-2c963f66afa9',
+        pdlId: '',
+        title: 'Tester',
+        workEmail: 'test@tester.com'
+      },
+      role: ['MEMBER'],
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/7/74/SNL_MrBill_Doll.jpg'
+    }
+  }
+};
+
+const adminState = { ...initialState };
+adminState.state = { ...adminState.state };
+adminState.state.userProfile = { ...adminState.state.userProfile };
+adminState.state.userProfile.role = ['MEMBER', 'ADMIN'];
+
+describe('TeamMemberMap', () => {
+  it('should render the component without team members', () => {
+    const withoutTeamMembers = {
+      members: [],
+      id: '2c1b77e2-e2fc-46d1-92f2-beabbd28ee3d',
+      closed: true,
+      planned: true,
+      reportDate: new Date()
+    };
+    render(
+      <AppContextProvider value={initialState}>
+        <TeamMemberMap {...withoutTeamMembers} />
+      </AppContextProvider>
+    );
+    const message = screen.getByText(
+      'No team members associated with this PDL.'
+    );
+    expect(message).toBeInTheDocument();
+  });
+
+  it('should render the component with team members', () => {
+    const withTeamMembers = {
+      members,
+      id: '2c1b77e2-e2fc-46d1-92f2-beabbd28ee3d',
+      closed: true,
+      planned: true,
+      reportDate: new Date()
+    };
+    render(
+      <AppContextProvider value={initialState}>
+        <TeamMemberMap {...withTeamMembers} />
+      </AppContextProvider>
+    );
+    const member1 = screen.getByText('John Doe');
+    const member2 = screen.getByText('Jane Doe');
+    expect(member1).toBeInTheDocument();
+    expect(member2).toBeInTheDocument();
+  });
+});

--- a/web-ui/src/components/reports-section/checkin-report/checkin-utils.js
+++ b/web-ui/src/components/reports-section/checkin-report/checkin-utils.js
@@ -29,7 +29,28 @@ export const getLastCheckinDate = checkins => {
 };
 
 /**
+ * Get the date of the last scheduled check-in for the reporting period.
+ * Include the grace period for the end of the quarter.
+ * @param {Checkin[]} checkins - Check-ins for a member.
+ * @param {Date} reportDate - The date of the report.
+ * @returns {Date} The date of the last scheduled check-in.
+ */
+export const getCheckinDateForPeriod = (checkins, reportDate) => {
+  const { startOfQuarter, endOfQuarter } = getQuarterBeginEnd(reportDate);
+  const endOfQuarterWithGrace = new Date(endOfQuarter);
+  endOfQuarterWithGrace.setMonth(endOfQuarter.getMonth() + 1);
+  const scheduled = checkins.filter(checkin => {
+    const checkinDate = getCheckinDate(checkin);
+    return (
+      checkinDate >= startOfQuarter && checkinDate <= endOfQuarterWithGrace // Include grace period
+    );
+  });
+  return getLastCheckinDate(scheduled);
+};
+
+/**
  * Determine check-in status for a member during the reporting period.
+ * Include the grace period for the end of the quarter.
  * @param {Checkin[]} checkins - Check-ins for a member.
  * @param {Date} reportDate - The date of the report.
  * @returns {SchedulingStatus} The status of the check-ins.

--- a/web-ui/src/components/reports-section/checkin-report/checkin-utils.test.js
+++ b/web-ui/src/components/reports-section/checkin-report/checkin-utils.test.js
@@ -1,5 +1,6 @@
 import {
   getCheckinDate,
+  getCheckinDateForPeriod,
   getLastCheckinDate,
   statusForPeriodByMemberScheduling
 } from './checkin-utils';
@@ -60,6 +61,61 @@ describe('getLastCheckinDate', () => {
     const checkins = [];
     const result = getLastCheckinDate(checkins);
     expect(result).toEqual(new Date(0)); // Date at epoch (Jan 1, 1970)
+  });
+});
+
+describe('getCheckinDateForPeriod', () => {
+  const mockReportDate = new Date(2024, 3, 15); // April 15, 2024 (example report date)
+
+  test('returns correct date when check-in is within the reporting period', () => {
+    const checkins = [
+      { checkInDate: [2024, 3, 1, 10, 0] }, // March 1, 2024
+      { checkInDate: [2024, 4, 1, 9, 0] }, // April 1, 2024
+      { checkInDate: [2024, 4, 15, 14, 30] } // April 15, 2024
+    ];
+
+    const result = getCheckinDateForPeriod(checkins, mockReportDate);
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(3); // April is 3 (zero-indexed)
+    expect(result.getDate()).toBe(15); // Latest date in the array
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
+  });
+
+  test('returns correct date when check-in is within the reporting period and grace period', () => {
+    const checkins = [
+      { checkInDate: [2024, 3, 1, 10, 0] }, // March 1, 2024
+      { checkInDate: [2024, 4, 1, 9, 0] }, // April 1, 2024
+      { checkInDate: [2024, 5, 1, 14, 30] } // May 1, 2024
+    ];
+
+    const result = getCheckinDateForPeriod(checkins, mockReportDate);
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(4); // May is 4 (zero-indexed)
+    expect(result.getDate()).toBe(1); // Latest date in the array
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
+  });
+
+  test('returns correct date regardless of checkin status (completed or not)', () => {
+    const checkins = [
+      { checkInDate: [2024, 3, 1, 10, 0], completed: true }, // March 1, 2024 (completed)
+      { checkInDate: [2024, 4, 1, 9, 0], completed: false }, // April 1, 2024 (not completed)
+      { checkInDate: [2024, 4, 15, 14, 30], completed: false } // April 15, 2024 (not completed)
+    ];
+
+    const result = getCheckinDateForPeriod(checkins, mockReportDate);
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(3); // April is 3 (zero-indexed)
+    expect(result.getDate()).toBe(15); // Latest date in the array
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
   });
 });
 


### PR DESCRIPTION
Now when an Admin is viewing the enhanced check-ins report they can the new details summary for #2213. This report adds member title, check-in date, and an at-a-glance summary of all members' status for a given PDL in each period.


https://github.com/objectcomputing/check-ins/assets/97140109/10cbb751-5487-4f2f-80ab-418318cfc4b2

