### PR TITLE
(Backend) - Update Google Dependencies to Address Vulnerabilities and General Tech Debt

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    rewrite('org.openrewrite.recipe:rewrite-micronaut:2.1.1')
+    rewrite('org.openrewrite.recipe:rewrite-micronaut:2.5.0')
 
     runtimeOnly("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.yaml:snakeyaml")

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testRuntimeOnly "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
 
     testImplementation('io.projectreactor:reactor-test')
-    testImplementation 'io.github.bonigarcia:webdrivermanager:4.1.0'
+    testImplementation 'io.github.bonigarcia:webdrivermanager:5.8.0'
     testImplementation "org.seleniumhq.selenium:selenium-java:$seleniumVersion"
     testImplementation "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
     testImplementation "org.seleniumhq.selenium:selenium-api:$seleniumVersion"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("io.micronaut.application") version "4.3.6"
+    id("io.micronaut.application") version "4.3.8"
     id "idea"
     id "jacoco"
     id("org.openrewrite.rewrite") version "latest.release"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -76,13 +76,13 @@ dependencies {
     implementation "jakarta.annotation:jakarta.annotation-api"
     implementation "jakarta.persistence:jakarta.persistence-api"
 
-    implementation "com.google.api-client:google-api-client:1.30.9"
-    implementation "com.google.oauth-client:google-oauth-client-jetty:1.28.0"
-    implementation "com.google.apis:google-api-services-drive:v3-rev20200326-1.30.9"
-    implementation "com.google.apis:google-api-services-gmail:v1-rev20200203-1.30.9"
-    implementation "com.google.apis:google-api-services-admin-directory:directory_v1-rev118-1.25.0"
+    implementation "com.google.api-client:google-api-client:2.5.1"
+    implementation "com.google.oauth-client:google-oauth-client-jetty:1.36.0"
+    implementation "com.google.apis:google-api-services-drive:v3-rev20240509-2.0.0"
+    implementation "com.google.apis:google-api-services-gmail:v1-rev20240422-2.0.0"
+    implementation "com.google.apis:google-api-services-admin-directory:directory_v1-rev20240509-2.0.0"
 
-    implementation 'com.google.cloud.sql:postgres-socket-factory:1.0.15'
+    implementation 'com.google.cloud.sql:postgres-socket-factory:1.18.1'
 
     implementation("io.micronaut.reactor:micronaut-reactor")
     implementation("io.micrometer:context-propagation")

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,2 +1,2 @@
-micronautVersion=4.4.1
 seleniumVersion=3.141.59
+micronautVersion=4.4.2

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,2 +1,2 @@
-seleniumVersion=3.141.59
 micronautVersion=4.4.2
+seleniumVersion=4.21.0

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/GoogleDriveAccessor.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/GoogleDriveAccessor.java
@@ -4,7 +4,7 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.auth.http.HttpCredentialsAdapter;
 import io.micronaut.context.annotation.Property;
@@ -16,7 +16,7 @@ import java.security.GeneralSecurityException;
 @Singleton
 public class GoogleDriveAccessor {
 
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private final NetHttpTransport httpTransport;
     private final String applicationName;
     private final GoogleAuthenticator authenticator;

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImpl.java
@@ -2,8 +2,8 @@ package com.objectcomputing.checkins.services.memberprofile.memberphoto;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.services.admin.directory.Directory;
-import com.google.api.services.admin.directory.model.UserPhoto;
+import com.google.api.services.directory.Directory;
+import com.google.api.services.directory.model.UserPhoto;
 import com.objectcomputing.checkins.util.googleapiaccess.GoogleApiAccess;
 import io.micronaut.cache.annotation.CacheConfig;
 import io.micronaut.cache.annotation.Cacheable;

--- a/server/src/main/java/com/objectcomputing/checkins/util/googleapiaccess/GoogleAccessor.java
+++ b/server/src/main/java/com/objectcomputing/checkins/util/googleapiaccess/GoogleAccessor.java
@@ -4,11 +4,10 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.services.admin.directory.Directory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.directory.Directory;
 import com.google.api.services.drive.Drive;
 import com.google.auth.http.HttpCredentialsAdapter;
-import com.objectcomputing.checkins.security.GoogleServiceConfiguration;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
@@ -24,7 +23,7 @@ import java.util.List;
 @Singleton
 public class GoogleAccessor {
 
-    private final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     private final String applicationName;
     private final GoogleAuthenticator authenticator;

--- a/server/src/main/java/com/objectcomputing/checkins/util/googleapiaccess/GoogleApiAccess.java
+++ b/server/src/main/java/com/objectcomputing/checkins/util/googleapiaccess/GoogleApiAccess.java
@@ -1,6 +1,6 @@
 package com.objectcomputing.checkins.util.googleapiaccess;
 
-import com.google.api.services.admin.directory.Directory;
+import com.google.api.services.directory.Directory;
 import com.google.api.services.drive.Drive;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsControllerTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import jakarta.inject.Inject;
 import java.util.*;
 
-import org.mortbay.util.ajax.JSON;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.junit.jupiter.api.Assertions.*;
@@ -59,7 +58,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         FeedbackSuggestionDTO idealOne = createFeedbackSuggestion(supervisorReason, supervisor.getId());
         FeedbackSuggestionDTO idealTwo = createFeedbackSuggestion(teamLeadReason, requesteeTeamLead.getId());
 
-        assertNotNull(JSON.toString(response.getBody().get()));
+        assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
         assertEquals(response.getBody().get().size(), 2 );
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
@@ -87,7 +86,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         FeedbackSuggestionDTO idealOne = createFeedbackSuggestion(pdlReason, pdlProfile.getId());
         FeedbackSuggestionDTO idealTwo = createFeedbackSuggestion(teamLeadReason, requesteeTeamLead.getId());
 
-        assertNotNull(JSON.toString(response.getBody().get()));
+        assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
         assertEquals(response.getBody().get().size(), 2 );
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
@@ -117,7 +116,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         FeedbackSuggestionDTO idealOne = createFeedbackSuggestion(supervisorReason, supervisor.getId());
         FeedbackSuggestionDTO idealTwo = createFeedbackSuggestion(pdlReason, pdlProfile.getId());
 
-        assertNotNull(JSON.toString(response.getBody().get()));
+        assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
         assertEquals(response.getBody().get().size(), 2 );
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
@@ -149,7 +148,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         FeedbackSuggestionDTO idealTwo = createFeedbackSuggestion(pdlReason, pdlProfile.getId());
         FeedbackSuggestionDTO idealThree = createFeedbackSuggestion(teamLeadReason, requesteeTeamLead.getId());
 
-        assertNotNull(JSON.toString(response.getBody().get()));
+        assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
         assertEquals( 3, response.getBody().get().size() );
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
@@ -184,7 +183,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
         FeedbackSuggestionDTO idealTwo = createFeedbackSuggestion(pdlReason, pdlProfile.getId());
         FeedbackSuggestionDTO idealThree = createFeedbackSuggestion(teamLeadReason, requesteeTeamLead.getId());
 
-        assertNotNull(JSON.toString(response.getBody().get()));
+        assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
         assertEquals( 3, response.getBody().get().size() );
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImplTest.java
@@ -1,8 +1,8 @@
 package com.objectcomputing.checkins.services.memberprofile.memberphoto;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.admin.directory.Directory;
-import com.google.api.services.admin.directory.model.UserPhoto;
+import com.google.api.services.directory.Directory;
+import com.google.api.services.directory.model.UserPhoto;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.util.googleapiaccess.GoogleApiAccess;
 import io.micronaut.context.env.Environment;


### PR DESCRIPTION
The original plan was to perform a minor upgrade of the Google dependencies, however the latest `postgres-socket-factory` pulls in a transitive major update to v2 of the `google-api-client`

So I went for it and grabbed the latest major version of all Google dependencies.

Also updated:

- Patch Micronaut upgrade to 4.4.2
- Micronaut Gradle plugin patch update
- Selenium to latest
- Latest webdrivermanager
- Latest openrewrite library

Some Google classes have changed package, but I don't believe these are persisted (internal use only), so I think this is ok
