### PR TITLE
Restrict review period status transitions

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -99,6 +99,7 @@ dependencies {
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.hamcrest:hamcrest")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("org.mockito:mockito-core")
 }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewStatusTransitionValidator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewStatusTransitionValidator.java
@@ -1,0 +1,7 @@
+package com.objectcomputing.checkins.services.reviews;
+
+@FunctionalInterface
+interface ReviewStatusTransitionValidator {
+
+    boolean isValid(ReviewStatus from, ReviewStatus to);
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewStatusTransitionValidatorImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewStatusTransitionValidatorImpl.java
@@ -1,0 +1,17 @@
+package com.objectcomputing.checkins.services.reviews;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+class ReviewStatusTransitionValidatorImpl implements ReviewStatusTransitionValidator {
+
+    @Override
+    public boolean isValid(ReviewStatus from, ReviewStatus to) {
+        return from == to || switch (from) {
+            case PLANNING -> to == ReviewStatus.AWAITING_APPROVAL;
+            case AWAITING_APPROVAL, CLOSED -> to == ReviewStatus.OPEN;
+            case OPEN -> to == ReviewStatus.CLOSED;
+            case UNKNOWN -> to == ReviewStatus.PLANNING;
+        };
+    }
+}

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/ReviewPeriodFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/ReviewPeriodFixture.java
@@ -14,6 +14,12 @@ public interface ReviewPeriodFixture extends RepositoryFixture {
                 LocalDateTime.now().plusDays(2).truncatedTo(ChronoUnit.MILLIS)));
     }
 
+    default ReviewPeriod createADefaultReviewPeriod(ReviewStatus reviewStatus) {
+        return getReviewPeriodRepository().save(new ReviewPeriod("Period of Time", reviewStatus, null, null,
+                LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS), LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.MILLIS),
+                LocalDateTime.now().plusDays(2).truncatedTo(ChronoUnit.MILLIS)));
+    }
+
     default ReviewPeriod createASecondaryReviewPeriod() {
         return getReviewPeriodRepository().save(new ReviewPeriod("Period of Play", ReviewStatus.OPEN, null, null,
                 LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS), LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.MILLIS),

--- a/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodControllerTest.java
@@ -372,10 +372,15 @@ class ReviewPeriodControllerTest extends TestContainersSuite implements ReviewPe
 
     private static Stream<Arguments> validStatusTransitions() {
         return Stream.of(
+                Arguments.of(ReviewStatus.PLANNING, ReviewStatus.PLANNING),
                 Arguments.of(ReviewStatus.PLANNING, ReviewStatus.AWAITING_APPROVAL),
+                Arguments.of(ReviewStatus.AWAITING_APPROVAL, ReviewStatus.AWAITING_APPROVAL),
                 Arguments.of(ReviewStatus.AWAITING_APPROVAL, ReviewStatus.OPEN),
+                Arguments.of(ReviewStatus.OPEN, ReviewStatus.OPEN),
                 Arguments.of(ReviewStatus.OPEN, ReviewStatus.CLOSED),
+                Arguments.of(ReviewStatus.CLOSED, ReviewStatus.CLOSED),
                 Arguments.of(ReviewStatus.CLOSED, ReviewStatus.OPEN),
+                Arguments.of(ReviewStatus.UNKNOWN, ReviewStatus.UNKNOWN),
                 Arguments.of(ReviewStatus.UNKNOWN, ReviewStatus.PLANNING)
         );
     }
@@ -399,12 +404,11 @@ class ReviewPeriodControllerTest extends TestContainersSuite implements ReviewPe
     }
 
     private static Stream<Arguments> invalidStatusTransitions() {
-        // The invalid status transitions are all the possible transitions that are not in the valid status transitions.
         var validTransitions = validStatusTransitions().toList();
         var allPermutations = new ArrayList<Arguments>();
         for (ReviewStatus from : ReviewStatus.values()) {
             for (ReviewStatus to : ReviewStatus.values()) {
-                if (from != to && validTransitions.stream().noneMatch(a -> a.get()[0] == from && a.get()[1] == to)) {
+                if (validTransitions.stream().noneMatch(a -> a.get()[0] == from && a.get()[1] == to)) {
                     allPermutations.add(Arguments.of(from, to));
                 }
             }

--- a/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodControllerTest.java
@@ -17,14 +17,19 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
@@ -363,6 +368,68 @@ class ReviewPeriodControllerTest extends TestContainersSuite implements ReviewPe
 
         assertEquals(reviewPeriod, response.body());
         assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    private static Stream<Arguments> validStatusTransitions() {
+        return Stream.of(
+                Arguments.of(ReviewStatus.PLANNING, ReviewStatus.AWAITING_APPROVAL),
+                Arguments.of(ReviewStatus.AWAITING_APPROVAL, ReviewStatus.OPEN),
+                Arguments.of(ReviewStatus.OPEN, ReviewStatus.CLOSED),
+                Arguments.of(ReviewStatus.CLOSED, ReviewStatus.OPEN),
+                Arguments.of(ReviewStatus.UNKNOWN, ReviewStatus.PLANNING)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validStatusTransitions")
+    void testUpdateReviewPeriodAsAdminWithValidStatusTransitions(ReviewStatus oldStatus, ReviewStatus newStatus) {
+        MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
+        assignAdminRole(memberProfileOfAdmin);
+
+        ReviewPeriod reviewPeriod = createADefaultReviewPeriod(oldStatus);
+        reviewPeriod.setReviewStatus(newStatus);
+
+        final HttpRequest<ReviewPeriod> request = HttpRequest.
+                PUT("/", reviewPeriod).basicAuth(memberProfileOfAdmin.getWorkEmail(), ADMIN_ROLE);
+
+        final HttpResponse<ReviewPeriod> response = client.toBlocking().exchange(request, ReviewPeriod.class);
+
+        assertEquals(reviewPeriod, response.body());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    private static Stream<Arguments> invalidStatusTransitions() {
+        // The invalid status transitions are all the possible transitions that are not in the valid status transitions.
+        var validTransitions = validStatusTransitions().toList();
+        var allPermutations = new ArrayList<Arguments>();
+        for (ReviewStatus from : ReviewStatus.values()) {
+            for (ReviewStatus to : ReviewStatus.values()) {
+                if (from != to && validTransitions.stream().noneMatch(a -> a.get()[0] == from && a.get()[1] == to)) {
+                    allPermutations.add(Arguments.of(from, to));
+                }
+            }
+        }
+        return allPermutations.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidStatusTransitions")
+    void testUpdateReviewPeriodAsAdminWithInvalidStatusTransitions(ReviewStatus oldStatus, ReviewStatus newStatus) {
+        MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
+        assignAdminRole(memberProfileOfAdmin);
+
+        ReviewPeriod reviewPeriod = createADefaultReviewPeriod(oldStatus);
+        reviewPeriod.setReviewStatus(newStatus);
+
+        final HttpRequest<ReviewPeriod> request = HttpRequest.
+                PUT("/", reviewPeriod).basicAuth(memberProfileOfAdmin.getWorkEmail(), ADMIN_ROLE);
+
+        HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(request, ReviewPeriod.class));
+
+        assertNotNull(responseException.getResponse());
+        assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
+        assertEquals("Invalid status transition from %s to %s".formatted(oldStatus, newStatus), responseException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Prior to updating a ReviewPeriod, we now validate that the ReviewStatus follows the following rules:

- State can remain the same
- `PLANNING` can progress to `AWAITING_APROVAL`
- `AWAITING_APPROVAL` can progress to `OPEN`
- `OPEN` can progress to `CLOSED`
- `CLOSED` can progress to `OPEN` (for when a case is re-opened)
- `UNKNOWN` can progress to `PLANNING` (`UNKNOWN` was used for period where isOpen was NULL prior to migration)

All other state changes will cause a `BAD_REQUEST` response with an appropriate message