### PR TITLE
#2224 - limit create review period

### DIFF
--- a/web-ui/src/components/reviews/periods/ReviewPeriods.jsx
+++ b/web-ui/src/components/reviews/periods/ReviewPeriods.jsx
@@ -126,7 +126,6 @@ const ReviewPeriods = ({ onPeriodSelected, mode }) => {
   const csrf = selectCsrfToken(state);
   const periods = selectReviewPeriods(state);
   const userProfile = selectUserProfile(state);
-  const isAdmin = userProfile?.role?.includes('ADMIN');
 
   useQueryParameters([
     {


### PR DESCRIPTION
- guards Add Review Period to permission `CAN_CREATE_REVIEW_PERIOD`
- removes unused `isAdmin`