### PR TITLE
fix: allow keyboard-only menu navigation

### DIFF
--- a/web-ui/src/components/menu/Menu.css
+++ b/web-ui/src/components/menu/Menu.css
@@ -87,6 +87,7 @@
     font-size: 14px;
   }
 
+  .Menu-listItem,
   .Menu-subListItem,
   .MuiListItem-root {
     color: var(--checkins-palette-primary-menuItem);

--- a/web-ui/src/components/menu/Menu.jsx
+++ b/web-ui/src/components/menu/Menu.jsx
@@ -30,6 +30,7 @@ import {
   IconButton,
   List,
   ListItem,
+  ListItemButton,
   ListItemText,
   Modal,
   Toolbar
@@ -44,6 +45,7 @@ const classes = {
   menuButton: `${PREFIX}-menuButton`,
   drawerPaper: `${PREFIX}-drawerPaper`,
   content: `${PREFIX}-content`,
+  listItem: `${PREFIX}-listItem`,
   listStyle: `${PREFIX}-listStyle`,
   nested: `${PREFIX}-nested`,
   subListItem: `${PREFIX}-subListItem`
@@ -238,7 +240,7 @@ function Menu({ children }) {
 
   const createLinkJsx = (path, name, isSubLink) => {
     return (
-      <ListItem
+      <ListItemButton
         key={path}
         component={Link}
         to={path}
@@ -256,7 +258,7 @@ function Menu({ children }) {
           classes={isSubLink ? { primary: classes.subListItem } : null}
           primary={name}
         />
-      </ListItem>
+      </ListItemButton>
     );
   };
 
@@ -284,48 +286,57 @@ function Menu({ children }) {
 
       <List component="nav" className={classes.listStyle}>
         <div>
-          {createLinkJsx('/', 'HOME', false)}
+          <span className="Menu-listItem">
+            {createLinkJsx('/', 'HOME', false)}
+          </span>
           {isAdmin && (
             <>
-              <ListItem onClick={toggleAdmin} className={classes.listItem}>
+              <ListItemButton
+                onClick={toggleAdmin}
+                className={classes.listItem}
+              >
                 <ListItemText primary="ADMIN" />
-              </ListItem>
+              </ListItemButton>
               <Collapse in={adminOpen} timeout="auto" unmountOnExit>
                 {createListJsx(adminLinks, true)}
                 {isAdmin && (
-                  <ListItem
+                  <ListItemButton
+                    sx={{ pl: 4, py: 1.5 }}
                     className={classes.listItem}
                     onClick={openHoursUpload}
-                    style={{ marginLeft: '1rem' }}
                   >
                     Upload Hours
-                  </ListItem>
+                  </ListItemButton>
                 )}
               </Collapse>
             </>
           )}
-          {createLinkJsx('/checkins', 'CHECK-INS', false)}
-          <ListItem onClick={toggleDirectory} className={classes.listItem}>
+          <span className="Menu-listItem">
+            {createLinkJsx('/checkins', 'CHECK-INS', false)}
+          </span>
+          <ListItemButton
+            onClick={toggleDirectory}
+            className={classes.listItem}
+          >
             <ListItemText primary="DIRECTORY" />
-          </ListItem>
+          </ListItemButton>
           <Collapse in={directoryOpen} timeout="auto" unmountOnExit>
             {createListJsx(directoryLinks, true)}
           </Collapse>
-          <ListItem onClick={toggleFeedback} className={classes.listItem}>
+          <ListItemButton onClick={toggleFeedback} className={classes.listItem}>
             <ListItemText primary="FEEDBACK" />
-          </ListItem>
+          </ListItemButton>
           <Collapse in={feedbackOpen} timeout="auto" unmountOnExit>
             {createListJsx(feedbackLinks, true)}
           </Collapse>
           {hasReportPermission && (
             <React.Fragment>
-              <ListItem
-                button
+              <ListItemButton
                 onClick={toggleReports}
                 className={classes.listItem}
               >
                 <ListItemText primary="REPORTS" />
-              </ListItem>
+              </ListItemButton>
               <Collapse in={reportsOpen} timeout="auto" unmountOnExit>
                 {createListJsx(getReportLinks(), true)}
               </Collapse>

--- a/web-ui/src/components/menu/__snapshots__/Menu.test.jsx.snap
+++ b/web-ui/src/components/menu/__snapshots__/Menu.test.jsx.snap
@@ -85,42 +85,50 @@ exports[`<Menu /> > renders correctly 1`] = `
               class="MuiList-root MuiList-padding Menu-listStyle css-h4y409-MuiList-root"
             >
               <div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      HOME
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/checkins"
-                  tabindex="0"
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        HOME
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/checkins"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      CHECK-INS
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        CHECK-INS
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -254,42 +262,50 @@ exports[`<Menu /> > renders correctly 1`] = `
               class="MuiList-root MuiList-padding Menu-listStyle css-h4y409-MuiList-root"
             >
               <div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      HOME
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/checkins"
-                  tabindex="0"
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        HOME
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/checkins"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      CHECK-INS
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        CHECK-INS
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -493,24 +509,28 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
               class="MuiList-root MuiList-padding Menu-listStyle css-h4y409-MuiList-root"
             >
               <div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      HOME
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        HOME
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -529,24 +549,28 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/checkins"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/checkins"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      CHECK-INS
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        CHECK-INS
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -698,24 +722,28 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
               class="MuiList-root MuiList-padding Menu-listStyle css-h4y409-MuiList-root"
             >
               <div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      HOME
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        HOME
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -734,24 +762,28 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/checkins"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/checkins"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      CHECK-INS
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        CHECK-INS
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -973,42 +1005,50 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
               class="MuiList-root MuiList-padding Menu-listStyle css-h4y409-MuiList-root"
             >
               <div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      HOME
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/checkins"
-                  tabindex="0"
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        HOME
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/checkins"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      CHECK-INS
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        CHECK-INS
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
@@ -1142,42 +1182,50 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
               class="MuiList-root MuiList-padding Menu-listStyle css-h4y409-MuiList-root"
             >
               <div>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/"
-                  tabindex="0"
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      HOME
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
-                <a
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                  href="/checkins"
-                  tabindex="0"
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        HOME
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
+                <span
+                  class="Menu-listItem"
                 >
-                  <div
-                    class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/checkins"
+                    tabindex="0"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      CHECK-INS
-                    </span>
-                  </div>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </a>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+                      >
+                        CHECK-INS
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </span>
                 <div
                   class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"

--- a/web-ui/src/components/menu/__snapshots__/Menu.test.jsx.snap
+++ b/web-ui/src/components/menu/__snapshots__/Menu.test.jsx.snap
@@ -86,8 +86,9 @@ exports[`<Menu /> > renders correctly 1`] = `
             >
               <div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -98,10 +99,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                       HOME
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/checkins"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -112,9 +117,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                       CHECK-INS
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -125,7 +135,10 @@ exports[`<Menu /> > renders correctly 1`] = `
                       DIRECTORY
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
                   class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
                   style="min-height: 0px;"
@@ -137,8 +150,9 @@ exports[`<Menu /> > renders correctly 1`] = `
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Mui-selected Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/guilds"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -149,10 +163,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                             Guilds & Communities
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/people"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -163,10 +181,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                             People
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/teams"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -177,12 +199,17 @@ exports[`<Menu /> > renders correctly 1`] = `
                             Teams
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                     </div>
                   </div>
                 </div>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -193,7 +220,10 @@ exports[`<Menu /> > renders correctly 1`] = `
                       FEEDBACK
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
               </div>
             </nav>
           </div>
@@ -225,8 +255,9 @@ exports[`<Menu /> > renders correctly 1`] = `
             >
               <div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -237,10 +268,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                       HOME
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/checkins"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -251,9 +286,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                       CHECK-INS
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -264,7 +304,10 @@ exports[`<Menu /> > renders correctly 1`] = `
                       DIRECTORY
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
                   class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
                   style="min-height: 0px;"
@@ -276,8 +319,9 @@ exports[`<Menu /> > renders correctly 1`] = `
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Mui-selected Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/guilds"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -288,10 +332,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                             Guilds & Communities
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/people"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -302,10 +350,14 @@ exports[`<Menu /> > renders correctly 1`] = `
                             People
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/teams"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -316,12 +368,17 @@ exports[`<Menu /> > renders correctly 1`] = `
                             Teams
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                     </div>
                   </div>
                 </div>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -332,7 +389,10 @@ exports[`<Menu /> > renders correctly 1`] = `
                       FEEDBACK
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
               </div>
             </nav>
           </div>
@@ -434,8 +494,9 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
             >
               <div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -446,9 +507,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       HOME
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -459,10 +525,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       ADMIN
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/checkins"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -473,9 +543,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       CHECK-INS
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -486,7 +561,10 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       DIRECTORY
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
                   class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
                   style="min-height: 0px;"
@@ -498,8 +576,9 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Mui-selected Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/guilds"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -510,10 +589,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                             Guilds & Communities
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/people"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -524,10 +607,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                             People
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/teams"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -538,12 +625,17 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                             Teams
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                     </div>
                   </div>
                 </div>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -554,9 +646,12 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       FEEDBACK
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
-                  class="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
                   tabindex="0"
                 >
@@ -604,8 +699,9 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
             >
               <div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -616,9 +712,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       HOME
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -629,10 +730,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       ADMIN
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/checkins"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -643,9 +748,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       CHECK-INS
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -656,7 +766,10 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       DIRECTORY
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
                   class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
                   style="min-height: 0px;"
@@ -668,8 +781,9 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Mui-selected Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/guilds"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -680,10 +794,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                             Guilds & Communities
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/people"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -694,10 +812,14 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                             People
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/teams"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -708,12 +830,17 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                             Teams
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                     </div>
                   </div>
                 </div>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -724,9 +851,12 @@ exports[`<Menu /> > renders correctly for admin 1`] = `
                       FEEDBACK
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
-                  class="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-padding MuiListItem-button css-bshv44-MuiButtonBase-root-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="button"
                   tabindex="0"
                 >
@@ -844,8 +974,9 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
             >
               <div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -856,10 +987,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       HOME
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/checkins"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -870,9 +1005,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       CHECK-INS
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -883,7 +1023,10 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       DIRECTORY
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
                   class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
                   style="min-height: 0px;"
@@ -895,8 +1038,9 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Mui-selected Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/guilds"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -907,10 +1051,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                             Guilds & Communities
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/people"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -921,10 +1069,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                             People
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/teams"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -935,12 +1087,17 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                             Teams
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                     </div>
                   </div>
                 </div>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -951,7 +1108,10 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       FEEDBACK
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
               </div>
             </nav>
           </div>
@@ -983,8 +1143,9 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
             >
               <div>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -995,10 +1156,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       HOME
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
                 <a
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   href="/checkins"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -1009,9 +1174,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       CHECK-INS
                     </span>
                   </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
                 </a>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -1022,7 +1192,10 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       DIRECTORY
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
                 <div
                   class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-pwcg7p-MuiCollapse-root"
                   style="min-height: 0px;"
@@ -1034,8 +1207,9 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Mui-selected Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/guilds"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -1046,10 +1220,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                             Guilds & Communities
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/people"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -1060,10 +1238,14 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                             People
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                       <a
-                        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding Menu-nested css-1p823my-MuiListItem-root"
+                        class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-nested css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                         href="/teams"
+                        tabindex="0"
                       >
                         <div
                           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -1074,12 +1256,17 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                             Teams
                           </span>
                         </div>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
                       </a>
                     </div>
                   </div>
                 </div>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters Menu-listItem css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemText-root css-tlelie-MuiListItemText-root"
@@ -1090,7 +1277,10 @@ exports[`<Menu /> > renders correctly for pdl 1`] = `
                       FEEDBACK
                     </span>
                   </div>
-                </li>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
               </div>
             </nav>
           </div>


### PR DESCRIPTION
closes: #2378

Replaces deprecated MUI feature in favor of suggested replacement with better semantics. This fixes a keyboard navigation issue existing on the site, which was making some areas of the navigation keyboard inaccessible. When the keyboard works as expected, the button focus states appear as expected as well which is was spawned the closed issue.

https://github.com/objectcomputing/check-ins/assets/97140109/7efe3d90-dc6e-4ab1-90dd-5e874e67f817

