### PR TITLE
Fix permissions for updating earned certifications

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/certification/EarnedCertificationRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/certification/EarnedCertificationRepository.java
@@ -4,9 +4,11 @@ import io.micronaut.data.annotation.Query;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @JdbcRepository(dialect = Dialect.POSTGRES)
@@ -17,7 +19,7 @@ public interface EarnedCertificationRepository extends CrudRepository<EarnedCert
     @Query("""
             SELECT earned.*
                 FROM earned_certification AS earned
-                    LEFT JOIN certification AS cert USING(certification_id)
+                    JOIN certification AS cert USING(certification_id)
                 WHERE cert.is_active = TRUE OR :includeDeactivated = TRUE
                 ORDER BY earned.earned_date DESC, earned.description""")
     List<EarnedCertification> findAllOrderByEarnedDateDesc(boolean includeDeactivated);
@@ -25,7 +27,7 @@ public interface EarnedCertificationRepository extends CrudRepository<EarnedCert
     @Query("""
             SELECT earned.*
                 FROM earned_certification AS earned
-                    LEFT JOIN certification AS cert USING(certification_id)
+                    JOIN certification AS cert USING(certification_id)
                 WHERE earned.certification_id = :certificationId
                   AND (cert.is_active = TRUE OR :includeDeactivated = TRUE)
                 ORDER BY earned.earned_date DESC, earned.description""")
@@ -34,7 +36,7 @@ public interface EarnedCertificationRepository extends CrudRepository<EarnedCert
     @Query("""
             SELECT earned.*
                 FROM earned_certification AS earned
-                    LEFT JOIN certification AS cert USING(certification_id)
+                    JOIN certification AS cert USING(certification_id)
                 WHERE earned.member_id = :memberId
                   AND (cert.is_active = TRUE OR :includeDeactivated = TRUE)
                 ORDER BY earned.earned_date DESC, earned.description""")
@@ -43,10 +45,12 @@ public interface EarnedCertificationRepository extends CrudRepository<EarnedCert
     @Query("""
             SELECT earned.*
                 FROM earned_certification AS earned
-                    LEFT JOIN certification AS cert USING(certification_id)
+                    JOIN certification AS cert USING(certification_id)
                 WHERE earned.certification_id = :certificationId
                   AND earned.member_id = :memberId
                   AND (cert.is_active = TRUE OR :includeDeactivated = TRUE)
                 ORDER BY earned.earned_date DESC, earned.description""")
     List<EarnedCertification> findByMemberIdAndCertificationIdOrderByEarnedDateDesc(@NotNull UUID memberId, @NotNull UUID certificationId, boolean includeDeactivated);
+
+    Optional<EarnedCertification> findById(@Nullable UUID id);
 }


### PR DESCRIPTION
Previously we checked the owner of the passed in object, but not the owner of the db object in the case of an update.

This meant that people could effectively change ownership of earned certifications from someone else to themselves.

This commit makes the change so we check both the object in flight, and the object at rest for updates.