### PR TITLE
chore: update docs for jdk 17 usage

### DIFF
--- a/docs/getting-started/setup/macos.md
+++ b/docs/getting-started/setup/macos.md
@@ -95,10 +95,10 @@ If you haven't already, you will want to [configure git to use ssh for connectin
 
 JDK is required to build and run the Check-Ins project. You can install JDK in a number of ways, including via Homebrew, SDKMAN, or by downloading the JDK from the [AdoptOpenJDK](https://adoptopenjdk.net/) website.
 
-To install JDK 14 with Homebrew (intel Macs only), run the following command on the command line:
+Intel Macs can install the latest OpenJDK using Homebrew:
 
 ```shell
-brew install --cask AdoptOpenJDK/openjdk/adoptopenjdk14
+brew install --cask adoptopenjdk
 ```
 
 If you are using an M1 Mac, you can install a specific version of the JDK using SDKMAN. First, install SDKMAN by running the following command:
@@ -112,11 +112,12 @@ Before running the above command, it's recommended you review the script content
 Then, install the JDK with:
 
 ```shell
-sdk install java 21.0.2-tem
-sdk use java 21.0.2-tem
+sdk install java 17.0.10-tem
+sdk use java 17.0.10-tem
+sdk default java 17.0.10-tem
 ```
 
-Please note that the version number `21.0.2-tem` is the latest version at the time of writing. You can find the latest version on the [AdoptOpenJDK website](https://adoptopenjdk.net/). Other versions of the JDK can be installed using the same method. See the `.java-version` file in the project root for the version of the JDK required for this project.
+Please note JDK `21` is the latest version at the time of writing. See the `.java-version` file in the project root for the version of the JDK required for this project. You will also find versions in `server/Dockerfile`.
 
 # Install jEnv
 
@@ -233,6 +234,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 ```
+
 ## Install Correct Node Version
 
 Install and use the correct node version for the project.

--- a/docs/getting-started/setup/windowsos.md
+++ b/docs/getting-started/setup/windowsos.md
@@ -8,10 +8,10 @@ grand_parent: Getting Started
 
 - [Install Chocolatey](#install-chocolatey)
 - [Install Git](#install-git)
-    - [Install Hub](#install-hub)
-    - [SSH Keys](#ssh-keys)
+  - [Install Hub](#install-hub)
+  - [SSH Keys](#ssh-keys)
 - [Install jEnv](#install-jenv)
-    - [Plugins](#plugins)
+  - [Plugins](#plugins)
 - [Install OpenJDK](#install-openjdk)
 - [Install NVM](#install-nvm)
 - [Install Yarn](#install-yarn)
@@ -31,7 +31,7 @@ project using WindowsOS.
 Note: If you prefer to use Windows installers for installing required software, then you can skip installing Chocolatey.
 
 Chocolatey is a package manager for Windows that automates the process of installing, updating, and configuring software.
-It is similar to package managers like apt-get on Ubuntu or Homebrew on macOS. 
+It is similar to package managers like apt-get on Ubuntu or Homebrew on macOS.
 For complete information on using Chocolatey, visit https://docs.chocolatey.org/en-us/getting-started
 
 Installation guide: https://chocolatey.org/install
@@ -75,13 +75,13 @@ If you haven't already, you will want to [configure git to use ssh for connectin
 
 # Install OpenJDK
 
-Install OpenJDK 14 with Chocolatey:
+Install OpenJDK 17 with Chocolatey:
 
 ```shell
-choco install openjdk --version=14.0.0
+choco install openjdk --version=17.0.0
 ```
 
-or download the laster installer: https://www.oracle.com/java/technologies/javase/jdk14-archive-downloads.html
+or download the laster installer: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 
 # Install NVM
 
@@ -116,12 +116,8 @@ Install Podman Desktop: https://podman-desktop.io/
 The setup process will ask if you want to install Podman and Podman Compose for the cli.
 Be sure to do this.
 
-
 # Install Jekyll
 
 This project uses Jekyll for working with documentation:
 
 https://jekyllrb.com/docs/installation/windows/
-
-
-


### PR DESCRIPTION
Pass at the docs to capture recent updates to JDK from 14 to 17.