### PR TITLE
[2339] Reducing test run times by preventing migration after each test

### DIFF
--- a/server/src/test/java/com/objectcomputing/checkins/services/TestContainersSuite.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/TestContainersSuite.java
@@ -8,7 +8,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import jakarta.inject.Inject;
 import org.flywaydb.core.Flyway;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -51,16 +50,51 @@ public abstract class TestContainersSuite implements RepositoryFixture, TestProp
         this.shouldResetDBAfterEachTest = shouldResetDBAfterEachTest;
     }
 
-    @BeforeEach
-    public void setup() {
-        flyway.migrate();
+    private void deleteAllEntities() {
+        // Note order can matter here.
+        getEntityTagRepository().deleteAll();
+        getTagRepository().deleteAll();
+        getPulseResponseRepository().deleteAll();
+        getCheckInNoteRepository().deleteAll();
+        getPrivateNoteRepository().deleteAll();
+        getCheckInDocumentRepository().deleteAll();
+        getActionItemRepository().deleteAll();
+        getAgendaItemRepository().deleteAll();
+        getQuestionRepository().deleteAll();
+        getMemberHistoryRepository().deleteAll();
+        getMemberSkillRepository().deleteAll();
+        getSkillCategorySkillRepository().deleteAll();
+        getSkillCategoryRepository().deleteAll();
+        getSkillRepository().deleteAll();
+        getQuestionCategoryRepository().deleteAll();
+        getSurveyRepository().deleteAll();
+        getEmployeeHoursRepository().deleteAll();
+        getFeedbackAnswerRepository().deleteAll();
+        getTemplateQuestionRepository().deleteAll();
+        getSettingsRepository().deleteAll();
+        getOpportunitiesRepository().deleteAll();
+        getDemographicsRepository().deleteAll();
+        getRolePermissionRepository().deleteAll();
+        getEmailRepository().deleteAll();
+        getGuildMemberRepository().deleteAll();
+        getGuildMemberHistoryRepository().deleteAll();
+        getGuildRepository().deleteAll();
+        getTeamMemberRepository().deleteAll();
+        getTeamRepository().deleteAll();
+        getMemberRoleRepository().deleteAll();
+        getRoleRepository().deleteAll();
+        getCheckInRepository().deleteAll();
+        getFeedbackRequestRepository().deleteAll();
+        getFeedbackTemplateRepository().deleteAll();
+        getMemberProfileRepository().deleteAll();
+        getReviewPeriodRepository().deleteAll();
+        getReviewAssignmentRepository().deleteAll();
     }
 
-    @AfterEach
-    public void teardown() {
-        if(shouldResetDBAfterEachTest) {
-            flyway.clean();
-        }
+    @BeforeEach
+    public void setup() {
+        deleteAllEntities();
+        flyway.migrate();
     }
 
     @Override

--- a/server/src/test/java/com/objectcomputing/checkins/services/TestContainersSuite.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/TestContainersSuite.java
@@ -40,15 +40,7 @@ public abstract class TestContainersSuite implements RepositoryFixture, TestProp
     @Value("${aes.key}")
     protected String key;
 
-    private final boolean shouldResetDBAfterEachTest;
-
-    public TestContainersSuite() {
-        this(true);
-    }
-
-    public TestContainersSuite(boolean shouldResetDBAfterEachTest) {
-        this.shouldResetDBAfterEachTest = shouldResetDBAfterEachTest;
-    }
+    public TestContainersSuite() {}
 
     private void deleteAllEntities() {
         // Note order can matter here.


### PR DESCRIPTION
This commit will ensure we only run flyway migration once, and after each test we clear all entities from the db instead of cleaning it completely. As of now this takes our server test runtime from about 12 mins to a little under 2 mins.