### PR TITLE
Delete certification before member_profile

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -23,12 +23,12 @@ delete from review_periods;
 delete from feedback_templates;
 delete from emails;
 delete from member_history;
+delete from earned_certification;
+delete from certification;
 delete from member_profile;
 delete from skillcategory_skills;
 delete from skills;
 delete from skillcategories;
-delete from earned_certification;
-delete from certification;
 
 -- Member Profiles
 INSERT INTO member_profile -- Gina Bremehr


### PR DESCRIPTION
Otherwise the script fails when it tries to delete member_profile as it's still used in earned_certification