### PR TITLE
chore: update local cors config

### DIFF
--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ micronaut:
       enabled: true
       configurations:
         web:
-          allowedOrigins:
+          allowedOriginsRegex:
             - ^http(|s):\/\/localhost:.*$
   security:
     authentication: cookie


### PR DESCRIPTION
With the micronaut upgrade in #2360 our HMR functionality began malfunctioning as pictured below. Looking at the latest CORS docs for Micronaut (4.4.x) https://docs.micronaut.io/latest/guide/index.html#cors I see the Regex property uses the name regex. When the name is configured like the documentation with the `Regex` postfix the regex works as expected and attempts to fetch resources from a browser on port `5137` will work as expected.

<img width="1380" alt="Screenshot 2024-05-15 at 4 29 01 PM" src="https://github.com/objectcomputing/check-ins/assets/97140109/bd9cfb5b-3685-4a51-9ce4-9937a20bd090">
