### PR TITLE
fix: use import.meta.env and not process.env

### DIFF
--- a/web-ui/src/components/checkin/CheckinHistory.jsx
+++ b/web-ui/src/components/checkin/CheckinHistory.jsx
@@ -31,15 +31,11 @@ const CheckinsHistory = () => {
       const [year, month, day, hour, minute] = checkins[index].checkInDate;
       return new Date(year, month - 1, day, hour, minute, 0);
     }
-    // return new date unless you are running a Jest test
-    let currentDate = null;
-    try {
-      currentDate = process?.env?.VITEST_WORKER_ID
-        ? new Date(2020, 9, 21)
-        : new Date();
-    } catch (e) {
-      currentDate = new Date();
-    }
+
+    // Mock the date if under test so the snapshot stays consistent
+    const currentDate = import.meta.env.VITEST_WORKER_ID
+      ? new Date(2020, 9, 21)
+      : new Date();
 
     return currentDate;
   };

--- a/web-ui/src/pages/PulseReportPage.jsx
+++ b/web-ui/src/pages/PulseReportPage.jsx
@@ -89,7 +89,9 @@ const PulseReportPage = () => {
   const memberMap = selectProfileMap(state);
 
   // Mock the date if under test so the snapshot stays consistent
-  const today = process?.env?.VITEST_WORKER_ID ? new Date(2024, 5, 4) : new Date();
+  const today = import.meta.env.VITEST_WORKER_ID
+    ? new Date(2024, 5, 4)
+    : new Date();
   const initialDateFrom = new Date(today);
   initialDateFrom.setMonth(initialDateFrom.getMonth() - 3);
   const [dateFrom, setDateFrom] = useState(initialDateFrom);


### PR DESCRIPTION
Introduction of `process` keyword in https://github.com/objectcomputing/check-ins/pull/2479 caused the web-ui to stop rendering the pulse report page. This allows the page to render as expected when served on port 8080 for local development. Hoping this does not impact the test outcomes.