### PR TITLE
Make sure we use JUnit 5 assertions

### DIFF
--- a/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
@@ -43,7 +43,7 @@ public class MailJetSenderTest extends TestContainersSuite {
         List<String> firstEmailGroup = recipients.subList(0, MailJetSender.MAILJET_RECIPIENT_LIMIT);
         for (int i = 0; i < MailJetSender.MAILJET_RECIPIENT_LIMIT; i++) {
             Object email = firstBatch.getJSONObject(i).get("Email");
-            assertTrue(email instanceof String);
+            assertInstanceOf(String.class, email);
             assertTrue(firstEmailGroup.contains(email));
         }
 
@@ -53,7 +53,7 @@ public class MailJetSenderTest extends TestContainersSuite {
         List<String> secondEmailGroup = recipients.subList(MailJetSender.MAILJET_RECIPIENT_LIMIT, numRecipients);
         for (int i = 0; i < 10; i++) {
             Object email = secondBatch.getJSONObject(i).get("Email");
-            assertTrue(email instanceof String);
+            assertInstanceOf(String.class, email);
             assertTrue(secondEmailGroup.contains(email));
         }
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/action_item/ActionItemControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/action_item/ActionItemControllerTest.java
@@ -1,6 +1,5 @@
 package com.objectcomputing.checkins.services.action_item;
 
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.objectcomputing.checkins.services.TestContainersSuite;
 import com.objectcomputing.checkins.services.checkins.CheckIn;
@@ -10,7 +9,6 @@ import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
 import com.objectcomputing.checkins.services.fixture.RoleFixture;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.role.Role;
-
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -18,19 +16,23 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
-import static org.junit.Assert.assertNotNull;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.PDL_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 
 class ActionItemControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, CheckInFixture, ActionItemFixture {
 
@@ -42,6 +44,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
     void createRolesAndPermissions() {
         createAndAssignRoles();
     }
+
     @Test
     void testCreateAnActionItemByAdmin() {
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemControllerTest.java
@@ -15,22 +15,25 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
-
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
-import static org.junit.Assert.assertNotNull;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.PDL_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
-public class AgendaItemControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, AgendaItemFixture, RoleFixture {
+class AgendaItemControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, AgendaItemFixture, RoleFixture {
 
     @Inject
     @Client("/services/agenda-items")
@@ -40,6 +43,7 @@ public class AgendaItemControllerTest extends TestContainersSuite implements Mem
     void createRolesAndPermissions() {
         createAndAssignRoles();
     }
+
     @Test
     void testCreateAgendaItemByAdmin() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkin_notes/CheckinNoteControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkin_notes/CheckinNoteControllerTest.java
@@ -16,22 +16,24 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.PDL_ROLE;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
-public class CheckinNoteControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, CheckInNoteFixture, RoleFixture {
+class CheckinNoteControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, CheckInNoteFixture, RoleFixture {
 
     @Inject
     @Client("/services/checkin-notes")

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentControllerTest.java
@@ -3,7 +3,11 @@ package com.objectcomputing.checkins.services.checkindocument;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.objectcomputing.checkins.services.TestContainersSuite;
 import com.objectcomputing.checkins.services.checkins.CheckIn;
-import com.objectcomputing.checkins.services.fixture.*;
+import com.objectcomputing.checkins.services.fixture.CheckInDocumentFixture;
+import com.objectcomputing.checkins.services.fixture.CheckInFixture;
+import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
+import com.objectcomputing.checkins.services.fixture.RepositoryFixture;
+import com.objectcomputing.checkins.services.fixture.RoleFixture;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.role.Role;
 import io.micronaut.core.type.Argument;
@@ -14,20 +18,22 @@ import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
-import jakarta.inject.Inject;
-import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
-public class CheckinDocumentControllerTest extends TestContainersSuite implements RepositoryFixture, MemberProfileFixture,
+class CheckinDocumentControllerTest extends TestContainersSuite implements RepositoryFixture, MemberProfileFixture,
         RoleFixture, CheckInFixture, CheckInDocumentFixture {
 
     @Inject
@@ -38,6 +44,7 @@ public class CheckinDocumentControllerTest extends TestContainersSuite implement
     void createRolesAndPermissions() {
         createAndAssignRoles();
     }
+
     @Test
     void testCreateACheckinDocument() {
         MemberProfile memberProfile = createADefaultMemberProfile();

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkins/CheckInControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkins/CheckInControllerTest.java
@@ -24,12 +24,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CheckInControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, RoleFixture {
+class CheckInControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, RoleFixture {
 
     @Inject
     @Client("/services/check-ins")
@@ -39,8 +39,9 @@ public class CheckInControllerTest extends TestContainersSuite implements Member
     void createRolesAndPermissions() {
         createAndAssignRoles();
     }
+
     @Test
-    public void testCreateACheckInByAdmin() {
+    void testCreateACheckInByAdmin() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
         Role role = assignAdminRole(memberProfileOfUser);
@@ -64,7 +65,7 @@ public class CheckInControllerTest extends TestContainersSuite implements Member
     }
 
     @Test
-    public void testCreateACheckInByMember() {
+    void testCreateACheckInByMember() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
         Role role = assignMemberRole(memberProfileOfUser);
@@ -88,7 +89,7 @@ public class CheckInControllerTest extends TestContainersSuite implements Member
     }
 
     @Test
-    public void testCreateACheckInByPDL() {
+    void testCreateACheckInByPDL() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
         Role role = assignPdlRole(memberProfileOfPDL);
@@ -112,7 +113,7 @@ public class CheckInControllerTest extends TestContainersSuite implements Member
     }
 
     @Test
-    public void testCreateACheckInByUnrelatedUser() {
+    void testCreateACheckInByUnrelatedUser() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
         MemberProfile memberProfileOfMrNobody = createAnUnrelatedUser();

--- a/server/src/test/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursControllerTest.java
@@ -23,11 +23,11 @@ import java.util.*;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class EmployeeHoursControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, EmployeeHoursFixture {
+class EmployeeHoursControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, EmployeeHoursFixture {
 
     @Inject
     @Client("/services/employee/hours")
@@ -136,7 +136,7 @@ public class EmployeeHoursControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGetByIdNotFound() {
+    void testGetByIdNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/%s", UUID.randomUUID().toString())).basicAuth(ADMIN_ROLE,ADMIN_ROLE);

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/MemberSkillControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/MemberSkillControllerTest.java
@@ -18,15 +18,20 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class MemberSkillControllerTest extends TestContainersSuite implements MemberProfileFixture, SkillFixture, MemberSkillFixture {
+class MemberSkillControllerTest extends TestContainersSuite implements MemberProfileFixture, SkillFixture, MemberSkillFixture {
 
     @Inject
     @Client("/services/member-skills")
@@ -81,8 +86,8 @@ public class MemberSkillControllerTest extends TestContainersSuite implements Me
         assertEquals(memberSkill, response.body());
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(String.format("%s/%s", request.getPath(), memberSkill.getId()), response.getHeaders().get("location"));
-        assertEquals(memberSkill.getSkilllevel(), null);
-        assertEquals(memberSkill.getLastuseddate(), null);
+        assertNull(memberSkill.getSkilllevel());
+        assertNull(memberSkill.getLastuseddate());
     }
 
     @Test
@@ -316,7 +321,7 @@ public class MemberSkillControllerTest extends TestContainersSuite implements Me
     }
 
     @Test
-    public void testPUTUpdateMemberSkill() {
+    void testPUTUpdateMemberSkill() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
         Skill skill = createADefaultSkill();
@@ -335,7 +340,7 @@ public class MemberSkillControllerTest extends TestContainersSuite implements Me
     }
 
     @Test
-    public void testPUTUpdateNullMemberSkill() {
+    void testPUTUpdateNullMemberSkill() {
 
         final HttpRequest<String> request = HttpRequest.PUT("", "").basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
@@ -352,7 +357,7 @@ public class MemberSkillControllerTest extends TestContainersSuite implements Me
     }
 
     @Test
-    public void testPUTUpdateNonexistentMemberSkill() {
+    void testPUTUpdateNonexistentMemberSkill() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
         Skill skill = createADefaultSkill();

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/retentionreport/RetentionReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/retentionreport/RetentionReportControllerTest.java
@@ -1,11 +1,5 @@
 package com.objectcomputing.checkins.services.memberprofile.retentionreport;
 
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.objectcomputing.checkins.services.TestContainersSuite;
 import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
 import com.objectcomputing.checkins.services.fixture.RoleFixture;
@@ -17,15 +11,23 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class RetentionReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+
     @Inject
     @Client("/reports/retention")
     private HttpClient client;
@@ -40,7 +42,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
     }
 
     @Test
-    public void testPOSTEmptyRequestReturns400() {
+    void testPOSTEmptyRequestReturns400() {
         MemberProfile adminMember = createAnUnrelatedUser();
         assignAdminRole(adminMember);
 
@@ -56,7 +58,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
     }
 
     @Test
-    public void testPOSTNullStartDateReturns400() {
+    void testPOSTNullStartDateReturns400() {
         MemberProfile adminMember = createAnUnrelatedUser();
         assignAdminRole(adminMember);
 
@@ -75,7 +77,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
     }
 
     @Test
-    public void testPOSTNullEndDateReturns400() {
+    void testPOSTNullEndDateReturns400() {
         MemberProfile adminMember = createAnUnrelatedUser();
         assignAdminRole(adminMember);
 
@@ -94,7 +96,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
     }
 
     @Test
-    public void testPOSTEndDateBeforeStartDateReturns400() {
+    void testPOSTEndDateBeforeStartDateReturns400() {
         MemberProfile adminMember = createAnUnrelatedUser();
         assignAdminRole(adminMember);
 
@@ -128,7 +130,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
                 .exchange(request, RetentionReportResponseDTO.class);
 
         final RetentionReportResponseDTO responseDTO = response.body();
-        Assertions.assertNotNull(responseDTO);
+        assertNotNull(responseDTO);
 
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(String.format("%s", request.getPath()), response.getHeaders().get("Location"));
@@ -150,7 +152,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
                 .exchange(request, RetentionReportResponseDTO.class);
 
         final RetentionReportResponseDTO responseDTO = response.body();
-        Assertions.assertNotNull(responseDTO);
+        assertNotNull(responseDTO);
 
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(String.format("%s", request.getPath()), response.getHeaders().get("Location"));
@@ -172,7 +174,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
                 .exchange(request, RetentionReportResponseDTO.class);
 
         final RetentionReportResponseDTO responseDTO = response.body();
-        Assertions.assertNotNull(responseDTO);
+        assertNotNull(responseDTO);
 
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(String.format("%s", request.getPath()), response.getHeaders().get("Location"));
@@ -199,7 +201,7 @@ public class RetentionReportControllerTest extends TestContainersSuite implement
                 .exchange(request, RetentionReportResponseDTO.class);
 
         final RetentionReportResponseDTO responseDTO = response.body();
-        Assertions.assertNotNull(responseDTO);
+        assertNotNull(responseDTO);
 
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(String.format("%s", request.getPath()), response.getHeaders().get("Location"));

--- a/server/src/test/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesControllerTest.java
@@ -17,23 +17,27 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class OpportunitiesControllerTest extends TestContainersSuite implements MemberProfileFixture, OpportunitiesFixture, RoleFixture {
+class OpportunitiesControllerTest extends TestContainersSuite implements MemberProfileFixture, OpportunitiesFixture, RoleFixture {
 
     @Inject
     @Client("/services/opportunities")
     private HttpClient client;
 
     @Test
-    public void testCreateAOpportunities(){
+    void testCreateAOpportunities(){
         MemberProfile memberProfile = createADefaultMemberProfile();
 
         OpportunitiesCreateDTO opportunitiesResponseCreateDTO = new OpportunitiesCreateDTO();
@@ -54,7 +58,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testMemberCreateAnOpportunities(){
+    void testMemberCreateAnOpportunities(){
         MemberProfile memberProfile = createADefaultMemberProfile();
 
         OpportunitiesCreateDTO opportunitiesResponseCreateDTO = new OpportunitiesCreateDTO();
@@ -73,6 +77,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(String.format("%s/%s", request.getPath(), opportunitiesResponseResponse.getId()), response.getHeaders().get("location"));
     }
+
     @Test
     void testCreateAnInvalidOpportunities() {
         OpportunitiesCreateDTO opportunitiesResponseCreateDTO = new OpportunitiesCreateDTO();
@@ -109,7 +114,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGETFindByValueName() {
+    void testGETFindByValueName() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -123,7 +128,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGetFindBySubmittedBy() {
+    void testGetFindBySubmittedBy() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -138,7 +143,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGetFindByDescription() {
+    void testGetFindByDescription() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -154,7 +159,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
 
 
     @Test
-    public void testGetFindByPending() {
+    void testGetFindByPending() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -169,7 +174,7 @@ public class OpportunitiesControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGetFindAll() {
+    void testGetFindAll() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteControllerTest.java
@@ -14,23 +14,24 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
-import static org.junit.Assert.assertNotNull;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.PDL_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PrivateNoteControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, CheckInFixture, PrivateNoteFixture {
+class PrivateNoteControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, CheckInFixture, PrivateNoteFixture {
 
     @Inject
     @Client("/services/private-notes")
@@ -41,6 +42,7 @@ public class PrivateNoteControllerTest extends TestContainersSuite implements Me
     void createRolesAndPermissions() {
         createAndAssignRoles();
     }
+
     @Test
     void testReadPrivateNoteNotFound() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();

--- a/server/src/test/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryControllerTest.java
@@ -24,11 +24,11 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class QuestionCategoryControllerTest extends TestContainersSuite implements QuestionCategoryFixture, MemberProfileFixture, RoleFixture {
+class QuestionCategoryControllerTest extends TestContainersSuite implements QuestionCategoryFixture, MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/question-categories")
@@ -43,7 +43,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETNonExistingEndpointReturns404() {
+    void testGETNonExistingEndpointReturns404() {
 
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
             client.toBlocking().exchange(HttpRequest.GET(String.format("/?id=%s", UUID.randomUUID().toString()))
@@ -55,7 +55,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETFindByNameReturnsNotFound() {
+    void testGETFindByNameReturnsNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/?name=%s", encodeValue("silly"))).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -68,7 +68,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGetAllCategories() {
+    void testGetAllCategories() {
         QuestionCategory questionCategory = createADefaultQuestionCategory();
         final HttpRequest<Object> request = HttpRequest.
                 GET("/").basicAuth(MEMBER_ROLE,MEMBER_ROLE);
@@ -82,7 +82,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETGetByIdHappyPath() {
+    void testGETGetByIdHappyPath() {
 
         QuestionCategory questionCategory = createADefaultQuestionCategory();
 
@@ -97,7 +97,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETGetByIdNotFound() {
+    void testGETGetByIdNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/?id=%s", UUID.randomUUID().toString())).basicAuth(MEMBER_ROLE,MEMBER_ROLE);
@@ -111,7 +111,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPUTSuccessfulUpdate() {
+    void testPUTSuccessfulUpdate() {
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         createAndAssignAdminRole(memberProfileOfAdmin);
 
@@ -127,7 +127,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPUTUpdateNoPermission() {
+    void testPUTUpdateNoPermission() {
 
         QuestionCategory questionCategory = createADefaultQuestionCategory();
 
@@ -142,7 +142,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPUTNoIDSupplied() {
+    void testPUTNoIDSupplied() {
 
         QuestionCategoryCreateDTO requestBody = new QuestionCategoryCreateDTO();
         requestBody.setName("Fake Category");
@@ -159,7 +159,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPUTQuestionCategoryNotFound() {
+    void testPUTQuestionCategoryNotFound() {
 
         QuestionCategory requestBody = new QuestionCategory();
         requestBody.setId(UUID.randomUUID());
@@ -177,7 +177,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPOSTCreateAQuestionCategory() {
+    void testPOSTCreateAQuestionCategory() {
 
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         createAndAssignAdminRole(memberProfileOfAdmin);
@@ -195,7 +195,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPOSTCreateAQuestionCategoryNoPermission() {
+    void testPOSTCreateAQuestionCategoryNoPermission() {
 
         QuestionCategoryCreateDTO newQuestionCategory = new QuestionCategoryCreateDTO();
         newQuestionCategory.setName("Inquisitive");
@@ -211,7 +211,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPOSTCreateAQuestionCategoryAlreadyExists() {
+    void testPOSTCreateAQuestionCategoryAlreadyExists() {
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         createAndAssignAdminRole(memberProfileOfAdmin);
 
@@ -230,7 +230,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPOSTCreateAQuestionNullQuestion() {
+    void testPOSTCreateAQuestionNullQuestion() {
 
         QuestionCategoryCreateDTO newQuestionCategory = new QuestionCategoryCreateDTO();
 
@@ -245,7 +245,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testDELETEQuestionCategory() {
+    void testDELETEQuestionCategory() {
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         createAndAssignAdminRole(memberProfileOfAdmin);
 
@@ -261,7 +261,7 @@ public class QuestionCategoryControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testDELETEQuestionCategoryNoPermission() {
+    void testDELETEQuestionCategoryNoPermission() {
 
         QuestionCategory questionCategory = createADefaultQuestionCategory();
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/questions/QuestionControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/questions/QuestionControllerTest.java
@@ -13,20 +13,23 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.hateoas.JsonError;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class QuestionControllerTest extends TestContainersSuite implements QuestionFixture, QuestionCategoryFixture {
+class QuestionControllerTest extends TestContainersSuite implements QuestionFixture, QuestionCategoryFixture {
 
     @Inject
     @Client("/services/questions")
@@ -41,7 +44,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETNonExistingEndpointReturns404() {
+    void testGETNonExistingEndpointReturns404() {
 
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
             client.toBlocking().exchange(HttpRequest.GET((String.format("/%s", UUID.randomUUID().toString())))
@@ -51,7 +54,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETreadAllQuestions() {
+    void testGETreadAllQuestions() {
 
         Question question = createADefaultQuestion();
         final HttpRequest<Object> request = HttpRequest.
@@ -66,7 +69,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETFindQuestionsSimilar() {
+    void testGETFindQuestionsSimilar() {
 
         Question question = createADefaultQuestion();
         String partOfQuestion = question.getText().substring(0,3);
@@ -82,7 +85,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETGetByIdHappyPath() {
+    void testGETGetByIdHappyPath() {
 
         QuestionCategory questionCategory = createADefaultQuestionCategory();
         Question question = createADefaultQuestionWithCategory(questionCategory.getId());
@@ -99,7 +102,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETGetByIdNotFound() {
+    void testGETGetByIdNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/%s", UUID.randomUUID().toString())).basicAuth(MEMBER_ROLE,MEMBER_ROLE);
@@ -113,7 +116,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testPUTSuccessfulUpdate() {
+    void testPUTSuccessfulUpdate() {
 
         Question question = createADefaultQuestion();
 
@@ -127,7 +130,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testPUTNoIDSupplied() {
+    void testPUTNoIDSupplied() {
 
         QuestionCreateDTO requestBody = new QuestionCreateDTO();
         requestBody.setText("Fake Question");
@@ -144,7 +147,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testPUTQuestionNotFound() {
+    void testPUTQuestionNotFound() {
 
         QuestionUpdateDTO requestBody = new QuestionUpdateDTO();
         requestBody.setId(UUID.randomUUID());
@@ -162,7 +165,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testPOSTCreateAQuestion() {
+    void testPOSTCreateAQuestion() {
 
         Question question = createADefaultQuestion();
         QuestionCreateDTO newQuestion = new QuestionCreateDTO();
@@ -178,7 +181,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testPOSTCreateAQuestionAlreadyExists() {
+    void testPOSTCreateAQuestionAlreadyExists() {
 
         Question question = createADefaultQuestion();
         QuestionCreateDTO newQuestion = new QuestionCreateDTO();
@@ -195,7 +198,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testPOSTCreateAQuestionNullQuestion() {
+    void testPOSTCreateAQuestionNullQuestion() {
 
         QuestionCreateDTO newQuestion = new QuestionCreateDTO();
 
@@ -210,7 +213,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETFindQuestionWithCategory() {
+    void testGETFindQuestionWithCategory() {
 
         QuestionCategory questionCategory = createADefaultQuestionCategory();
         Question question = createADefaultQuestionWithCategory(questionCategory.getId());
@@ -228,7 +231,7 @@ public class QuestionControllerTest extends TestContainersSuite implements Quest
     }
 
     @Test
-    public void testGETFindQuestionWithCategoryNotFound() {
+    void testGETFindQuestionWithCategoryNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/?categoryId=%s", encodeValue(String.valueOf(UUID.randomUUID())))).basicAuth(MEMBER_ROLE,MEMBER_ROLE);

--- a/server/src/test/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillsControllerTest.java
@@ -28,11 +28,11 @@ import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CombineSkillsControllerTest extends TestContainersSuite
+class CombineSkillsControllerTest extends TestContainersSuite
         implements MemberProfileFixture, RoleFixture, SkillFixture, MemberSkillFixture {
 
     @Inject
@@ -55,7 +55,7 @@ public class CombineSkillsControllerTest extends TestContainersSuite
 //    }
 
     @Test
-    public void testPOSTCombine2SkillsIntoOne() {
+    void testPOSTCombine2SkillsIntoOne() {
         MemberProfile memberProfile1 = createADefaultMemberProfile();
         MemberProfile memberProfile2 = createAnUnrelatedUser();
 
@@ -98,7 +98,7 @@ public class CombineSkillsControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPOSTCombine2SkillsIntoOneNonAdmin() {
+    void testPOSTCombine2SkillsIntoOneNonAdmin() {
 
         MemberProfile memberProfile1 = createADefaultMemberProfile();
         MemberProfile memberProfile2 = createAnUnrelatedUser();
@@ -160,7 +160,7 @@ public class CombineSkillsControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPOSTCombineBlankSkillNameAdmin() {
+    void testPOSTCombineBlankSkillNameAdmin() {
 
         UUID[] newSkillsArray = new UUID[2];
         newSkillsArray[0] = UUID.randomUUID();
@@ -181,7 +181,7 @@ public class CombineSkillsControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPOSTCombineNonExistingSkillsAdmin() {
+    void testPOSTCombineNonExistingSkillsAdmin() {
 
         CombineSkillsDTO combineSkillsDTO =
              new CombineSkillsDTO("New Skill", "New Skill Desc", null);
@@ -199,7 +199,7 @@ public class CombineSkillsControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPOSTCombine2SkillsIntoOneCheckSkillsDeleted() {
+    void testPOSTCombine2SkillsIntoOneCheckSkillsDeleted() {
 
         MemberProfile memberProfile1 = createADefaultMemberProfile();
         MemberProfile memberProfile2 = createAnUnrelatedUser();
@@ -252,7 +252,7 @@ public class CombineSkillsControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPOSTCombine2SkillsIntoOneCheckMemberSkills() {
+    void testPOSTCombine2SkillsIntoOneCheckMemberSkills() {
 
         MemberProfile memberProfile1 = createADefaultMemberProfile();
         MemberProfile memberProfile2 = createAnUnrelatedUser();

--- a/server/src/test/java/com/objectcomputing/checkins/services/survey/SurveyControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/survey/SurveyControllerTest.java
@@ -17,22 +17,29 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SurveyControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, SurveyFixture {
+class SurveyControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, SurveyFixture {
 
     @Inject
     @Client("/services/surveys")
     private HttpClient client;
 
     @Test
-    public void testCreateASurvey(){
+    void testCreateASurvey(){
         MemberProfile user = createAnUnrelatedUser();
         createAndAssignAdminRole(user);
 
@@ -137,7 +144,7 @@ public class SurveyControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    public void testGETFindByValueName() {
+    void testGETFindByValueName() {
         MemberProfile user = createAnUnrelatedUser();
         createAndAssignAdminRole(user);
 
@@ -152,7 +159,7 @@ public class SurveyControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    public void testGetFindByCreatedBy() {
+    void testGetFindByCreatedBy() {
         MemberProfile user = createAnUnrelatedUser();
         createAndAssignAdminRole(user);
 
@@ -168,7 +175,7 @@ public class SurveyControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    public void testGetFindAll() {
+    void testGetFindAll() {
         MemberProfile user = createAnUnrelatedUser();
         createAndAssignAdminRole(user);
 
@@ -390,7 +397,7 @@ public class SurveyControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    public void testMemberCreateASurvey(){
+    void testMemberCreateASurvey(){
         MemberProfile memberProfile = createADefaultMemberProfile();
 
         SurveyCreateDTO surveyResponseCreateDTO = new SurveyCreateDTO();
@@ -411,7 +418,7 @@ public class SurveyControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    public void testMemberGETFindByValueName() {
+    void testMemberGETFindByValueName() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -428,7 +435,7 @@ public class SurveyControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    public void testMemberGetFindByCreatedBy() {
+    void testMemberGetFindByCreatedBy() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 


### PR DESCRIPTION
We had a mix of Junit4/5 assertions.
This commit switches to the JUnit 5 jupiter assertions. Also uses specific asserts for nulls and instance checks. And removes public from test classes/methods which were touched

Closes #2417 