### PR TITLE
Remove the Mono.xxx wrapping from the controllers

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/demographics/DemographicsController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/demographics/DemographicsController.java
@@ -3,7 +3,14 @@ package com.objectcomputing.checkins.services.demographics;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -11,12 +18,10 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Controller("/services/demographics")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -37,38 +42,38 @@ public class DemographicsController {
      * @return {@link DemographicsResponseDTO} Returned demographic
      */
     @Get("/{id}")
-    public Mono<HttpResponse<DemographicsResponseDTO>> getById(UUID id) {
-        return Mono.fromCallable(() -> demographicsServices.getById(id))
-                .map(demographic -> HttpResponse.ok(fromEntity(demographic))
-                        .headers(headers -> headers.location(location(demographic.getId()))));
+    public HttpResponse<DemographicsResponseDTO> getById(UUID id) {
+        Demographics demographic = demographicsServices.getById(id);
+        return demographic == null ? null : HttpResponse.ok(fromEntity(demographic))
+                .headers(headers -> headers.location(location(demographic.getId())));
     }
 
     /**
      * Find demographics by memberId, gender, degreeLevel, industryTenure, personOfColor, veteran, militaryTenure, militaryBranch or find all.
      *
-     * @param memberId {@link UUID} Find demographics with the given memberId
-     * @param gender {@link String} Find demographics with the given gender
-     * @param degreeLevel {@link String} Find demographics with given degree level
+     * @param memberId       {@link UUID} Find demographics with the given memberId
+     * @param gender         {@link String} Find demographics with the given gender
+     * @param degreeLevel    {@link String} Find demographics with given degree level
      * @param industryTenure {@link Integer} Find demographics with given industry tenure
-     * @param personOfColor {@link Boolean} Find demographics who are persons of color
-     * @param veteran {@link Boolean} Find demographics for are veterans
+     * @param personOfColor  {@link Boolean} Find demographics who are persons of color
+     * @param veteran        {@link Boolean} Find demographics for are veterans
      * @param militaryTenure {@link Integer} Find demographics with given military tenure
      * @param militaryBranch {@link String} Find demographics with given military branch
      * @return {@link List <DemographicsResponseDTO>} List of demographics that match the input parameters
      */
     @Get("/{?memberId,gender,degreeLevel,industryTenure,personOfColor,veteran,militaryTenure,militaryBranch}")
-    public Mono<HttpResponse<List<DemographicsResponseDTO>>> findByValue(@Nullable UUID memberId,
-                                                                            @Nullable String gender,
-                                                                            @Nullable String degreeLevel,
-                                                                            @Nullable Integer industryTenure,
-                                                                            @Nullable Boolean personOfColor,
-                                                                            @Nullable Boolean veteran,
-                                                                            @Nullable Integer militaryTenure,
-                                                                            @Nullable String militaryBranch) {
-        return Mono.fromCallable(() -> demographicsServices.findByValues(memberId, gender, degreeLevel, industryTenure,
-                        personOfColor, veteran, militaryTenure, militaryBranch))
-                .map(demographicsEntities -> demographicsEntities.stream().map(this::fromEntity).collect(Collectors.toList()))
-                .map(HttpResponse::ok);
+    public List<DemographicsResponseDTO> findByValue(@Nullable UUID memberId,
+                                                     @Nullable String gender,
+                                                     @Nullable String degreeLevel,
+                                                     @Nullable Integer industryTenure,
+                                                     @Nullable Boolean personOfColor,
+                                                     @Nullable Boolean veteran,
+                                                     @Nullable Integer militaryTenure,
+                                                     @Nullable String militaryBranch) {
+        return demographicsServices.findByValues(memberId, gender, degreeLevel, industryTenure, personOfColor, veteran, militaryTenure, militaryBranch)
+                .stream()
+                .map(this::fromEntity)
+                .toList();
     }
 
     /**
@@ -78,15 +83,12 @@ public class DemographicsController {
      * @return {@link DemographicsResponseDTO} The created demographics
      */
     @Post
-    public Mono<HttpResponse<DemographicsResponseDTO>> save(@Body @Valid DemographicsCreateDTO demographics,
-                                                            HttpRequest<?> request) {
+    public HttpResponse<DemographicsResponseDTO> save(@Body @Valid DemographicsCreateDTO demographics,
+                                                      HttpRequest<?> request) {
 
-        return Mono.fromCallable(() -> demographicsServices.saveDemographics(fromDTO(demographics)))
-                .map(savedDemographics -> {
-                        DemographicsResponseDTO savedDemographicsResponse = fromEntity(savedDemographics);
-                        return HttpResponse.created(savedDemographicsResponse)
-                                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), savedDemographicsResponse.getId()))));
-                });
+        Demographics savedDemographic = demographicsServices.saveDemographics(fromDTO(demographics));
+        return HttpResponse.created(fromEntity(savedDemographic))
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), savedDemographic.getId()))));
     }
 
     /**
@@ -96,27 +98,23 @@ public class DemographicsController {
      * @return {@link DemographicsResponseDTO} The updated demographics
      */
     @Put
-    public Mono<HttpResponse<DemographicsResponseDTO>> update(@Body @Valid DemographicsUpdateDTO demographics,
-                                                                HttpRequest<?> request) {
+    public HttpResponse<DemographicsResponseDTO> update(@Body @Valid DemographicsUpdateDTO demographics,
+                                                        HttpRequest<?> request) {
 
-        return Mono.fromCallable(() -> demographicsServices.updateDemographics(fromDTO(demographics)))
-                .map(savedDemographics -> {
-                    DemographicsResponseDTO updatedDemographics = fromEntity(savedDemographics);
-                    return HttpResponse.ok(updatedDemographics)
-                            .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedDemographics.getId()))));
-                });
+        Demographics savedDemographics = demographicsServices.updateDemographics(fromDTO(demographics));
+        return HttpResponse.ok(fromEntity(savedDemographics))
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), savedDemographics.getId()))));
     }
 
     /**
      * Delete demographics.
      *
      * @param id {@link UUID} Demographics unique id
-     * @return
      */
     @Delete("/{id}")
-    public Mono<HttpResponse<?>> delete(@NotNull UUID id) {
-        return Mono.fromRunnable(() -> demographicsServices.deleteDemographics(id))
-                .thenReturn(HttpResponse.ok());
+    @Status(value = HttpStatus.OK)
+    public void delete(@NotNull UUID id) {
+        demographicsServices.deleteDemographics(id);
     }
 
     protected URI location(UUID id) {
@@ -148,5 +146,4 @@ public class DemographicsController {
         dto.setVeteran(entity.getVeteran());
         return dto;
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/email/EmailController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/email/EmailController.java
@@ -1,13 +1,13 @@
 package com.objectcomputing.checkins.services.email;
 
-import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -23,9 +23,8 @@ public class EmailController {
     }
 
     @Post
-    public Mono<HttpResponse<List<Email>>> sendEmail(String subject, String content, boolean html, String... recipients) {
-        return Mono.fromCallable(() -> emailServices.sendAndSaveEmail(subject, content, html, recipients))
-                .map(HttpResponse::created);
+    @Status(HttpStatus.CREATED)
+    public List<Email> sendEmail(String subject, String content, boolean html, String... recipients) {
+        return emailServices.sendAndSaveEmail(subject, content, html, recipients);
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursController.java
@@ -2,7 +2,6 @@ package com.objectcomputing.checkins.services.employee_hours;
 
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
@@ -14,7 +13,6 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.util.Set;
 import java.util.UUID;
@@ -36,9 +34,8 @@ public class EmployeeHoursController {
      * @return
      */
     @Get("/{?employeeId}")
-    public Mono<HttpResponse<Set<EmployeeHours>>> findEmployeeHours(@Nullable String employeeId) {
-        return Mono.fromCallable(() -> employeeHoursServices.findByFields(employeeId))
-                .map(HttpResponse::ok);
+    public Set<EmployeeHours> findEmployeeHours(@Nullable String employeeId) {
+        return employeeHoursServices.findByFields(employeeId);
     }
 
 
@@ -47,15 +44,12 @@ public class EmployeeHoursController {
      * @return
      */
     @Get("/{id}")
-    public Mono<HttpResponse<EmployeeHours>> readEmployeeHours(@NotNull UUID id) {
-        return Mono.fromCallable(() -> {
-            EmployeeHours result = employeeHoursServices.read(id);
-            if (result == null) {
-                throw new NotFoundException("No employee hours for employee id");
-            }
-            return result;
-        }).map(HttpResponse::ok);
-
+    public EmployeeHours readEmployeeHours(@NotNull UUID id) {
+        EmployeeHours result = employeeHoursServices.read(id);
+        if (result == null) {
+            throw new NotFoundException("No employee hours for employee id");
+        }
+        return result;
     }
 
     /**
@@ -64,9 +58,7 @@ public class EmployeeHoursController {
      * @{@link HttpResponse<EmployeeHoursResponseDTO>}
      */
     @Post(uri="/upload" , consumes = MediaType.MULTIPART_FORM_DATA)
-    public Mono<HttpResponse<EmployeeHoursResponseDTO>> upload(CompletedFileUpload file){
-        return Mono.fromCallable(() -> employeeHoursServices.save(file))
-                .map(HttpResponse::ok);
+    public EmployeeHoursResponseDTO upload(CompletedFileUpload file){
+        return employeeHoursServices.save(file);
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsController.java
@@ -1,6 +1,5 @@
 package com.objectcomputing.checkins.services.feedback.suggestions;
 
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.scheduling.TaskExecutors;
@@ -8,7 +7,6 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
@@ -26,8 +24,7 @@ public class FeedbackSuggestionsController {
     }
 
     @Get("/{id}")
-    public Mono<HttpResponse<List<FeedbackSuggestionDTO>>> getSuggestionsByProfileId(UUID id) {
-        return Mono.fromCallable(() -> suggestionsService.getSuggestionsByProfileId(id))
-                .map(HttpResponse::ok);
+    public List<FeedbackSuggestionDTO> getSuggestionsByProfileId(UUID id) {
+        return suggestionsService.getSuggestionsByProfileId(id);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerController.java
@@ -1,14 +1,12 @@
 package com.objectcomputing.checkins.services.feedback_answer.question_and_answer;
 
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
@@ -25,14 +23,12 @@ public class QuestionAndAnswerController {
     }
 
     @Get("/{?requestId,questionId}")
-    public Mono<HttpResponse<QuestionAndAnswerServices.Tuple>> getQuestionAndAnswer(@Nullable UUID requestId, @Nullable UUID questionId) {
-        return Mono.fromCallable(() -> questionAndAnswerServices.getQuestionAndAnswer(requestId, questionId))
-                .map(HttpResponse::ok);
+    public QuestionAndAnswerServices.Tuple getQuestionAndAnswer(@Nullable UUID requestId, @Nullable UUID questionId) {
+        return questionAndAnswerServices.getQuestionAndAnswer(requestId, questionId);
     }
 
     @Get("/{requestId}")
-    public Mono<HttpResponse<List<QuestionAndAnswerServices.Tuple>>> getAllQuestionsAndAnswers(@Nullable UUID requestId) {
-        return Mono.fromCallable(() -> questionAndAnswerServices.getAllQuestionsAndAnswers(requestId))
-                .map(HttpResponse::ok);
+    public List<QuestionAndAnswerServices.Tuple> getAllQuestionsAndAnswers(@Nullable UUID requestId) {
+        return questionAndAnswerServices.getAllQuestionsAndAnswers(requestId);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionController.java
@@ -2,7 +2,14 @@ package com.objectcomputing.checkins.services.feedback_template.template_questio
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -11,12 +18,10 @@ import io.micronaut.validation.Validated;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Controller("/services/feedback/template_questions")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -38,10 +43,10 @@ public class TemplateQuestionController {
      * @return {@link TemplateQuestionResponseDTO}
      */
     @Post
-    public Mono<HttpResponse<TemplateQuestionResponseDTO>> save(@Body @Valid @NotNull TemplateQuestionCreateDTO requestBody) {
-        return Mono.fromCallable(() -> templateQuestionServices.save(fromDTO(requestBody)))
-                .map(savedFeedbackQuestion -> HttpResponse.created(fromEntity(savedFeedbackQuestion))
-                        .headers(headers -> headers.location(URI.create("/template_questions/" + savedFeedbackQuestion.getId()))));
+    public HttpResponse<TemplateQuestionResponseDTO> save(@Body @Valid @NotNull TemplateQuestionCreateDTO requestBody) {
+        TemplateQuestion savedFeedbackQuestion = templateQuestionServices.save(fromDTO(requestBody));
+        return HttpResponse.created(fromEntity(savedFeedbackQuestion))
+                .headers(headers -> headers.location(URI.create("/template_questions/" + savedFeedbackQuestion.getId())));
     }
 
     /**
@@ -51,10 +56,10 @@ public class TemplateQuestionController {
      * @return {@link TemplateQuestionResponseDTO}
      */
     @Put
-    public Mono<HttpResponse<TemplateQuestionResponseDTO>> update(@Body @Valid @NotNull TemplateQuestionUpdateDTO requestBody) {
-        return Mono.fromCallable(() -> templateQuestionServices.update(fromDTO(requestBody)))
-                .map(savedFeedbackTemplateQ -> HttpResponse.ok(fromEntity(savedFeedbackTemplateQ))
-                        .headers(headers -> headers.location(URI.create("/template_questions/" + savedFeedbackTemplateQ.getId()))));
+    public HttpResponse<TemplateQuestionResponseDTO> update(@Body @Valid @NotNull TemplateQuestionUpdateDTO requestBody) {
+        TemplateQuestion savedFeedbackTemplateQ = templateQuestionServices.update(fromDTO(requestBody));
+        return HttpResponse.ok(fromEntity(savedFeedbackTemplateQ))
+                .headers(headers -> headers.location(URI.create("/template_questions/" + savedFeedbackTemplateQ.getId())));
     }
 
     /**
@@ -64,9 +69,9 @@ public class TemplateQuestionController {
      * @return {Boolean}
      */
     @Delete("/{id}")
-    public Mono<HttpResponse<?>> deleteTemplateQuestion(@NotNull UUID id) {
-        return Mono.fromRunnable(() -> templateQuestionServices.delete(id))
-                .thenReturn(HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void deleteTemplateQuestion(@NotNull UUID id) {
+        templateQuestionServices.delete(id);
     }
 
     /**
@@ -76,10 +81,10 @@ public class TemplateQuestionController {
      * @return {@link TemplateQuestionResponseDTO}
      */
     @Get("/{id}")
-    public Mono<HttpResponse<TemplateQuestionResponseDTO>> getById(UUID id) {
-        return Mono.fromCallable(() -> templateQuestionServices.getById(id))
-                .map(feedbackQuestion -> HttpResponse.ok(fromEntity(feedbackQuestion))
-                        .headers(headers -> headers.location(URI.create("/template_questions/" + feedbackQuestion.getId()))));
+    public HttpResponse<TemplateQuestionResponseDTO> getById(UUID id) {
+        TemplateQuestion feedbackQuestion = templateQuestionServices.getById(id);
+        return feedbackQuestion == null ? HttpResponse.notFound() : HttpResponse.ok(fromEntity(feedbackQuestion))
+                .headers(headers -> headers.location(URI.create("/template_questions/" + feedbackQuestion.getId())));
     }
 
     /**
@@ -89,14 +94,15 @@ public class TemplateQuestionController {
      * @return list of {@link TemplateQuestionResponseDTO}
      */
     @Get("/{?templateId}")
-    public Mono<HttpResponse<List<TemplateQuestionResponseDTO>>> findByValues(@Nullable UUID templateId) {
-        return Mono.fromCallable(() -> templateQuestionServices.findByFields(templateId))
-                .map(entities -> entities.stream().map(this::fromEntity).collect(Collectors.toList()))
-                .map(HttpResponse::ok);
+    public List<TemplateQuestionResponseDTO> findByValues(@Nullable UUID templateId) {
+        return templateQuestionServices.findByFields(templateId)
+                .stream()
+                .map(this::fromEntity).toList();
     }
 
     /**
      * Converts a {@link TemplateQuestionCreateDTO} into a {@link TemplateQuestion}
+     *
      * @param dto {@link TemplateQuestionCreateDTO}
      * @return {@link TemplateQuestion}
      */
@@ -106,6 +112,7 @@ public class TemplateQuestionController {
 
     /**
      * Converts a {@link TemplateQuestionUpdateDTO} into a {@link TemplateQuestion}
+     *
      * @param dto {@link TemplateQuestionUpdateDTO}
      * @return {@link TemplateQuestion}
      */
@@ -115,6 +122,7 @@ public class TemplateQuestionController {
 
     /**
      * Converts a {@link TemplateQuestion} into a {@link TemplateQuestionResponseDTO}
+     *
      * @param templateQuestion {@link TemplateQuestion}
      * @return {@link TemplateQuestionResponseDTO}
      */

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileController.java
@@ -3,9 +3,14 @@ package com.objectcomputing.checkins.services.file;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Error;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.hateoas.Link;
 import io.micronaut.http.multipart.CompletedFileUpload;
@@ -16,7 +21,6 @@ import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.validation.Validated;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.io.File;
 import java.util.Set;
@@ -51,9 +55,8 @@ public class FileController {
      * @return {@link HttpResponse<Set<FileInfoDTO>>} Returns a set of FileInfoDTO associated with CheckInId or all files
      */
     @Get("{?id}")
-    public Mono<HttpResponse<Set<FileInfoDTO>>> findDocuments(@Nullable UUID id) {
-        return Mono.fromCallable(() -> fileServices.findFiles(id))
-                .map(HttpResponse::ok);
+    public Set<FileInfoDTO> findDocuments(@Nullable UUID id) {
+        return fileServices.findFiles(id);
     }
 
     /**
@@ -63,9 +66,8 @@ public class FileController {
      * @return {@link HttpResponse<java.io.File>} Returns file
      */
     @Get("/{uploadDocId}/download")
-    public Mono<HttpResponse<File>> downloadDocument(@NotNull String uploadDocId) {
-        return Mono.fromCallable(() -> fileServices.downloadFiles(uploadDocId))
-                .map(HttpResponse::ok);
+    public File downloadDocument(@NotNull String uploadDocId) {
+        return fileServices.downloadFiles(uploadDocId);
     }
 
     /**
@@ -75,9 +77,9 @@ public class FileController {
      * @return {@link HttpResponse<FileInfoDTO>} Returns metadata of document uploaded to Google Drive
      */
     @Post(uri = "/{checkInId}", consumes = MediaType.MULTIPART_FORM_DATA)
-    public Mono<HttpResponse<FileInfoDTO>> upload(@NotNull UUID checkInId, CompletedFileUpload file) {
-        return Mono.fromCallable(() -> fileServices.uploadFile(checkInId, file))
-                .map(HttpResponse::created);
+    @Status(HttpStatus.CREATED)
+    public FileInfoDTO upload(@NotNull UUID checkInId, CompletedFileUpload file) {
+        return fileServices.uploadFile(checkInId, file);
     }
 
     /**
@@ -87,8 +89,7 @@ public class FileController {
      * @return HttpResponse
      */
     @Delete("/{uploadDocId}")
-    public Mono<HttpResponse<?>> delete(@NotNull String uploadDocId) {
-        return Mono.fromCallable(() -> fileServices.deleteFile(uploadDocId))
-                .map(successFlag -> HttpResponse.ok());
+    public boolean delete(@NotNull String uploadDocId) {
+        return fileServices.deleteFile(uploadDocId);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildController.java
@@ -1,12 +1,17 @@
 package com.objectcomputing.checkins.services.guild;
 
-import com.objectcomputing.checkins.services.guild.member.GuildMemberResponseDTO;
-import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -14,10 +19,8 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -43,10 +46,10 @@ public class GuildController {
      * @return {@link HttpResponse<GuildResponseDTO>}
      */
     @Post
-    public Mono<HttpResponse<GuildResponseDTO>> createAGuild(@Body @Valid GuildCreateDTO guild, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> guildService.save(guild))
-                .map(createdGuild -> HttpResponse.created(createdGuild)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdGuild.getId())))));
+    public HttpResponse<GuildResponseDTO> createAGuild(@Body @Valid GuildCreateDTO guild, HttpRequest<?> request) {
+        GuildResponseDTO createdGuild = guildService.save(guild);
+        return HttpResponse.created(createdGuild)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdGuild.getId()))));
     }
 
     /**
@@ -55,11 +58,9 @@ public class GuildController {
      * @param id of guild
      * @return {@link GuildResponseDTO guild matching id}
      */
-
     @Get("/{id}")
-    public Mono<HttpResponse<GuildResponseDTO>> readGuild(@NotNull UUID id) {
-        return Mono.fromCallable(() -> guildService.read(id))
-                .map(HttpResponse::ok);
+    public GuildResponseDTO readGuild(@NotNull UUID id) {
+        return guildService.read(id);
     }
 
     /**
@@ -70,11 +71,9 @@ public class GuildController {
      * @return {@link List < GuildResponseDTO > list of guilds}, return all guilds when no parameters filled in else
      * return all guilds that match the filled in params
      */
-
     @Get("/{?name,memberid}")
-    public Mono<HttpResponse<Set<GuildResponseDTO>>> findGuilds(@Nullable String name, @Nullable UUID memberId) {
-        return Mono.fromCallable(() -> guildService.findByFields(name, memberId))
-                .map(HttpResponse::ok);
+    public Set<GuildResponseDTO> findGuilds(@Nullable String name, @Nullable UUID memberId) {
+        return guildService.findByFields(name, memberId);
     }
 
     /**
@@ -84,10 +83,10 @@ public class GuildController {
      * @return {@link HttpResponse<GuildResponseDTO>}
      */
     @Put
-    public Mono<HttpResponse<GuildResponseDTO>> update(@Body @Valid GuildUpdateDTO guild, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> guildService.update(guild))
-                .map(updated -> HttpResponse.ok(updated)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), guild.getId())))));
+    public HttpResponse<GuildResponseDTO> update(@Body @Valid GuildUpdateDTO guild, HttpRequest<?> request) {
+        GuildResponseDTO updated = guildService.update(guild);
+        return HttpResponse.ok(updated)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), guild.getId()))));
 
     }
 
@@ -95,12 +94,10 @@ public class GuildController {
      * Delete Guild
      *
      * @param id, id of {@link GuildUpdateDTO} to delete
-     * @return http ok response
      */
     @Delete("/{id}")
-    public Mono<HttpResponse<Object>> deleteGuild(@NotNull UUID id) {
-        return Mono.fromCallable(() -> guildService.delete(id))
-                .map(success -> HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void deleteGuild(@NotNull UUID id) {
+        guildService.delete(id);
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportController.java
@@ -4,7 +4,9 @@ import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -12,7 +14,6 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 
@@ -35,10 +36,10 @@ public class SkillsReportController {
      */
     @Post
     @RequiredPermission(Permission.CAN_VIEW_SKILLS_REPORT)
-    public Mono<HttpResponse<SkillsReportResponseDTO>> reportSkills(@Body @Valid @NotNull SkillsReportRequestDTO requestBody,
-                                                                    HttpRequest<?> request) {
-        return Mono.fromCallable(() -> skillsReportServices.report(requestBody))
-                .map(responseBody -> HttpResponse.created(responseBody)
-                        .headers(headers -> headers.location(URI.create(String.format("%s", request.getPath())))));
+    public HttpResponse<SkillsReportResponseDTO> reportSkills(@Body @Valid @NotNull SkillsReportRequestDTO requestBody,
+                                                              HttpRequest<?> request) {
+        SkillsReportResponseDTO responseBody = skillsReportServices.report(requestBody);
+        return HttpResponse.created(responseBody)
+                .headers(headers -> headers.location(URI.create(String.format("%s", request.getPath()))));
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileController.java
@@ -4,7 +4,15 @@ import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -14,15 +22,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Controller("/services/member-profiles")
-@ExecuteOn(TaskExecutors.IO)
+@ExecuteOn(TaskExecutors.BLOCKING)
 @Secured(SecurityRule.IS_AUTHENTICATED)
 @Tag(name = "member profiles")
 public class MemberProfileController {
@@ -41,10 +47,10 @@ public class MemberProfileController {
      * @return {@link MemberProfileResponseDTO} Returned member profile
      */
     @Get("/{id}")
-    public Mono<HttpResponse<MemberProfileResponseDTO>> getById(UUID id) {
-        return Mono.fromCallable(() -> memberProfileServices.getById(id))
-                .map(memberProfile -> HttpResponse.ok(fromEntity(memberProfile))
-                        .headers(headers -> headers.location(location(memberProfile.getId()))));
+    public HttpResponse<MemberProfileResponseDTO> getById(UUID id) {
+        MemberProfile memberProfile = memberProfileServices.getById(id);
+        return HttpResponse.ok(fromEntity(memberProfile))
+                .headers(headers -> headers.location(location(memberProfile.getId())));
     }
 
     /**
@@ -54,35 +60,36 @@ public class MemberProfileController {
      * @return {@link List<MemberProfileResponseDTO>} List of the profiles for the supervisors of the requested member
      */
     @Get("/{id}/supervisors")
-    public Mono<HttpResponse<List<MemberProfileResponseDTO>>> getSupervisorsForId(UUID id) {
-        return Mono.fromCallable(() -> memberProfileServices.getSupervisorsForId(id))
-                .map(entities -> entities.stream()
-                        .map(this::fromEntity).collect(Collectors.toList()))
-                .map(HttpResponse::ok);
+    public List<MemberProfileResponseDTO> getSupervisorsForId(UUID id) {
+        return memberProfileServices.getSupervisorsForId(id)
+                .stream()
+                .map(this::fromEntity)
+                .toList();
     }
 
     /**
      * Find member profile by first name, last name, title, leader's ID, email, supervisor's ID or find all.
      *
-     * @param firstName {@link String} Find members with the given first name
-     * @param lastName {@link String} Find member with the given last name
-     * @param title {@link String} Find member
-     * @param pdlId {@link UUID} ID of the leader
-     * @param workEmail {@link String} Requested work email
+     * @param firstName    {@link String} Find members with the given first name
+     * @param lastName     {@link String} Find member with the given last name
+     * @param title        {@link String} Find member
+     * @param pdlId        {@link UUID} ID of the leader
+     * @param workEmail    {@link String} Requested work email
      * @param supervisorId {@link UUID} ID of the supervisor
      * @return {@link List<MemberProfileResponseDTO>} List of members that match the input parameters
      */
     @Get("/{?firstName,lastName,title,pdlId,workEmail,supervisorId,terminated}")
-    public Mono<HttpResponse<List<MemberProfileResponseDTO>>> findByValue(@Nullable String firstName,
-                                                                            @Nullable String lastName,
-                                                                            @Nullable String title,
-                                                                            @Nullable UUID pdlId,
-                                                                            @Nullable String workEmail,
-                                                                            @Nullable UUID supervisorId,
-                                                                            @QueryValue(value = "terminated" , defaultValue = "false") Boolean terminated) {
-        return Mono.fromCallable(() -> memberProfileServices.findByValues(firstName, lastName, title, pdlId, workEmail, supervisorId, terminated))
-                .map(entities -> entities.stream().map(this::fromEntity).collect(Collectors.toList()))
-                .map(HttpResponse::ok);
+    public List<MemberProfileResponseDTO> findByValue(@Nullable String firstName,
+                                                      @Nullable String lastName,
+                                                      @Nullable String title,
+                                                      @Nullable UUID pdlId,
+                                                      @Nullable String workEmail,
+                                                      @Nullable UUID supervisorId,
+                                                      @QueryValue(value = "terminated", defaultValue = "false") Boolean terminated) {
+        return memberProfileServices.findByValues(firstName, lastName, title, pdlId, workEmail, supervisorId, terminated)
+                .stream()
+                .map(this::fromEntity)
+                .toList();
     }
 
     /**
@@ -93,11 +100,10 @@ public class MemberProfileController {
      */
     @Post
     @RequiredPermission(Permission.CAN_CREATE_ORGANIZATION_MEMBERS)
-    public Mono<HttpResponse<MemberProfileResponseDTO>> save(@Body @Valid MemberProfileCreateDTO memberProfile) {
-
-        return Mono.fromCallable(() -> memberProfileServices.saveProfile(fromDTO(memberProfile)))
-                .map(savedProfile -> HttpResponse.created(fromEntity(savedProfile))
-                        .headers(headers -> headers.location(location(savedProfile.getId()))));
+    public HttpResponse<MemberProfileResponseDTO> save(@Body @Valid MemberProfileCreateDTO memberProfile) {
+        MemberProfile savedProfile = memberProfileServices.saveProfile(fromDTO(memberProfile));
+        return HttpResponse.created(fromEntity(savedProfile))
+                .headers(headers -> headers.location(location(savedProfile.getId())));
     }
 
     /**
@@ -107,27 +113,22 @@ public class MemberProfileController {
      * @return {@link MemberProfileResponseDTO} The updated member profile
      */
     @Put
-    public Mono<HttpResponse<MemberProfileResponseDTO>> update(@Body @Valid MemberProfileUpdateDTO memberProfile) {
-
-        return Mono.fromCallable(() -> memberProfileServices.saveProfile(fromDTO(memberProfile)))
-                .map(savedProfile -> {
-                    MemberProfileResponseDTO updatedMemberProfile = fromEntity(savedProfile);
-                    return HttpResponse.ok(updatedMemberProfile)
-                            .headers(headers -> headers.location(location(updatedMemberProfile.getId())));
-                });
+    public HttpResponse<MemberProfileResponseDTO> update(@Body @Valid MemberProfileUpdateDTO memberProfile) {
+        MemberProfile savedProfile = memberProfileServices.saveProfile(fromDTO(memberProfile));
+        return HttpResponse.ok(fromEntity(savedProfile))
+                .headers(headers -> headers.location(location(savedProfile.getId())));
     }
 
     /**
      * Delete a member profile
      *
      * @param id {@link UUID} Member unique id
-     * @return
      */
     @Delete("/{id}")
     @RequiredPermission(Permission.CAN_DELETE_ORGANIZATION_MEMBERS)
-    public Mono<HttpResponse<?>> delete(@NotNull UUID id) {
-        return Mono.fromCallable(() -> memberProfileServices.deleteProfile(id))
-                .map(successFlag -> HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void delete(@NotNull UUID id) {
+        memberProfileServices.deleteProfile(id);
     }
 
     protected URI location(UUID id) {
@@ -160,7 +161,7 @@ public class MemberProfileController {
         return new MemberProfile(dto.getId(), dto.getFirstName(), dto.getMiddleName(), dto.getLastName(),
                 dto.getSuffix(), dto.getTitle(), dto.getPdlId(), dto.getLocation(), dto.getWorkEmail(),
                 dto.getEmployeeId(), dto.getStartDate(), dto.getBioText(), dto.getSupervisorid(),
-                dto.getTerminationDate(),dto.getBirthDay(), dto.getVoluntary(), dto.getExcluded(), dto.getLastSeen());
+                dto.getTerminationDate(), dto.getBirthDay(), dto.getVoluntary(), dto.getExcluded(), dto.getLastSeen());
     }
 
     private MemberProfile fromDTO(MemberProfileCreateDTO dto) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/anniversaryreport/AnniversaryReportController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/anniversaryreport/AnniversaryReportController.java
@@ -3,7 +3,6 @@ package com.objectcomputing.checkins.services.memberprofile.anniversaryreport;
 import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.scheduling.TaskExecutors;
@@ -11,10 +10,8 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Set;
 
 @Controller("/services/reports/anniversaries")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -31,14 +28,12 @@ public class AnniversaryReportController {
     /**
      * Find anniversary or anniversaries given a month, or if blank get all anniversaries.
      *
-     * @param month,    month of the anniversary
-     * @return {@link Set < AnniversaryReportResponseDTO > list of anniversaries}
+     * @param month month of the anniversary
+     * @return list of anniversaries
      */
-
     @Get("/{?month}")
     @RequiredPermission(Permission.CAN_VIEW_ANNIVERSARY_REPORT)
-    public Mono<HttpResponse<List<AnniversaryReportResponseDTO>>> findByValue(@Nullable String[] month) {
-        return Mono.fromCallable(() -> anniversaryServices.findByValue(month))
-                .map(HttpResponse::ok);
+    public List<AnniversaryReportResponseDTO> findByValue(@Nullable String[] month) {
+        return anniversaryServices.findByValue(month);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/birthday/BirthDayController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/birthday/BirthDayController.java
@@ -3,7 +3,6 @@ package com.objectcomputing.checkins.services.memberprofile.birthday;
 import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.scheduling.TaskExecutors;
@@ -11,17 +10,14 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Set;
 
 @Controller("/services/reports/birthdays")
 @ExecuteOn(TaskExecutors.BLOCKING)
 @Secured(SecurityRule.IS_AUTHENTICATED)
 @Tag(name = "Member Birthday")
 public class BirthDayController {
-
 
     private final BirthDayServices birthDayServices;
 
@@ -32,14 +28,12 @@ public class BirthDayController {
     /**
      * Find birthdays given a month, or if blank get all birthdays.
      *
-     * @param month,    month of the birthday
-     * @return {@link Set < BirthDayResponseDTO > list of birthdays}
+     * @param month month of the birthday
+     * @return list of birthdays
      */
-
     @Get("/{?month,dayOfMonth}")
     @RequiredPermission(Permission.CAN_VIEW_BIRTHDAY_REPORT)
-    public Mono<HttpResponse<List<BirthDayResponseDTO>>> findByValue(@Nullable String[] month, @Nullable Integer[] dayOfMonth) {
-        return Mono.fromCallable(() -> birthDayServices.findByValue(month, dayOfMonth))
-                .map(HttpResponse::ok);
+    public List<BirthDayResponseDTO> findByValue(@Nullable String[] month, @Nullable Integer[] dayOfMonth) {
+        return birthDayServices.findByValue(month, dayOfMonth);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoController.java
@@ -12,7 +12,6 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import static io.micronaut.http.HttpHeaders.CACHE_CONTROL;
 
@@ -25,6 +24,7 @@ public class MemberPhotoController {
 
     private final String expiry;
     private final MemberPhotoService memberPhotoService;
+
     public MemberPhotoController(@Property(name = "micronaut.caches.photo-cache.expire-after-write") String expiry,
                                  MemberPhotoService memberPhotoService) {
         this.expiry = expiry;
@@ -34,13 +34,13 @@ public class MemberPhotoController {
     /**
      * Get user photo data from Google Directory API
      *
-     * @param workEmail
-     * @return {@link HttpResponse<String>} StringURL of photo data
+     * @param workEmail {@link String} work email of the user
+     * @return StringURL of photo data
      */
     @Get("/{workEmail}")
-    public Mono<HttpResponse<byte[]>> userImage(@NotNull String workEmail) {
-        return Mono.fromCallable(() -> memberPhotoService.getImageByEmailAddress(workEmail))
-                .map(photoData -> HttpResponse.ok(photoData)
-                        .header(CACHE_CONTROL, String.format("public, max-age=%s", expiry)));
+    public HttpResponse<byte[]> userImage(@NotNull String workEmail) {
+        byte[] photoData = memberPhotoService.getImageByEmailAddress(workEmail);
+        return HttpResponse.ok(photoData)
+                .header(CACHE_CONTROL, String.format("public, max-age=%s", expiry));
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoService.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoService.java
@@ -1,7 +1,6 @@
 package com.objectcomputing.checkins.services.memberprofile.memberphoto;
 
-import java.io.IOException;
-
 public interface MemberPhotoService {
-    byte[] getImageByEmailAddress(String workEmail) throws IOException;
+
+    byte[] getImageByEmailAddress(String workEmail);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImpl.java
@@ -47,7 +47,7 @@ public class MemberPhotoServiceImpl implements MemberPhotoService {
 
     @Override
     @Cacheable
-    public byte[] getImageByEmailAddress(@NotNull String workEmail) throws IOException {
+    public byte[] getImageByEmailAddress(@NotNull String workEmail) {
 
         byte[] photoData;
 
@@ -62,6 +62,9 @@ public class MemberPhotoServiceImpl implements MemberPhotoService {
             } else {
                 LOG.error(String.format("An unexpected error occurred while retrieving photo from Google Directory API for: %s", workEmail), gjse);
             }
+            photoData = defaultPhoto;
+        } catch (IOException e) {
+            LOG.error(String.format("An unexpected error occurred while retrieving photo from Google Directory API for: %s", workEmail), e);
             photoData = defaultPhoto;
         }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesController.java
@@ -3,7 +3,14 @@ package com.objectcomputing.checkins.services.opportunities;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -11,18 +18,15 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 
 @Controller("/services/opportunities")
 @ExecuteOn(TaskExecutors.BLOCKING)
 @Secured(SecurityRule.IS_AUTHENTICATED)
-@Tag(name="opportunities")
+@Tag(name = "opportunities")
 public class OpportunitiesController {
 
     private final OpportunitiesService opportunitiesResponseServices;
@@ -34,16 +38,15 @@ public class OpportunitiesController {
     /**
      * Find opportunities by Name or Description or submittedBy.
      *
-     * @param name {@link String}
+     * @param name        {@link String}
      * @param description {@link String}
      * @param submittedBy {@link UUID} of member
      * @return list of opportunities
      */
     @Get("/{?name,description,submittedBy}")
-    public Mono<HttpResponse<List<Opportunities>>> findOpportunities(@Nullable String name,
-                                                                     @Nullable String description, @Nullable UUID submittedBy) {
-        return Mono.fromCallable(() -> opportunitiesResponseServices.findByFields(name, description, submittedBy))
-                .map(opportunities -> HttpResponse.ok(new ArrayList<>(opportunities)));
+    public List<Opportunities> findOpportunities(@Nullable String name,
+                                                 @Nullable String description, @Nullable UUID submittedBy) {
+        return opportunitiesResponseServices.findByFields(name, description, submittedBy);
     }
 
     /**
@@ -54,13 +57,13 @@ public class OpportunitiesController {
      */
 
     @Post
-    public Mono<HttpResponse<Opportunities>> createOpportunities(@Body @Valid OpportunitiesCreateDTO opportunitiesResponse,
-                                                     HttpRequest<?> request) {
-        return Mono.fromCallable(() -> opportunitiesResponseServices.save(new Opportunities(opportunitiesResponse.getName(),
-                        opportunitiesResponse.getDescription(), opportunitiesResponse.getUrl(),
-                        opportunitiesResponse.getExpiresOn(),opportunitiesResponse.getPending())))
-                .map(opportunities -> HttpResponse.created(opportunities)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), opportunities.getId())))));
+    public HttpResponse<Opportunities> createOpportunities(@Body @Valid OpportunitiesCreateDTO opportunitiesResponse,
+                                                           HttpRequest<?> request) {
+        Opportunities opportunities = opportunitiesResponseServices.save(new Opportunities(opportunitiesResponse.getName(),
+                opportunitiesResponse.getDescription(), opportunitiesResponse.getUrl(),
+                opportunitiesResponse.getExpiresOn(), opportunitiesResponse.getPending()));
+        return HttpResponse.created(opportunities)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), opportunities.getId()))));
     }
 
     /**
@@ -70,11 +73,11 @@ public class OpportunitiesController {
      * @return {@link HttpResponse<Opportunities>}
      */
     @Put
-    public Mono<HttpResponse<Opportunities>> update(@Body @Valid @NotNull Opportunities opportunitiesResponse,
-                                               HttpRequest<?> request) {
-        return Mono.fromCallable(() -> opportunitiesResponseServices.update(opportunitiesResponse))
-                .map(updatedOpportunities -> HttpResponse.ok(updatedOpportunities)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedOpportunities.getId())))));
+    public HttpResponse<Opportunities> update(@Body @Valid @NotNull Opportunities opportunitiesResponse,
+                                              HttpRequest<?> request) {
+        Opportunities updatedOpportunities = opportunitiesResponseServices.update(opportunitiesResponse);
+        return HttpResponse.ok(updatedOpportunities)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedOpportunities.getId()))));
 
     }
 
@@ -84,8 +87,8 @@ public class OpportunitiesController {
      * @param id, id of {@link Opportunities} to delete
      */
     @Delete("/{id}")
-    public Mono<HttpResponse<?>> deleteOpportunities(@NotNull UUID id) {
-        return Mono.fromRunnable(() -> opportunitiesResponseServices.delete(id))
-                .thenReturn(HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void deleteOpportunities(@NotNull UUID id) {
+        opportunitiesResponseServices.delete(id);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/permissions/PermissionController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/permissions/PermissionController.java
@@ -1,6 +1,5 @@
 package com.objectcomputing.checkins.services.permissions;
 
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.scheduling.TaskExecutors;
@@ -8,7 +7,6 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -29,11 +27,10 @@ public class PermissionController {
      *
      * @return {@link List < Permission > list order by Permissions}
      */
-    @RequiredPermission(Permission.CAN_VIEW_PERMISSIONS)
     @Get("/OrderByPermission")
-    public Mono<HttpResponse<List<Permission>>> listOrderByPermission() {
-        return Mono.fromCallable(permissionServices::listOrderByPermission)
-                .map(HttpResponse::ok);
+    @RequiredPermission(Permission.CAN_VIEW_PERMISSIONS)
+    public List<Permission> listOrderByPermission() {
+        return permissionServices.listOrderByPermission();
     }
 
     /**
@@ -41,10 +38,9 @@ public class PermissionController {
      *
      * @return {@link List < Permission > list of all Permissions}
      */
-    @RequiredPermission(Permission.CAN_VIEW_PERMISSIONS)
     @Get
-    public Mono<HttpResponse<List<Permission>>> getAllPermissions() {
-        return Mono.fromCallable(permissionServices::findAll)
-                .map(HttpResponse::ok);
+    @RequiredPermission(Permission.CAN_VIEW_PERMISSIONS)
+    public List<Permission> getAllPermissions() {
+        return permissionServices.findAll();
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseController.java
@@ -5,7 +5,11 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.Format;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -13,7 +17,6 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.time.LocalDate;
@@ -23,7 +26,7 @@ import java.util.UUID;
 @Controller("/services/pulse-responses")
 @ExecuteOn(TaskExecutors.BLOCKING)
 @Secured(SecurityRule.IS_AUTHENTICATED)
-@Tag(name="pulse-responses")
+@Tag(name = "pulse-responses")
 public class PulseResponseController {
 
     private final PulseResponseService pulseResponseServices;
@@ -34,65 +37,57 @@ public class PulseResponseController {
 
     /**
      * Find Pulse Response by Team Member or Date Range.
-     * 
+     *
      * @param teamMemberId
      * @param dateFrom
      * @param dateTo
      * @return
      */
     @Get("/{?teamMemberId,dateFrom,dateTo}")
-    public Mono<HttpResponse<Set<PulseResponse>>> findPulseResponses(@Nullable @Format("yyyy-MM-dd") LocalDate dateFrom,
-                                                                       @Nullable @Format("yyyy-MM-dd") LocalDate dateTo,
-                                                                       @Nullable UUID teamMemberId) {
-        return Mono.fromCallable(() -> pulseResponseServices.findByFields(teamMemberId, dateFrom, dateTo))
-                .map(HttpResponse::ok);
+    public Set<PulseResponse> findPulseResponses(@Nullable @Format("yyyy-MM-dd") LocalDate dateFrom,
+                                                 @Nullable @Format("yyyy-MM-dd") LocalDate dateTo,
+                                                 @Nullable UUID teamMemberId) {
+        return pulseResponseServices.findByFields(teamMemberId, dateFrom, dateTo);
     }
 
-     /**
+    /**
      * Create and save a new PulseResponse.
      *
      * @param pulseResponse, {@link PulseResponseCreateDTO}
      * @return {@link HttpResponse<PulseResponse>}
      */
-
     @Post
-    public Mono<HttpResponse<PulseResponse>> createPulseResponse(@Body @Valid PulseResponseCreateDTO pulseResponse,
-                                                                    HttpRequest<?> request) {
-        return Mono.fromCallable(() -> pulseResponseServices.save(new PulseResponse(pulseResponse.getInternalScore(), pulseResponse.getExternalScore(), pulseResponse.getSubmissionDate(), pulseResponse.getTeamMemberId(), pulseResponse.getInternalFeelings(), pulseResponse.getExternalFeelings())))
-                .map(pulseresponse -> HttpResponse.created(pulseresponse)
-                    .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), pulseresponse.getId()))))
-                );
+    public HttpResponse<PulseResponse> createPulseResponse(@Body @Valid PulseResponseCreateDTO pulseResponse,
+                                                           HttpRequest<?> request) {
+        PulseResponse pulseresponse = pulseResponseServices.save(new PulseResponse(pulseResponse.getInternalScore(), pulseResponse.getExternalScore(), pulseResponse.getSubmissionDate(), pulseResponse.getTeamMemberId(), pulseResponse.getInternalFeelings(), pulseResponse.getExternalFeelings()));
+        return HttpResponse.created(pulseresponse)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), pulseresponse.getId()))));
     }
 
-     /**
+    /**
      * Update a PulseResponse
      *
      * @param pulseResponse, {@link PulseResponse}
      * @return {@link HttpResponse<PulseResponse>}
      */
     @Put
-    public Mono<HttpResponse<PulseResponse>> update(@Body @Valid @NotNull PulseResponse pulseResponse,
-                                                      HttpRequest<?> request) {
-        return Mono.fromCallable(() -> pulseResponseServices.update(pulseResponse))
-            .map(updatedPulseResponse -> HttpResponse.ok(updatedPulseResponse)
-                    .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedPulseResponse.getId())))));
-
+    public HttpResponse<PulseResponse> update(@Body @Valid @NotNull PulseResponse pulseResponse,
+                                              HttpRequest<?> request) {
+        PulseResponse updatedPulseResponse = pulseResponseServices.update(pulseResponse);
+        return HttpResponse.ok(updatedPulseResponse)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedPulseResponse.getId()))));
     }
 
     /**
-     * 
      * @param id
      * @return
      */
     @Get("/{id}")
-    public Mono<HttpResponse<PulseResponse>> readRole(@NotNull UUID id) {
-        return Mono.fromCallable(() -> {
-            PulseResponse result = pulseResponseServices.read(id);
-            if (result == null) {
-                throw new NotFoundException("No role item for UUID");
-            }
-            return result;
-        }).map(HttpResponse::ok);
-
+    public PulseResponse readRole(@NotNull UUID id) {
+        PulseResponse result = pulseResponseServices.read(id);
+        if (result == null) {
+            throw new NotFoundException("No role item for UUID");
+        }
+        return result;
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryController.java
@@ -3,7 +3,14 @@ package com.objectcomputing.checkins.services.question_category;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -11,7 +18,6 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.Set;
@@ -37,28 +43,25 @@ public class QuestionCategoryController {
      */
 
     @Post
-    public Mono<HttpResponse<QuestionCategory>> createAQuestionCategory(@Body @Valid QuestionCategoryCreateDTO questionCategory,
-                                                                        HttpRequest<?> request) {
+    public HttpResponse<QuestionCategory> createAQuestionCategory(@Body @Valid QuestionCategoryCreateDTO questionCategory,
+                                                                  HttpRequest<?> request) {
 
-        return Mono.fromCallable(() -> questionCategoryService.saveQuestionCategory(new QuestionCategory(questionCategory.getName())))
-                .map(createdQuestionCategory -> HttpResponse.created(createdQuestionCategory)
-                        .headers(headers -> headers.location(
-                                URI.create(String.format("%s/%s", request.getPath(), createdQuestionCategory.getId())))));
-
+        QuestionCategory createdQuestionCategory = questionCategoryService.saveQuestionCategory(new QuestionCategory(questionCategory.getName()));
+        return HttpResponse.created(createdQuestionCategory)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdQuestionCategory.getId()))));
     }
 
     /**
      * Find and read a question category or categories given its id, or name, if both are blank get all question categories.
      *
-     * @param id,    id of the question category
-     * @param name,  name of the question category
+     * @param id,   id of the question category
+     * @param name, name of the question category
      * @return {@link Set < QuestionCategory > list of Question Categories}
      */
 
     @Get("/{?id,name}")
-    public Mono<HttpResponse<Set<QuestionCategory>>> findByValue(@Nullable UUID id, @Nullable String name) {
-        return Mono.fromCallable(() -> questionCategoryService.findByValue(name, id))
-                .map(HttpResponse::ok);
+    public Set<QuestionCategory> findByValue(@Nullable UUID id, @Nullable String name) {
+        return questionCategoryService.findByValue(name, id);
     }
 
     /**
@@ -68,10 +71,10 @@ public class QuestionCategoryController {
      * @return {@link HttpResponse<QuestionCategory>}
      */
     @Put
-    public Mono<HttpResponse<QuestionCategory>> update(@Body @Valid QuestionCategory questionCategory, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> questionCategoryService.update(questionCategory))
-                .map(updatedQuestionCategory -> HttpResponse.ok(updatedQuestionCategory)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedQuestionCategory.getId())))));
+    public HttpResponse<QuestionCategory> update(@Body @Valid QuestionCategory questionCategory, HttpRequest<?> request) {
+        QuestionCategory updatedQuestionCategory = questionCategoryService.update(questionCategory);
+        return HttpResponse.ok(updatedQuestionCategory)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedQuestionCategory.getId()))));
     }
 
     /**
@@ -80,9 +83,8 @@ public class QuestionCategoryController {
      * @param id, id of {@link QuestionCategory} to delete
      */
     @Delete("/{id}")
-    public Mono<HttpResponse<?>> deleteQuestionCategory(@NotNull UUID id) {
-        return Mono.fromCallable(() -> questionCategoryService.delete(id))
-                .thenReturn(HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void deleteQuestionCategory(@NotNull UUID id) {
+        questionCategoryService.delete(id);
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesController.java
@@ -1,14 +1,11 @@
 package com.objectcomputing.checkins.services.request_notifications;
 
-
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import jakarta.annotation.security.PermitAll;
-import reactor.core.publisher.Mono;
 
 @Controller("/services/feedback/daily-request-check")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -24,11 +21,9 @@ public class CheckServicesController {
     }
 
     @Get
-    public Mono<? extends HttpResponse<?>> sendScheduledEmails(@Header("Authorization") String authorizationHeader) {
+    public boolean sendScheduledEmails(@Header("Authorization") String authorizationHeader) {
         String authorization = authorizationHeader.split(" ")[1];
         serviceAccountVerifier.verify(authorization);
-        return Mono.fromCallable(checkServices::sendScheduledEmails)
-                .map(success -> (HttpResponse<?>) HttpResponse.ok());
+        return checkServices.sendScheduledEmails();
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentController.java
@@ -6,7 +6,15 @@ import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -14,13 +22,11 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Controller("/services/review-assignments")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -37,34 +43,32 @@ public class ReviewAssignmentController {
     /**
      * Create and save a new {@link ReviewAssignment}.
      *
-     * @param assignment  a {@link ReviewAssignmentDTO} representing the desired review assignment
+     * @param assignment a {@link ReviewAssignmentDTO} representing the desired review assignment
      * @return a streamable response containing the stored {@link ReviewAssignment}
      */
     @Post
     @RequiredPermission(Permission.CAN_CREATE_REVIEW_ASSIGNMENTS)
-    public Mono<HttpResponse<ReviewAssignment>> createReviewAssignment(@Body @Valid ReviewAssignmentDTO assignment, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> reviewAssignmentServices.save(assignment.convertToEntity()))
-            .map(reviewAssignment -> HttpResponse.created(reviewAssignment)
+    public HttpResponse<ReviewAssignment> createReviewAssignment(@Body @Valid ReviewAssignmentDTO assignment, HttpRequest<?> request) {
+        ReviewAssignment reviewAssignment = reviewAssignmentServices.save(assignment.convertToEntity());
+        return HttpResponse.created(reviewAssignment)
                 .headers(headers -> headers.location(
-                    URI.create(String.format("%s/%s", request.getPath(), reviewAssignment.getId())))));
-
+                        URI.create(String.format("%s/%s", request.getPath(), reviewAssignment.getId()))));
     }
 
     /**
      * Create and save multiple new {@link ReviewAssignment}s and associate them with a given {@link ReviewPeriod}.
      *
      * @param reviewPeriodId a {@link UUID} representing the review period to associate the review assignments with
-     * @param assignments a List of {@link ReviewAssignmentDTO} representing the desired review assignments
+     * @param assignments    a List of {@link ReviewAssignmentDTO} representing the desired review assignments
      * @return a streamable response containing the list of stored {@link ReviewAssignment}
      */
     @Post("/{reviewPeriodId}")
     @RequiredPermission(Permission.CAN_CREATE_REVIEW_ASSIGNMENTS)
-    public Mono<HttpResponse<List<ReviewAssignment>>> createReviewAssignment(@NotNull UUID reviewPeriodId,
-                                                                             @Body List<@Valid ReviewAssignmentDTO> assignments) {
-        return Mono.fromCallable(() -> reviewAssignmentServices.saveAll(reviewPeriodId,
-                assignments.stream().map(ReviewAssignmentDTO::convertToEntity).collect(Collectors.toList()), Boolean.TRUE)
-                ).map(HttpResponse::created);
-
+    @Status(HttpStatus.CREATED)
+    public List<ReviewAssignment> createReviewAssignment(@NotNull UUID reviewPeriodId,
+                                                         @Body List<@Valid ReviewAssignmentDTO> assignments) {
+        List<ReviewAssignment> assignmentEntities = assignments.stream().map(ReviewAssignmentDTO::convertToEntity).toList();
+        return reviewAssignmentServices.saveAll(reviewPeriodId, assignmentEntities, Boolean.TRUE);
     }
 
     /**
@@ -73,50 +77,45 @@ public class ReviewAssignmentController {
      * @param id {@link UUID} of the review assignment
      * @return a streamable response containing the found {@link ReviewAssignment} with the given ID
      */
-
     @RequiredPermission(Permission.CAN_VIEW_REVIEW_ASSIGNMENTS)
     @Get("/{id}")
-    public Mono<HttpResponse<ReviewAssignment>> getById(@NotNull UUID id) {
-        return Mono.fromCallable(() -> {
-            ReviewAssignment result = reviewAssignmentServices.findById(id);
-            if (result == null) {
-                throw new NotFoundException("No review assignment for UUID");
-            }
-            return result;
-        }).map(HttpResponse::ok);
+    public ReviewAssignment getById(@NotNull UUID id) {
+        ReviewAssignment result = reviewAssignmentServices.findById(id);
+        if (result == null) {
+            throw new NotFoundException("No review assignment for UUID");
+        }
+        return result;
     }
 
     @RequiredPermission(Permission.CAN_VIEW_REVIEW_ASSIGNMENTS)
     @Get("/period/{reviewPeriodId}{?reviewerId}")
-    public Mono<HttpResponse<Set<ReviewAssignment>>> findAssignmentsByPeriodId(@NotNull UUID reviewPeriodId, @Nullable @QueryValue UUID reviewerId) {
-        return Mono.fromCallable(() -> reviewAssignmentServices.findAllByReviewPeriodIdAndReviewerId(reviewPeriodId, reviewerId))
-            .map(HttpResponse::ok);
+    public Set<ReviewAssignment> findAssignmentsByPeriodId(@NotNull UUID reviewPeriodId, @Nullable @QueryValue UUID reviewerId) {
+        return reviewAssignmentServices.findAllByReviewPeriodIdAndReviewerId(reviewPeriodId, reviewerId);
     }
 
     /**
      * Update an existing {@link ReviewAssignment}.
      *
-     * @param reviewAssignment  the updated {@link ReviewAssignment}
+     * @param reviewAssignment the updated {@link ReviewAssignment}
      * @return a streamable response containing the stored {@link ReviewAssignment}
      */
     @RequiredPermission(Permission.CAN_UPDATE_REVIEW_ASSIGNMENTS)
     @Put
-    public Mono<HttpResponse<ReviewAssignment>> update(@Body @Valid ReviewAssignment reviewAssignment, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> reviewAssignmentServices.update(reviewAssignment))
-            .map(updatedReviewAssignment -> HttpResponse.ok(updatedReviewAssignment)
-                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedReviewAssignment.getId())))));
+    public HttpResponse<ReviewAssignment> update(@Body @Valid ReviewAssignment reviewAssignment, HttpRequest<?> request) {
+        ReviewAssignment updatedReviewAssignment = reviewAssignmentServices.update(reviewAssignment);
+        return HttpResponse.ok(updatedReviewAssignment)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), updatedReviewAssignment.getId()))));
     }
 
     /**
      * Delete a {@link ReviewAssignment}.
      *
-     * @param id  the id of the review assignment to be deleted to delete
+     * @param id the id of the review assignment to be deleted to delete
      */
     @RequiredPermission(Permission.CAN_DELETE_REVIEW_ASSIGNMENTS)
     @Delete("/{id}")
-    public Mono<HttpResponse<?>> deleteReviewAssignment(@NotNull UUID id) {
-        return Mono.fromRunnable(() -> reviewAssignmentServices.delete(id))
-                .thenReturn(HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void deleteReviewAssignment(@NotNull UUID id) {
+        reviewAssignmentServices.delete(id);
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/role_permissions/RolePermissionController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/role_permissions/RolePermissionController.java
@@ -3,15 +3,19 @@ package com.objectcomputing.checkins.services.role.role_permissions;
 import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.MutableHttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -34,23 +38,23 @@ public class RolePermissionController {
      */
     @RequiredPermission(Permission.CAN_VIEW_ROLE_PERMISSIONS)
     @Get
-    public Mono<HttpResponse<List<RolePermissionsResponseDTO>>> getAllRolePermissions() {
-        return Mono.fromCallable(rolePermissionServices::findAll)
-                .map(HttpResponse::ok);
+    public List<RolePermissionsResponseDTO> getAllRolePermissions() {
+        return rolePermissionServices.findAll();
     }
 
     @RequiredPermission(Permission.CAN_ASSIGN_ROLE_PERMISSIONS)
     @Post
-    public Mono<HttpResponse<RolePermissionResponseDTO>> save(@Body @Valid RolePermissionDTO rolePermission) {
-        return Mono.fromCallable(() -> rolePermissionServices.save(rolePermission.getRoleId(), Permission.fromName(rolePermission.getPermission())))
-                .map(savedRolePermission -> HttpResponse.created(fromEntity(savedRolePermission)));
+    @Status(HttpStatus.CREATED)
+    public HttpResponse<RolePermissionResponseDTO> save(@Body @Valid RolePermissionDTO rolePermission) {
+        RolePermission savedRolePermission = rolePermissionServices.save(rolePermission.getRoleId(), Permission.fromName(rolePermission.getPermission()));
+        return HttpResponse.created(fromEntity(savedRolePermission));
     }
 
     @RequiredPermission(Permission.CAN_ASSIGN_ROLE_PERMISSIONS)
     @Delete("/")
-    public Mono<MutableHttpResponse<Object>> delete(@Body RolePermissionDTO dto) {
-        return Mono.fromRunnable(() -> rolePermissionServices.delete(dto.getRoleId(), Permission.fromName(dto.getPermission())))
-                .thenReturn(HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void delete(@Body RolePermissionDTO dto) {
+        rolePermissionServices.delete(dto.getRoleId(), Permission.fromName(dto.getPermission()));
     }
 
     private RolePermissionResponseDTO fromEntity(RolePermission rolePermission) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/skillcategory/skillcategory_skill/SkillCategorySkillController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skillcategory/skillcategory_skill/SkillCategorySkillController.java
@@ -4,6 +4,7 @@ import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.*;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
@@ -29,17 +30,16 @@ public class SkillCategorySkillController {
 
     @Post
     @RequiredPermission(Permission.CAN_EDIT_SKILL_CATEGORIES)
-    public Mono<HttpResponse<SkillCategorySkill>> create(@Body @Valid SkillCategorySkillId dto, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> skillCategorySkillServices.save(dto))
-                .map(skillCategorySkill -> HttpResponse.created(skillCategorySkill)
-                        .headers(headers -> headers.location(URI.create(String.format("%s", request.getPath())))));
+    public HttpResponse<SkillCategorySkill> create(@Body @Valid SkillCategorySkillId dto, HttpRequest<?> request) {
+        SkillCategorySkill skillCategorySkill = skillCategorySkillServices.save(dto);
+        return HttpResponse.created(skillCategorySkill)
+                        .headers(headers -> headers.location(URI.create(String.format("%s", request.getPath()))));
     }
 
     @Delete
     @RequiredPermission(Permission.CAN_EDIT_SKILL_CATEGORIES)
-    public Mono<HttpResponse<?>> delete(@Body @Valid SkillCategorySkillId dto) {
-        return Mono.fromRunnable(() -> skillCategorySkillServices.delete(dto))
-                .thenReturn(HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void delete(@Body @Valid SkillCategorySkillId dto) {
+        skillCategorySkillServices.delete(dto);
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillController.java
@@ -12,7 +12,6 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 
@@ -36,10 +35,10 @@ public class CombineSkillController {
      */
 
     @Post
-    public Mono<HttpResponse<Skill>> createNewSkillFromList(@Body @Valid CombineSkillsDTO skill, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> combineSkillServices.combine(skill))
-                .map(createdSkill -> HttpResponse.created(createdSkill)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdSkill.getId())))));
+    public HttpResponse<Skill> createNewSkillFromList(@Body @Valid CombineSkillsDTO skill, HttpRequest<?> request) {
+        Skill createdSkill = combineSkillServices.combine(skill);
+        return HttpResponse.created(createdSkill)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdSkill.getId()))));
     }
 
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/TeamController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/TeamController.java
@@ -1,10 +1,16 @@
 package com.objectcomputing.checkins.services.team;
 
-
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
@@ -12,7 +18,6 @@ import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.List;
@@ -38,10 +43,10 @@ public class TeamController {
      * @return {@link HttpResponse<TeamResponseDTO>}
      */
     @Post
-    public Mono<HttpResponse<TeamResponseDTO>> createATeam(@Body @Valid TeamCreateDTO team, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> teamService.save(team))
-                .map(createdTeam -> HttpResponse.created(createdTeam)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdTeam.getId())))));
+    public HttpResponse<TeamResponseDTO> createATeam(@Body @Valid TeamCreateDTO team, HttpRequest<?> request) {
+        TeamResponseDTO createdTeam = teamService.save(team);
+        return HttpResponse.created(createdTeam)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getPath(), createdTeam.getId()))));
     }
 
     /**
@@ -50,11 +55,9 @@ public class TeamController {
      * @param id of team
      * @return {@link TeamResponseDTO team matching id}
      */
-
     @Get("/{id}")
-    public Mono<HttpResponse<TeamResponseDTO>> readTeam(@NotNull UUID id) {
-        return Mono.fromCallable(() -> teamService.read(id))
-                .map(HttpResponse::ok);
+    public TeamResponseDTO readTeam(@NotNull UUID id) {
+        return teamService.read(id);
     }
 
     /**
@@ -66,9 +69,8 @@ public class TeamController {
      * return all teams that match all the filled in params
      */
     @Get("/{?name,memberId}")
-    public Mono<HttpResponse<Set<TeamResponseDTO>>> findTeams(@Nullable String name, @Nullable UUID memberId) {
-        return Mono.fromCallable(() -> teamService.findByFields(name, memberId))
-                .map(HttpResponse::ok);
+    public Set<TeamResponseDTO> findTeams(@Nullable String name, @Nullable UUID memberId) {
+        return teamService.findByFields(name, memberId);
     }
 
     /**
@@ -78,22 +80,20 @@ public class TeamController {
      * @return {@link HttpResponse<TeamResponseDTO>}
      */
     @Put
-    public Mono<HttpResponse<TeamResponseDTO>> update(@Body @Valid TeamUpdateDTO team, HttpRequest<?> request) {
-        return Mono.fromCallable(() -> teamService.update(team))
-                .map(updated -> HttpResponse.ok(updated)
-                        .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), team.getId())))));
-
+    public HttpResponse<TeamResponseDTO> update(@Body @Valid TeamUpdateDTO team, HttpRequest<?> request) {
+        TeamResponseDTO updated = teamService.update(team);
+        return HttpResponse.ok(updated)
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), team.getId()))));
     }
 
     /**
      * Delete Team
      *
      * @param id, id of {@link TeamUpdateDTO} to delete
-     * @return
      */
     @Delete("/{id}")
-    public Mono<HttpResponse<Object>> deleteTeam(@NotNull UUID id) {
-        return Mono.fromCallable(() -> teamService.delete(id))
-                .map(success -> HttpResponse.ok());
+    @Status(HttpStatus.OK)
+    public void deleteTeam(@NotNull UUID id) {
+        teamService.delete(id);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/today/TodayController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/today/TodayController.java
@@ -1,6 +1,5 @@
 package com.objectcomputing.checkins.services.today;
 
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.scheduling.TaskExecutors;
@@ -8,7 +7,6 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import reactor.core.publisher.Mono;
 
 @Controller("/services/today")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -28,8 +26,7 @@ public class TodayController {
      * @return {@link TodayResponseDTO today's events}
      */
     @Get
-    public Mono<HttpResponse<TodayResponseDTO>> getTodaysEvents() {
-        return Mono.fromCallable(todayServices::getTodaysEvents)
-                .map(HttpResponse::ok);
+    public TodayResponseDTO getTodaysEvents() {
+        return todayServices.getTodaysEvents();
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
@@ -243,7 +243,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignAdminRole(lucy);
 
-        Demographics demographic = createDefaultDemographics(lucy.getId());
+        createDefaultDemographics(lucy.getId());
 
         final HttpRequest<Object> request = HttpRequest.
                 DELETE(String.format("/%s", UUID.randomUUID())).basicAuth(lucy.getWorkEmail(), ADMIN_ROLE);
@@ -253,6 +253,22 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
 
         assertEquals(HttpStatus.NOT_FOUND,responseException.getStatus());
 
+    }
+
+    @Test
+    void testGETDemographicsWrongId() {
+        MemberProfile lucy = memberWithoutBoss("Lucy");
+        createAndAssignAdminRole(lucy);
+
+        createDefaultDemographics(lucy.getId());
+
+        final HttpRequest<Object> request = HttpRequest.
+                GET(String.format("/%s", UUID.randomUUID())).basicAuth(lucy.getWorkEmail(), ADMIN_ROLE);
+
+        HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(request, Map.class));
+
+        assertEquals(HttpStatus.NOT_FOUND,responseException.getStatus());
     }
 
     @Test


### PR DESCRIPTION
We have many places where we are wrapping the responses in a Mono in the controllers.

As we declare `@ExecuteOn(TaskExecutors.BLOCKING)` in these controllers, I don't think this is required.

And it probably affects performance, as the work is probably offloaded multiple times to multiple thread pools.

This commit removes (almost) all of the wrapping. The only place it remains is in the Github client (as I'm not currently sure where that's used) 🤔