### PR TITLE
Some sonar cleanup (picking the most prevalent or highest priority)

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetSender.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetSender.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Requires(property = MailJetSender.FROM_ADDRESS)
 @Requires(property = MailJetSender.FROM_NAME)
@@ -58,7 +57,7 @@ public class MailJetSender implements EmailSender {
             // Get only the first n elements limited by MailJet's API
             List<String> limitedRecipients = recipientList.stream()
                     .limit(MAILJET_RECIPIENT_LIMIT)
-                    .collect(Collectors.toList());
+                    .toList();
 
             // Add each recipient to a JSON array to be sent in a MailJet request
             JSONArray recipientArray = new JSONArray();

--- a/server/src/main/java/com/objectcomputing/checkins/security/CheckinsOpenIdAuthenticationMapper.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/CheckinsOpenIdAuthenticationMapper.java
@@ -92,7 +92,7 @@ public class CheckinsOpenIdAuthenticationMapper implements OpenIdAuthenticationM
     protected List<String> getRoles(OpenIdClaims openIdClaims) {
         List<String> roles = new ArrayList<>();
         memberProfileRepository.findByWorkEmail(openIdClaims.getEmail())
-                .ifPresent((memberProfile) -> {
+                .ifPresent(memberProfile -> {
                         LOG.info("MemberProfile of the user: {}", memberProfile);
                         roles.addAll(roleRepository.findUserRoles(memberProfile.getId())
                                 .stream()

--- a/server/src/main/java/com/objectcomputing/checkins/security/CustomRefreshTokenPersistence.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/CustomRefreshTokenPersistence.java
@@ -13,15 +13,17 @@ import io.micronaut.runtime.event.annotation.EventListener;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.token.event.RefreshTokenGeneratedEvent;
 import io.micronaut.security.token.refresh.RefreshTokenPersistence;
+import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Singleton;
 import reactor.core.publisher.Mono;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 @Singleton
 public class CustomRefreshTokenPersistence implements RefreshTokenPersistence {
@@ -71,10 +73,10 @@ public class CustomRefreshTokenPersistence implements RefreshTokenPersistence {
 
     public Authentication createAuthentication(MemberProfile memberProfile) {
         List<Permission> permissions = rolePermissionServices.findUserPermissions(memberProfile.getId());
-        List<String> permissionsAsString = permissions.stream().map(Permission::name).collect(Collectors.toList());
+        List<String> permissionsAsString = permissions.stream().map(Permission::name).toList();
 
         Set<Role> userRoles = roleServices.findUserRoles(memberProfile.getId());
-        List<String> rolesAsString = userRoles.stream().map(Role::getRole).collect(Collectors.toList());
+        List<String> rolesAsString = userRoles.stream().map(Role::getRole).toList();
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("permissions", permissionsAsString);

--- a/server/src/main/java/com/objectcomputing/checkins/security/CustomRefreshTokenPersistence.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/CustomRefreshTokenPersistence.java
@@ -26,7 +26,8 @@ import java.util.stream.Collectors;
 @Singleton
 public class CustomRefreshTokenPersistence implements RefreshTokenPersistence {
 
-    final Logger LOG = LoggerFactory.getLogger(CustomRefreshTokenPersistence.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CustomRefreshTokenPersistence.class);
+
     final MemberProfileRepository memberProfileRepo;
     final RefreshTokenRepository refreshTokenRepo;
     final PermissionServices permissionServices;

--- a/server/src/main/java/com/objectcomputing/checkins/security/LocalUserPasswordAuthProvider.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/LocalUserPasswordAuthProvider.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Singleton
 @Requires(env = {Environments.LOCAL, Environment.TEST})

--- a/server/src/main/java/com/objectcomputing/checkins/security/LocalUserPasswordAuthProvider.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/LocalUserPasswordAuthProvider.java
@@ -77,10 +77,10 @@ public class LocalUserPasswordAuthProvider implements ReactiveAuthenticationProv
         }
 
         List<Permission> permissions = rolePermissionServices.findUserPermissions(memberProfile.getId());
-        List<String> permissionsAsString = permissions.stream().map(Enum::name).collect(Collectors.toList());
+        List<String> permissionsAsString = permissions.stream().map(Enum::name).toList();
 
         Set<Role> userRoles = roleServices.findUserRoles(memberProfile.getId());
-        List<String> rolesAsString = userRoles.stream().map(Role::getRole).collect(Collectors.toList());
+        List<String> rolesAsString = userRoles.stream().map(Role::getRole).toList();
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("roles", rolesAsString);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionServiceImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionServiceImpl.java
@@ -61,7 +61,7 @@ public class FeedbackSuggestionServiceImpl implements FeedbackSuggestionsService
 
         for(TeamMember currentMembership: teamMemberships){
             Set<TeamMember> teamMembers = teamMemberServices.findByFields(currentMembership.getTeamId(), null, null);
-            Set<TeamMember> leads = teamMembers.stream().filter((member)-> member.isLead()).collect(Collectors.toSet());
+            Set<TeamMember> leads = teamMembers.stream().filter(member -> member.isLead()).collect(Collectors.toSet());
             leads = filterTerminated(leads);
             for(TeamMember lead: leads) {
                 if(suggestions.size() < maxSuggestions && !lead.getMemberId().equals(id) && !lead.getMemberId().equals(currentUserId)) {
@@ -74,7 +74,7 @@ public class FeedbackSuggestionServiceImpl implements FeedbackSuggestionsService
 
         for(TeamMember currentMembership: teamMemberships){
             Set<TeamMember> teamMembers = teamMemberServices.findByFields(currentMembership.getTeamId(), null, null);
-            teamMembers = teamMembers.stream().filter((member)-> !member.isLead()).collect(Collectors.toSet());
+            teamMembers = teamMembers.stream().filter(member -> !member.isLead()).collect(Collectors.toSet());
             teamMembers = filterTerminated(teamMembers);
             for(TeamMember teamMember: teamMembers) {
                 if(suggestions.size() < maxSuggestions && !teamMember.getMemberId().equals(id) && !teamMember.getMemberId().equals(currentUserId)) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerServicesImpl.java
@@ -107,7 +107,7 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
         final UUID requestCreatorId = feedbackRequest.getCreatorId();
         final UUID requesteeId = feedbackRequest.getRequesteeId();
         final UUID recipientId = feedbackRequest.getRecipientId();
-        boolean isRequesteesSupervisor = requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter((profile) -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
+        boolean isRequesteesSupervisor = requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter(profile -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
         MemberProfile requestee = memberProfileServices.getById(requesteeId);
         final UUID requesteePDL = requestee.getPdlId();
         if (currentUserServices.isAdmin() || currentUserId.equals(requesteePDL) || isRequesteesSupervisor || requestCreatorId.equals(currentUserId) || recipientId.equals(currentUserId)) {
@@ -148,7 +148,7 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
         MemberProfile requestee = memberProfileServices.getById(requesteeId);
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         final UUID recipientId = feedbackRequest.getRecipientId();
-        boolean isRequesteesSupervisor = requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter((profile) -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
+        boolean isRequesteesSupervisor = requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter(profile -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
         final UUID requesteePDL = requestee.getPdlId();
 
         return isAdmin || currentUserId.equals(requesteePDL) || isRequesteesSupervisor || requestCreatorId.equals(currentUserId) || recipientId.equals(currentUserId);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerServicesImpl.java
@@ -107,7 +107,7 @@ public class QuestionAndAnswerServicesImpl implements QuestionAndAnswerServices 
         MemberProfile requestee = memberProfileServices.getById(requesteeId);
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         final UUID recipientId = feedbackRequest.getRecipientId();
-        boolean isRequesteesSupervisor = requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter((profile) -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
+        boolean isRequesteesSupervisor = requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter(profile -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
         final UUID requesteePDL = requestee.getPdlId();
 
         return isAdmin || currentUserId.equals(requesteePDL) || isRequesteesSupervisor || requestCreatorId.equals(currentUserId) || recipientId.equals(currentUserId);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -261,7 +261,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
     }
 
     private boolean isSupervisor(UUID requesteeId, UUID currentUserId) {
-        return requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter((profile) -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
+        return requesteeId != null ? memberProfileServices.getSupervisorsForId(requesteeId).stream().filter(profile -> currentUserId.equals(profile.getId())).findAny().isPresent() : false;
     }
 
     private boolean createIsPermitted(UUID requesteeId) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
@@ -98,7 +98,7 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
                 .stream()
                 .filter(template -> template.getIsPublic() || isAdmin || template.getCreatorId().equals(currentUserId))
                 .filter(template -> !template.getIsReview() || isAdmin)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
@@ -12,7 +12,6 @@ import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Singleton
 public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
@@ -6,7 +6,11 @@ import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
 import com.objectcomputing.checkins.notifications.email.MailJetConfig;
-import com.objectcomputing.checkins.services.guild.member.*;
+import com.objectcomputing.checkins.services.guild.member.GuildMember;
+import com.objectcomputing.checkins.services.guild.member.GuildMemberHistoryRepository;
+import com.objectcomputing.checkins.services.guild.member.GuildMemberRepository;
+import com.objectcomputing.checkins.services.guild.member.GuildMemberResponseDTO;
+import com.objectcomputing.checkins.services.guild.member.GuildMemberServices;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
@@ -20,7 +24,12 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
@@ -122,7 +131,7 @@ public class GuildServicesImpl implements GuildServices {
                     return terminationDate == null || !LocalDate.now().plusDays(1).isAfter(terminationDate);
                 })
                 .map(guildMember ->
-                        fromMemberEntity(guildMember, memberProfileServices.getById(guildMember.getMemberId()))).collect(Collectors.toList());
+                        fromMemberEntity(guildMember, memberProfileServices.getById(guildMember.getMemberId()))).toList();
 
         return fromEntity(foundGuild, guildMembers);
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
@@ -171,8 +171,8 @@ public class GuildServicesImpl implements GuildServices {
                     Set<GuildMember> existingGuildMembers = guildMemberServices.findByFields(guildDTO.getId(), null, null);
                   
                     //add new members to the guild
-                    guildDTO.getGuildMembers().stream().forEach((updatedMember) -> {
-                        Optional<GuildMember> first = existingGuildMembers.stream().filter((existing) -> existing.getMemberId().equals(updatedMember.getMemberId())).findFirst();
+                    guildDTO.getGuildMembers().stream().forEach(updatedMember -> {
+                        Optional<GuildMember> first = existingGuildMembers.stream().filter(existing -> existing.getMemberId().equals(updatedMember.getMemberId())).findFirst();
                         MemberProfile existingMember = memberProfileServices.getById(updatedMember.getMemberId());
                         if(first.isEmpty()) {
                             newMembers.add(fromMemberEntity(guildMemberServices.save(fromMemberDTO(updatedMember, newGuildEntity.getId())), existingMember));
@@ -183,8 +183,8 @@ public class GuildServicesImpl implements GuildServices {
                     });
 
                     //delete any removed members from guild
-                    existingGuildMembers.stream().forEach((existingMember) -> {
-                        if(!guildDTO.getGuildMembers().stream().filter((updatedTeamMember) -> updatedTeamMember.getMemberId().equals(existingMember.getMemberId())).findFirst().isPresent()) {
+                    existingGuildMembers.stream().forEach(existingMember -> {
+                        if(!guildDTO.getGuildMembers().stream().filter(updatedTeamMember -> updatedTeamMember.getMemberId().equals(existingMember.getMemberId())).findFirst().isPresent()) {
                             guildMemberServices.delete(existingMember.getId());
                             removedMembers.add(memberProfileServices.getById(existingMember.getMemberId()));
                         }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/anniversaryreport/AnniversaryReportServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/anniversaryreport/AnniversaryReportServicesImpl.java
@@ -15,7 +15,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Singleton
 public class AnniversaryReportServicesImpl implements AnniversaryServices {
@@ -48,7 +47,7 @@ public class AnniversaryReportServicesImpl implements AnniversaryServices {
                             .filter(member -> member.getStartDate() != null
                                     && month.equalsIgnoreCase(member.getStartDate().getMonth().name())
                                     && member.getTerminationDate() == null)
-                            .collect(Collectors.toList());
+                            .toList();
                 }
                 memberProfileAll.addAll(memberProfile);
             }
@@ -66,7 +65,7 @@ public class AnniversaryReportServicesImpl implements AnniversaryServices {
                 .stream()
                 .filter(member -> member.getStartDate() != null
                         && today.getMonthValue() == member.getStartDate().getMonthValue())
-                .collect(Collectors.toList());
+                .toList();
         return profileToAnniversaryResponseDto(results);
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/birthday/BirthDayServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/birthday/BirthDayServicesImpl.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Singleton
 public class BirthDayServicesImpl implements BirthDayServices{
@@ -30,14 +29,14 @@ public class BirthDayServicesImpl implements BirthDayServices{
         }
 
         Set<MemberProfile> memberProfiles = memberProfileServices.findByValues(null, null, null, null, null, null, false);
-        List<MemberProfile> memberProfileAll = memberProfiles.stream().collect(Collectors.toList());
+        List<MemberProfile> memberProfileAll = new ArrayList<>(memberProfiles);
         if (months != null) {
             for (String month : months) {
                 if (month != null) {
                     memberProfileAll = memberProfileAll
                             .stream()
                             .filter(member -> member.getBirthDate() != null && month.equalsIgnoreCase(member.getBirthDate().getMonth().name()) && member.getTerminationDate() == null)
-                            .collect(Collectors.toList());
+                            .toList();
                 }
             }
         }
@@ -47,13 +46,14 @@ public class BirthDayServicesImpl implements BirthDayServices{
                     memberProfileAll = memberProfiles
                             .stream()
                             .filter(member -> member.getBirthDate() != null && day.equals(member.getBirthDate().getDayOfMonth()) && member.getTerminationDate() == null)
-                            .collect(Collectors.toList());
+                            .toList();
                 }
             }
         }
 
         return profileToBirthDateResponseDto(memberProfileAll);
     }
+
     @Override
     public List<BirthDayResponseDTO> getTodaysBirthdays() {
         Set<MemberProfile> memberProfiles = memberProfileServices.findByValues(null, null, null, null, null, null, false);
@@ -61,7 +61,7 @@ public class BirthDayServicesImpl implements BirthDayServices{
         List<MemberProfile> results = memberProfiles
                 .stream()
                 .filter(member -> member.getBirthDate() != null && today.getMonthValue() == member.getBirthDate().getMonthValue())
-                .collect(Collectors.toList());
+                .toList();
         return profileToBirthDateResponseDto(results);
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServicesImpl.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Singleton
 public class MemberProfileReportServicesImpl implements MemberProfileReportServices {
@@ -32,7 +31,7 @@ public class MemberProfileReportServicesImpl implements MemberProfileReportServi
             List<MemberProfileRecord> allRecords = memberProfileReportRepository.findAll();
             memberRecords.addAll(allRecords);
         } else {
-            List<String> memberIds = queryDTO.getMemberIds().stream().map(UUID::toString).collect(Collectors.toList());
+            List<String> memberIds = queryDTO.getMemberIds().stream().map(UUID::toString).toList();
             List<MemberProfileRecord> filteredRecords = memberProfileReportRepository.findAllByMemberIds(memberIds);
             memberRecords.addAll(filteredRecords);
         }

--- a/server/src/main/java/com/objectcomputing/checkins/services/permissions/PermissionServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/permissions/PermissionServicesImpl.java
@@ -2,18 +2,17 @@ package com.objectcomputing.checkins.services.permissions;
 
 import jakarta.inject.Singleton;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.List;
 
 @Singleton
 public class PermissionServicesImpl implements PermissionServices {
 
-
   public List<Permission> findAll() {
-    return Arrays.stream(Permission.values()).collect(Collectors.toList());
+    return Arrays.asList(Permission.values());
   }
 
   public List<Permission> listOrderByPermission() {
-    return Arrays.stream(Permission.values()).sorted().collect(Collectors.toList());
+    return Arrays.stream(Permission.values()).sorted().toList();
   }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategory.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategory.java
@@ -41,8 +41,7 @@ public class QuestionCategory {
     }
 
     public QuestionCategory(@NotBlank String name) {
-        this.id = id;
-        this.name = name;
+        this(null, name);
     }
 
     public QuestionCategory() {}

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/role_permissions/RolePermissionServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/role_permissions/RolePermissionServicesImpl.java
@@ -11,8 +11,11 @@ import io.micronaut.cache.annotation.Cacheable;
 import jakarta.inject.Singleton;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 @Singleton
 @CacheConfig("role-permission-cache")
@@ -49,7 +52,7 @@ public class RolePermissionServicesImpl implements RolePermissionServices {
             rolePermissionsResponseDTO.setRoleId(role.getId());
             rolePermissionsResponseDTO.setRole(role.getRole());
             rolePermissionsResponseDTO.setDescription(role.getDescription());
-            rolePermissionsResponseDTO.setPermissions(permissionsAssociatedWithRole.stream().map((Permission permission) -> new PermissionDTO(permission)).collect(Collectors.toList()));
+            rolePermissionsResponseDTO.setPermissions(permissionsAssociatedWithRole.stream().map(PermissionDTO::new).toList());
             roleInfo.add(rolePermissionsResponseDTO);
         }
 
@@ -88,12 +91,10 @@ public class RolePermissionServicesImpl implements RolePermissionServices {
 
         Set<Role> memberRoles = roleServices.findUserRoles(id);
 
-        return memberRoles.stream().map(role ->
+        return memberRoles.stream().flatMap(role ->
                 findByRoleId(role.getId())
                     .stream()
-                    .map(RolePermission::getPermission)
-                    .collect(Collectors.toList()))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+                    .map(RolePermission::getPermission))
+            .toList();
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingOption.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingOption.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Getter

--- a/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingOption.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingOption.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.micronaut.core.annotation.Introspected;
 import lombok.Getter;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,8 +29,7 @@ public enum SettingOption {
     }
 
     public static List<SettingOption> getOptions(){
-        return Stream.of(SettingOption.values())
-                .collect(Collectors.toList());
+        return Arrays.asList(SettingOption.values());
     }
 
     public static Boolean isValidOption(String name){

--- a/server/src/main/java/com/objectcomputing/checkins/services/skillcategory/skillcategory_skill/SkillCategorySkillController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skillcategory/skillcategory_skill/SkillCategorySkillController.java
@@ -5,14 +5,17 @@ import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import reactor.core.publisher.Mono;
 
 import java.net.URI;
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/TeamServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/TeamServicesImpl.java
@@ -70,7 +70,8 @@ public class TeamServicesImpl implements TeamServices {
                     return terminationDate == null || !LocalDate.now().plusDays(1).isAfter(terminationDate);
                 })
                 .map(teamMember ->
-                        fromMemberEntity(teamMember, memberProfileServices.getById(teamMember.getMemberId()))).collect(Collectors.toList());
+                        fromMemberEntity(teamMember, memberProfileServices.getById(teamMember.getMemberId())))
+                .toList();
 
         return fromEntity(foundTeam, teamMembers);
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/TeamServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/TeamServicesImpl.java
@@ -97,8 +97,8 @@ public class TeamServicesImpl implements TeamServices {
 
                     Set<TeamMember> existingTeamMembers = teamMemberServices.findByFields(teamDTO.getId(), null, null);
                     //add any new members & updates
-                    teamDTO.getTeamMembers().stream().forEach((updatedMember) -> {
-                        Optional<TeamMember> first = existingTeamMembers.stream().filter((existing) -> existing.getMemberId().equals(updatedMember.getMemberId())).findFirst();
+                    teamDTO.getTeamMembers().stream().forEach(updatedMember -> {
+                        Optional<TeamMember> first = existingTeamMembers.stream().filter(existing -> existing.getMemberId().equals(updatedMember.getMemberId())).findFirst();
                         if (!first.isPresent()) {
                             MemberProfile existingMember = memberProfileServices.getById(updatedMember.getMemberId());
                             newMembers.add(fromMemberEntity(teamMemberServices.save(fromMemberDTO(updatedMember, newTeamEntity.getId())), existingMember));
@@ -109,8 +109,8 @@ public class TeamServicesImpl implements TeamServices {
                     });
 
                     //delete any removed members
-                    existingTeamMembers.stream().forEach((existingMember) -> {
-                        if (!teamDTO.getTeamMembers().stream().filter((updatedTeamMember) -> updatedTeamMember.getMemberId().equals(existingMember.getMemberId())).findFirst().isPresent()) {
+                    existingTeamMembers.stream().forEach(existingMember -> {
+                        if (!teamDTO.getTeamMembers().stream().filter(updatedTeamMember -> updatedTeamMember.getMemberId().equals(existingMember.getMemberId())).findFirst().isPresent()) {
                             teamMemberServices.delete(existingMember.getId());
                         }
                     });

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/member/MemberHistory.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/member/MemberHistory.java
@@ -61,7 +61,8 @@ public class MemberHistory {
         this.change = change;
         this.date = date;
     }
-    public MemberHistory(@NotNull UUID Id, @NotNull UUID teamId, @NotNull UUID memberId, @Nullable String change, @Nullable LocalDateTime date) {
+
+    public MemberHistory(@NotNull UUID id, @NotNull UUID teamId, @NotNull UUID memberId, @Nullable String change, @Nullable LocalDateTime date) {
         this.id = id;
         this.teamId = teamId;
         this.memberId = memberId;

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/member/TeamMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/member/TeamMemberServicesImpl.java
@@ -14,8 +14,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 @Singleton
 public class TeamMemberServicesImpl implements TeamMemberServices {

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/member/TeamMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/member/TeamMemberServicesImpl.java
@@ -150,7 +150,7 @@ public class TeamMemberServicesImpl implements TeamMemberServices {
 
         List<TeamMember> teamMembers = teamMemberRepo.findByTeamId(id);
         if (teamMembers != null) {
-            List<TeamMember> teamLeads = teamMembers.stream().filter((member) -> member.isLead()).collect(Collectors.toList());
+            List<TeamMember> teamLeads = teamMembers.stream().filter(TeamMember::isLead).toList();
 
             if (!isAdmin && teamLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
                 throw new PermissionException("You are not authorized to perform this operation");

--- a/server/src/test/java/com/objectcomputing/checkins/endtoend/pages/HomePage.java
+++ b/server/src/test/java/com/objectcomputing/checkins/endtoend/pages/HomePage.java
@@ -40,7 +40,7 @@ public class HomePage {
         String successMsg = this.successMsg.getText();
         System.out.println("Upload File Msg: " + successMsg);
         Thread.sleep(1000);
-        assertEquals(this.successMsg.getText(), "THE FILE APPLICATION.YML WAS UPLOADED");
+        assertEquals("THE FILE APPLICATION.YML WAS UPLOADED", this.successMsg.getText());
         Thread.sleep(5000);
     }
 
@@ -72,7 +72,7 @@ public class HomePage {
         String errorMsg = this.errorMsg.getText();
         System.out.println("Upload File Msg: " + errorMsg);
         Thread.sleep(1000);
-        assertEquals(this.errorMsg.getText(), "Please select a file before uploading.");
+        assertEquals("Please select a file before uploading.", this.errorMsg.getText());
         Thread.sleep(5000);
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
@@ -8,7 +8,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MailJetSenderTest extends TestContainersSuite {
+class MailJetSenderTest extends TestContainersSuite {
 
     @Test
     void testCreateBatchesForManyRecipients() {

--- a/server/src/test/java/com/objectcomputing/checkins/security/CheckinsOpenIdAuthenticationMapperTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/security/CheckinsOpenIdAuthenticationMapperTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 @MicronautTest(environments = {"prodtest","google"}, transactional = false)
-public class CheckinsOpenIdAuthenticationMapperTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class CheckinsOpenIdAuthenticationMapperTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     OpenIdAuthenticationMapper openIdAuthenticationMapper;

--- a/server/src/test/java/com/objectcomputing/checkins/security/GoogleServiceConfigurationTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/security/GoogleServiceConfigurationTest.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GoogleServiceConfigurationTest extends TestContainersSuite {
+class GoogleServiceConfigurationTest extends TestContainersSuite {
 
     @Inject
     private Validator validator;

--- a/server/src/test/java/com/objectcomputing/checkins/security/LocalLoginControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/security/LocalLoginControllerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest(environments = {Environments.LOCAL, Environments.LOCALTEST}, transactional = false)
-public class LocalLoginControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class LocalLoginControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Client("/oauth/login/google")
     @Inject

--- a/server/src/test/java/com/objectcomputing/checkins/services/action_item/ActionItemCreateDTOTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/action_item/ActionItemCreateDTOTest.java
@@ -29,7 +29,7 @@ class ActionItemCreateDTOTest extends TestContainersSuite {
         ActionItemCreateDTO dto = new ActionItemCreateDTO();
 
         Set<ConstraintViolation<ActionItemCreateDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 2);
+        assertEquals(2, violations.size());
         for (ConstraintViolation<ActionItemCreateDTO> violation : violations) {
             assertEquals("must not be null", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemCreateDTOTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemCreateDTOTest.java
@@ -29,7 +29,7 @@ class AgendaItemCreateDTOTest extends TestContainersSuite {
         AgendaItemCreateDTO dto = new AgendaItemCreateDTO();
 
         Set<ConstraintViolation<AgendaItemCreateDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 2);
+        assertEquals(2, violations.size());
         for (ConstraintViolation<AgendaItemCreateDTO> violation : violations) {
             assertEquals("must not be null", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentCreateDTOTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentCreateDTOTest.java
@@ -28,7 +28,7 @@ class CheckinDocumentCreateDTOTest extends TestContainersSuite {
         CheckinDocumentCreateDTO dto = new CheckinDocumentCreateDTO();
 
         Set<ConstraintViolation<CheckinDocumentCreateDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 2);
+        assertEquals(2, violations.size());
         for (ConstraintViolation<CheckinDocumentCreateDTO> violation : violations) {
             assertEquals("must not be null", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentServiceImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentServiceImplTest.java
@@ -99,8 +99,8 @@ class CheckinDocumentServiceImplTest extends TestContainersSuite {
         CheckinDocument cd = new CheckinDocument(UUID.randomUUID(), "docId");
         CheckIn checkin = new CheckIn();
 
-        when(checkinRepository.findById(eq(cd.getCheckinsId()))).thenReturn(Optional.of(checkin));
-        when(checkinDocumentRepository.save(eq(cd))).thenReturn(cd);
+        when(checkinRepository.findById(cd.getCheckinsId())).thenReturn(Optional.of(checkin));
+        when(checkinDocumentRepository.save(cd)).thenReturn(cd);
 
         assertEquals(cd, services.save(cd));
 
@@ -153,7 +153,7 @@ class CheckinDocumentServiceImplTest extends TestContainersSuite {
     void testSaveCheckinDocumentNonExistingCheckIn() {
         CheckinDocument cd = new CheckinDocument(UUID.randomUUID(), "docId");
 
-        when(checkinRepository.findById(eq(cd.getCheckinsId()))).thenReturn(Optional.empty());
+        when(checkinRepository.findById(cd.getCheckinsId())).thenReturn(Optional.empty());
 
         BadArgException exception = assertThrows(BadArgException.class, () -> services.save(cd));
         assertEquals(String.format("CheckIn %s doesn't exist", cd.getCheckinsId()), exception.getMessage());
@@ -168,8 +168,8 @@ class CheckinDocumentServiceImplTest extends TestContainersSuite {
 
         CheckIn checkin = new CheckIn();
 
-        when(checkinRepository.findById(eq(cd.getCheckinsId()))).thenReturn(Optional.of(checkin));
-        when(checkinDocumentRepository.findByUploadDocId(eq(cd.getUploadDocId()))).thenReturn(Optional.of(cd));
+        when(checkinRepository.findById(cd.getCheckinsId())).thenReturn(Optional.of(checkin));
+        when(checkinDocumentRepository.findByUploadDocId(cd.getUploadDocId())).thenReturn(Optional.of(cd));
 
         BadArgException exception = assertThrows(BadArgException.class, () -> services.save(cd));
         assertEquals(String.format("CheckinDocument with document ID %s already exists", cd.getUploadDocId()), exception.getMessage());
@@ -233,7 +233,7 @@ class CheckinDocumentServiceImplTest extends TestContainersSuite {
     @Test
     void testUpdateCheckinDocumentDoesNotExist() {
         CheckinDocument cd = new CheckinDocument(UUID.randomUUID(), UUID.randomUUID(), "docId");
-        when(checkinDocumentRepository.findById(eq(cd.getCheckinsId()))).thenReturn(Optional.empty());
+        when(checkinDocumentRepository.findById(cd.getCheckinsId())).thenReturn(Optional.empty());
 
         BadArgException exception = assertThrows(BadArgException.class, () -> services.update(cd));
         assertEquals(String.format("CheckinDocument id %s not found, please try inserting instead", cd.getId()), exception.getMessage());
@@ -246,8 +246,8 @@ class CheckinDocumentServiceImplTest extends TestContainersSuite {
     @Test
     void testUpdateCheckInDoesNotExist() {
         CheckinDocument cd = new CheckinDocument(UUID.randomUUID(), UUID.randomUUID(), "docId");
-        when(checkinDocumentRepository.findById(eq(cd.getId()))).thenReturn(Optional.of(cd));
-        when(checkinRepository.findById(eq(cd.getCheckinsId()))).thenReturn(Optional.empty());
+        when(checkinDocumentRepository.findById(cd.getId())).thenReturn(Optional.of(cd));
+        when(checkinRepository.findById(cd.getCheckinsId())).thenReturn(Optional.empty());
 
         BadArgException exception = assertThrows(BadArgException.class, () -> services.update(cd));
         assertEquals(String.format("CheckIn %s doesn't exist", cd.getCheckinsId()), exception.getMessage());

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkins/CheckInControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkins/CheckInControllerTest.java
@@ -130,7 +130,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
@@ -172,7 +172,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode errors = Objects.requireNonNull(body).get("_embedded").get("errors");
         JsonNode href = Objects.requireNonNull(body).get("_links").get("self").get("href");
         List<String> errorList = List.of(errors.get(0).get("message").asText(), errors.get(1).get("message").asText())
-                .stream().sorted().collect(Collectors.toList());
+                .stream().sorted().toList();
 
         assertEquals("checkIn.pdlId: must not be null", errorList.get(0));
         assertEquals("checkIn.teamMemberId: must not be null", errorList.get(1));
@@ -219,7 +219,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testCreateACheckInForInvalidPdlID() {
+    void testCreateACheckInForInvalidPdlID() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
         Role role = assignPdlRole(memberProfileOfPDL);
@@ -278,7 +278,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetReadByIdByAdmin() {
+    void testGetReadByIdByAdmin() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -297,7 +297,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetReadByIdByPDL() {
+    void testGetReadByIdByPDL() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -316,7 +316,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetReadByIdByMember() {
+    void testGetReadByIdByMember() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -335,7 +335,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetReadByIdByUnrelatedUser() {
+    void testGetReadByIdByUnrelatedUser() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
         MemberProfile memberProfileOfMrNobody = createAnUnrelatedUser();
@@ -352,7 +352,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
@@ -440,7 +440,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
@@ -504,7 +504,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String error = Objects.requireNonNull(body).get("message").asText();
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
-        assertEquals(String.format("Unable to find checkin record with id null", checkIn.getId()), error);
+        assertEquals("Unable to find checkin record with id null", error);
         assertEquals(request.getPath(), href);
     }
 
@@ -540,7 +540,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode errors = Objects.requireNonNull(body).get("_embedded").get("errors");
         JsonNode href = Objects.requireNonNull(body).get("_links").get("self").get("href");
         List<String> errorList = List.of(errors.get(0).get("message").asText(), errors.get(1).get("message").asText())
-                .stream().sorted().collect(Collectors.toList());
+                .stream().sorted().toList();
         assertEquals("checkIn.pdlId: must not be null", errorList.get(0));
         assertEquals("checkIn.teamMemberId: must not be null", errorList.get(1));
         assertEquals(request.getPath(), href.asText());
@@ -565,10 +565,10 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testUpdateACheckInForInvalidPdlID() {
+    void testUpdateACheckInForInvalidPdlID() {
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
-        Role role = assignPdlRole(memberProfileOfPDL);
+        assignPdlRole(memberProfileOfPDL);
 
         CheckIn checkIn = createADefaultCheckIn(memberProfileOfUser, memberProfileOfPDL);
         checkIn.setPdlId(UUID.randomUUID());
@@ -642,7 +642,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByTeamMemberIdByMember() {
+    void testGetFindByTeamMemberIdByMember() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -657,7 +657,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByTeamMemberIdByPdl() {
+    void testGetFindByTeamMemberIdByPdl() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -672,7 +672,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByTeamMemberIdByAdmin() {
+    void testGetFindByTeamMemberIdByAdmin() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -688,7 +688,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByTeamMemberIdByUnrelatedUser() {
+    void testGetFindByTeamMemberIdByUnrelatedUser() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -704,11 +704,11 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
-    public void testGetFindByPDLIdByMember() {
+    void testGetFindByPDLIdByMember() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -723,11 +723,11 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
-    public void testGetFindByPDLIdByPDL() {
+    void testGetFindByPDLIdByPDL() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -742,7 +742,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByPDLIdByAdmin() {
+    void testGetFindByPDLIdByAdmin() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -758,7 +758,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByPDLIdByUnrelatedUser() {
+    void testGetFindByPDLIdByUnrelatedUser() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -774,11 +774,11 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
-    public void testGetFindByCompletedByAdmin() {
+    void testGetFindByCompletedByAdmin() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -808,7 +808,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByCompletedByMember() {
+    void testGetFindByCompletedByMember() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -830,7 +830,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testGetFindByCompletedByPDL() {
+    void testGetFindByCompletedByPDL() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfUser = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -871,7 +871,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         CheckIn checkIn2 = createACompletedCheckIn(memberProfileOfUser, memberProfileOfPDL);
         CheckIn checkIn3 = createACompletedCheckIn(memberProfileOfUser, memberProfileOfPDL);
 
-        final HttpRequest<?> request = HttpRequest.GET(String.format("/")).basicAuth(memberProfileOfUnrelatedUser.getWorkEmail(), role.getRole());
+        final HttpRequest<?> request = HttpRequest.GET("/").basicAuth(memberProfileOfUnrelatedUser.getWorkEmail(), role.getRole());
         final HttpResponse<Set<CheckIn>> response = client.toBlocking().exchange(request, Argument.setOf(CheckIn.class));
 
         Set<CheckIn> expected = new HashSet<>();
@@ -890,7 +890,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         MemberProfile memberProfileOfUnrelatedUser = createAnUnrelatedUser();
         Role role = assignMemberRole(memberProfileOfUnrelatedUser);
 
-        final HttpRequest<?> request = HttpRequest.GET(String.format("/")).basicAuth(memberProfileOfUnrelatedUser.getWorkEmail(), role.getRole());
+        final HttpRequest<?> request = HttpRequest.GET("/").basicAuth(memberProfileOfUnrelatedUser.getWorkEmail(), role.getRole());
 
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
@@ -898,7 +898,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
@@ -907,14 +907,14 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         MemberProfile memberProfileOfUnrelatedUser = createAnUnrelatedUser();
         Role role = assignPdlRole(memberProfileOfUnrelatedUser);
 
-        final HttpRequest<?> request = HttpRequest.GET(String.format("/")).basicAuth(memberProfileOfUnrelatedUser.getWorkEmail(), role.getRole());
+        final HttpRequest<?> request = HttpRequest.GET("/").basicAuth(memberProfileOfUnrelatedUser.getWorkEmail(), role.getRole());
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
 
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals(String.format("You are not authorized to perform this operation"), error);
+        assertEquals("You are not authorized to perform this operation", error);
     }
 
     @Test
@@ -944,7 +944,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
     }
 
     @Test
-    public void testCheckInDoesNotExistForCompleted() {
+    void testCheckInDoesNotExistForCompleted() {
 
         MemberProfile memberProfileOfUnrelatedUser = createAnUnrelatedUser();
         Role role = assignMemberRole(memberProfileOfUnrelatedUser);

--- a/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
@@ -30,7 +30,7 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMI
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DemographicsControllerTest extends TestContainersSuite implements DemographicsFixture, MemberProfileFixture, RoleFixture {
+class DemographicsControllerTest extends TestContainersSuite implements DemographicsFixture, MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/demographics")
@@ -41,7 +41,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testGetAllDemographicsUnauthorized() {
+    void testGetAllDemographicsUnauthorized() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET("/");
@@ -53,7 +53,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testPostUnauthorized() {
+    void testPostUnauthorized() {
         final MemberProfile alice = getMemberProfileRepository().save(mkMemberProfile("Alice"));
         DemographicsCreateDTO newDemographics = new DemographicsCreateDTO();
         newDemographics.setMemberId(alice.getId());
@@ -69,7 +69,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testGetAllDemographics() {
+    void testGetAllDemographics() {
 
         final MemberProfile alice = getMemberProfileRepository().save(mkMemberProfile("Alice"));
         createAndAssignAdminRole(alice);
@@ -95,7 +95,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testGETFindByValidGender() {
+    void testGETFindByValidGender() {
         final MemberProfile alice = getMemberProfileRepository().save(mkMemberProfile("Alice"));
         createAndAssignAdminRole(alice);
         Demographics demographic = createDefaultDemographics(alice.getId());
@@ -113,10 +113,10 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testGETFindByWrongNameReturnsEmptyBody() {
+    void testGETFindByWrongNameReturnsEmptyBody() {
         final MemberProfile alice = getMemberProfileRepository().save(mkMemberProfile("Alice"));
         createAndAssignAdminRole(alice);
-        Demographics demographic = createDefaultDemographics(alice.getId());
+        createDefaultDemographics(alice.getId());
 
         final HttpRequest<Object> request = HttpRequest.GET(String.format("/?gender=%s", encodeValue("random")))
                 .basicAuth(alice.getWorkEmail(), ADMIN_ROLE);
@@ -130,7 +130,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testPOSTCreateADemographics() {
+    void testPOSTCreateADemographics() {
         final MemberProfile alice = getMemberProfileRepository().save(mkMemberProfile("Alice"));
         createAndAssignAdminRole(alice);
 
@@ -149,7 +149,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testPOSTCreateADemographicsNoName() {
+    void testPOSTCreateADemographicsNoName() {
         final MemberProfile alice = getMemberProfileRepository().save(mkMemberProfile("Alice"));
         createAndAssignAdminRole(alice);
 
@@ -166,7 +166,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testPUTSuccessfulUpdate() {
+    void testPUTSuccessfulUpdate() {
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignAdminRole(lucy);
 
@@ -186,7 +186,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testPUTWrongId() {
+    void testPUTWrongId() {
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignAdminRole(lucy);
 
@@ -207,7 +207,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testPUTNoId() {
+    void testPUTNoId() {
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignAdminRole(lucy);
 
@@ -220,11 +220,11 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
-        assertEquals(responseException.getMessage(), "Bad Request");
+        assertEquals("Bad Request", responseException.getMessage());
     }
 
     @Test
-    public void testDELETEDemographics() {
+    void testDELETEDemographics() {
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignAdminRole(lucy);
 
@@ -239,11 +239,11 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testDELETEDemographicsWrongId() {
+    void testDELETEDemographicsWrongId() {
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignAdminRole(lucy);
 
-        Demographics demographic = createDefaultDemographics(lucy.getId());
+        createDefaultDemographics(lucy.getId());
 
         final HttpRequest<Object> request = HttpRequest.
                 DELETE(String.format("/%s", UUID.randomUUID())).basicAuth(lucy.getWorkEmail(), ADMIN_ROLE);
@@ -256,7 +256,7 @@ public class DemographicsControllerTest extends TestContainersSuite implements D
     }
 
     @Test
-    public void testDELETEDemographicsNoPermission() {
+    void testDELETEDemographicsNoPermission() {
         final MemberProfile lucy = getMemberProfileRepository().save(mkMemberProfile("Lucy"));
         createAndAssignRole(RoleType.MEMBER, lucy);
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
@@ -84,9 +84,9 @@ class DemographicsControllerTest extends TestContainersSuite implements Demograp
 
         StepVerifier.create(response)
                         .thenConsumeWhile(resp -> {
-                            assertEquals(resp.getStatus(), HttpStatus.OK);
-                            assertEquals(resp.body().get(0).getId(), demographic.getId());
-                            assertEquals(resp.body().size(), 1);
+                            assertEquals(HttpStatus.OK, resp.getStatus());
+                            assertEquals(demographic.getId(), resp.body().get(0).getId());
+                            assertEquals(1, resp.body().size());
                             return true;
                         })
                 .expectComplete()
@@ -108,8 +108,8 @@ class DemographicsControllerTest extends TestContainersSuite implements Demograp
 
 
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(response.body().get(0).getId(), demographic.getId());
-        assertEquals(response.body().size(), 1);
+        assertEquals(demographic.getId(), response.body().get(0).getId());
+        assertEquals(1, response.body().size());
     }
 
     @Test
@@ -125,8 +125,7 @@ class DemographicsControllerTest extends TestContainersSuite implements Demograp
                 .exchange(request, Argument.listOf(DemographicsResponseDTO.class));
 
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertNotNull(response.body());
-        assertEquals(response.body(), new ArrayList<>());
+        assertTrue(response.body().isEmpty(), "Should return an empty list");
     }
 
     @Test
@@ -144,7 +143,7 @@ class DemographicsControllerTest extends TestContainersSuite implements Demograp
         final HttpResponse<DemographicsResponseDTO> response = client.toBlocking().exchange(request,DemographicsResponseDTO.class);
 
         assertNotNull(response);
-        assertEquals(HttpStatus.CREATED,response.getStatus());
+        assertEquals(HttpStatus.CREATED, response.getStatus());
         assertEquals(newDemographics.getGender(), response.body().getGender());
     }
 
@@ -181,8 +180,7 @@ class DemographicsControllerTest extends TestContainersSuite implements Demograp
         final HttpResponse<DemographicsResponseDTO> response = client.toBlocking().exchange(request, DemographicsResponseDTO.class);
 
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(String.format("%s/%s", request.getPath(), updatedDemographics.getId()),
-                response.getHeaders().get("location"));
+        assertEquals(String.format("%s/%s", request.getPath(), updatedDemographics.getId()), response.getHeaders().get("location"));
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/email/EmailControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/email/EmailControllerTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class EmailControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class EmailControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/email")

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionsControllerTest.java
@@ -60,7 +60,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
 
         assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(response.getBody().get().size(), 2 );
+        assertEquals(2, response.getBody().get().size());
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
         assertContentEqualsEntity(idealTwo, response.getBody().get().get(1));
 
@@ -88,7 +88,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
 
         assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(response.getBody().get().size(), 2 );
+        assertEquals(2, response.getBody().get().size());
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
         assertContentEqualsEntity(idealTwo, response.getBody().get().get(1));
 
@@ -118,7 +118,7 @@ class FeedbackSuggestionsControllerTest extends TestContainersSuite implements M
 
         assertNotNull(response.getBody().get());
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(response.getBody().get().size(), 2 );
+        assertEquals(2, response.getBody().get().size());
         assertContentEqualsEntity(idealOne, response.getBody().get().get(0));
         assertContentEqualsEntity(idealTwo, response.getBody().get().get(1));
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FeedbackAnswerControllerTest extends TestContainersSuite implements FeedbackAnswerFixture, MemberProfileFixture, RoleFixture, FeedbackRequestFixture, FeedbackTemplateFixture, TemplateQuestionFixture {
+class FeedbackAnswerControllerTest extends TestContainersSuite implements FeedbackAnswerFixture, MemberProfileFixture, RoleFixture, FeedbackRequestFixture, FeedbackTemplateFixture, TemplateQuestionFixture {
 
     @Inject
     @Client("/services/feedback/answers")
@@ -42,7 +42,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         createAndAssignRoles();
     }
 
-    public FeedbackAnswer createSampleAnswer(MemberProfile sender, MemberProfile recipient) {
+    FeedbackAnswer createSampleAnswer(MemberProfile sender, MemberProfile recipient) {
         assignPdlRole(sender);
         MemberProfile requestee = createADefaultMemberProfileForPdl(sender);
         MemberProfile templateCreator = createADefaultSupervisor();
@@ -53,7 +53,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         return createSampleFeedbackAnswer(question.getId(), feedbackRequest.getId());
     }
 
-    public FeedbackAnswer saveSampleAnswer(MemberProfile sender, MemberProfile recipient) {
+    FeedbackAnswer saveSampleAnswer(MemberProfile sender, MemberProfile recipient) {
         FeedbackAnswer answer = createSampleAnswer(sender, recipient);
         return getFeedbackAnswerRepository().save(answer);
     }
@@ -75,13 +75,13 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         return dto;
     }
 
-    public void assertContentEqualsResponse(FeedbackAnswer content, FeedbackAnswerResponseDTO response) {
+    void assertContentEqualsResponse(FeedbackAnswer content, FeedbackAnswerResponseDTO response) {
         assertEquals(content.getAnswer(), response.getAnswer());
         assertEquals(content.getQuestionId(), response.getQuestionId());
         assertEquals(content.getSentiment(), response.getSentiment());
     }
 
-    public void assertUnauthorized(HttpClientResponseException exception) {
+    void assertUnauthorized(HttpClientResponseException exception) {
         assertEquals("You are not authorized to do this operation", exception.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerControllerTest.java
@@ -24,13 +24,13 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class QuestionAndAnswerControllerTest extends TestContainersSuite implements FeedbackAnswerFixture, TemplateQuestionFixture, MemberProfileFixture, FeedbackTemplateFixture, FeedbackRequestFixture, RoleFixture {
+class QuestionAndAnswerControllerTest extends TestContainersSuite implements FeedbackAnswerFixture, TemplateQuestionFixture, MemberProfileFixture, FeedbackTemplateFixture, FeedbackRequestFixture, RoleFixture {
 
     @Inject
     @Client("/services/feedback/questions-and-answers")
     public HttpClient client;
 
-    public void assertTupleEqualsEntity(QuestionAndAnswerServices.Tuple actual, QuestionAndAnswerServices.Tuple response) {
+    void assertTupleEqualsEntity(QuestionAndAnswerServices.Tuple actual, QuestionAndAnswerServices.Tuple response) {
         assertEquals(actual.getQuestion().getQuestion(), response.getQuestion().getQuestion());
         assertEquals(actual.getQuestion().getQuestionNumber(), response.getQuestion().getQuestionNumber());
         assertEquals(actual.getQuestion().getTemplateId(), response.getQuestion().getTemplateId());
@@ -51,7 +51,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
 
     }
 
-    public QuestionAndAnswerServices.Tuple saveSampleTuple(MemberProfile sender, MemberProfile recipient) {
+    QuestionAndAnswerServices.Tuple saveSampleTuple(MemberProfile sender, MemberProfile recipient) {
         MemberProfile requestee = createADefaultMemberProfileForPdl(sender);
         MemberProfile templateCreator = createADefaultSupervisor();
         FeedbackTemplate template = createFeedbackTemplate(templateCreator.getId());
@@ -63,7 +63,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
         return new QuestionAndAnswerServices.Tuple(question, answer);
     }
 
-    public QuestionAndAnswerServices.Tuple saveAnotherSampleTuple(MemberProfile sender, MemberProfile recipient) {
+    QuestionAndAnswerServices.Tuple saveAnotherSampleTuple(MemberProfile sender, MemberProfile recipient) {
         MemberProfile requestee = createASecondDefaultMemberProfileForPdl(sender);
         MemberProfile templateCreator = createANewHireProfile();
         FeedbackTemplate template = createFeedbackTemplate(templateCreator.getId());
@@ -76,7 +76,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGetExistingQuestionAndAnswerPermitted() {
+    void testGetExistingQuestionAndAnswerPermitted() {
         MemberProfile sender = createADefaultMemberProfile();
         createAndAssignRole(RoleType.PDL, sender);
         MemberProfile recipient = createADefaultRecipient();
@@ -92,7 +92,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGetQuestionAndRequestWhereAnswerNotSavedPermitted() {
+    void testGetQuestionAndRequestWhereAnswerNotSavedPermitted() {
         final MemberProfile sender = createADefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
         createAndAssignRole(RoleType.PDL, sender);
@@ -118,7 +118,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGetQuestionAndAnswerNotPermitted() {
+    void testGetQuestionAndAnswerNotPermitted() {
         MemberProfile sender = createADefaultMemberProfile();
         createAndAssignRole(RoleType.PDL, sender);
         MemberProfile recipient = createADefaultRecipient();
@@ -134,7 +134,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGetAllQuestionsAndAnswersPermitted() {
+    void testGetAllQuestionsAndAnswersPermitted() {
         MemberProfile sender = createADefaultMemberProfile();
         createAndAssignRole(RoleType.PDL, sender);
         MemberProfile recipient = createADefaultRecipient();
@@ -151,7 +151,7 @@ public class QuestionAndAnswerControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGetAllQuestionsAndAnswersNotPermitted() {
+    void testGetAllQuestionsAndAnswersNotPermitted() {
         MemberProfile sender = createADefaultMemberProfile();
         createAndAssignRole(RoleType.PDL, sender);
         MemberProfile recipient = createADefaultRecipient();

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
@@ -624,7 +624,7 @@ class FeedbackRequestControllerTest extends TestContainersSuite implements Membe
 
         assertEquals(HttpStatus.OK, response.getStatus());
         assertTrue(response.getBody().isPresent());
-        assertEquals(response.getBody().get().size(), 2);
+        assertEquals(2, response.getBody().get().size());
         assertResponseEqualsEntity(feedbackReq, response.getBody().get().get(0));
         assertResponseEqualsEntity(feedbackReqTwo, response.getBody().get().get(1));
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
@@ -33,7 +33,7 @@ import static com.objectcomputing.checkins.services.memberprofile.MemberProfileT
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class FeedbackRequestControllerTest extends TestContainersSuite implements MemberProfileFixture, FeedbackTemplateFixture, FeedbackRequestFixture, RoleFixture, ReviewPeriodFixture {
+class FeedbackRequestControllerTest extends TestContainersSuite implements MemberProfileFixture, FeedbackTemplateFixture, FeedbackRequestFixture, RoleFixture, ReviewPeriodFixture {
 
     @Inject
     @Client("/services/feedback/requests")
@@ -56,7 +56,6 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
         feedbackRequestServicesImpl.setEmailSender(emailSender);
         createAndAssignRoles();
     }
-
 
     private String createEmailContent(FeedbackRequest storedRequest, UUID requestId, MemberProfile creator, MemberProfile requestee){
         String newContent = "<h1>You have received a feedback request.</h1>" +
@@ -204,7 +203,7 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
     }
 
     @Test
-    public void testCreateFeedbackRequestSendsEmailFuture() {
+    void testCreateFeedbackRequestSendsEmailFuture() {
         //create two member profiles: one for normal employee, one for PDL of normal employee
         final MemberProfile pdlMemberProfile = createADefaultMemberProfile();
         assignPdlRole(pdlMemberProfile);
@@ -1397,7 +1396,7 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
         // Create two sample feedback requests by the same PDL
         FeedbackRequest feedbackReq = saveFeedbackRequest(pdlMemberProfile, memberOne, recipient);
         FeedbackRequest feedbackReqTwo = saveFeedbackRequest(pdlMemberProfile, memberTwo, recipient);
-        FeedbackRequest feedbackReqThree = saveFeedbackRequest(pdlMemberProfileTwo, memberThree, recipient);
+        saveFeedbackRequest(pdlMemberProfileTwo, memberThree, recipient);
 
         // Create a feedback request by a different PDL
         saveFeedbackRequest(pdlMemberProfileTwo, memberThree, recipient);

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateControllerTest.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class FeedbackTemplateControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, TemplateQuestionFixture, FeedbackTemplateFixture {
+class FeedbackTemplateControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, TemplateQuestionFixture, FeedbackTemplateFixture {
 
     @Inject
     @Client("/services/feedback/templates")

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionControllerTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import jakarta.inject.Inject;
 import java.util.*;
 
-public class TemplateQuestionControllerTest extends TestContainersSuite implements MemberProfileFixture, FeedbackTemplateFixture, TemplateQuestionFixture, RoleFixture {
+class TemplateQuestionControllerTest extends TestContainersSuite implements MemberProfileFixture, FeedbackTemplateFixture, TemplateQuestionFixture, RoleFixture {
 
     @Inject
     @Client("/services/feedback/template_questions")

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildTest.java
@@ -103,7 +103,7 @@ class GuildTest extends TestContainersSuite {
         guild.setName("");
 
         Set<ConstraintViolation<Guild>> violations = validator.validate(guild);
-        assertEquals(violations.size(), 1);
+        assertEquals(1, violations.size());
         for (ConstraintViolation<Guild> violation : violations) {
             assertEquals("must not be blank", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
@@ -149,8 +149,8 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request));
 
-        assertEquals(responseException.getMessage(), "At least one guild lead must be present in the guild at all times");
-        assertEquals(responseException.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals("At least one guild lead must be present in the guild at all times", responseException.getMessage());
+        assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
     }
 
     @Test
@@ -695,7 +695,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
 
         final List<GuildMemberHistory> entries = (List<GuildMemberHistory>) getGuildMemberHistoryRepository().findAll();
 
-        assertEquals(entries.get(0).getChange(),"Added");
+        assertEquals("Added", entries.get(0).getChange());
     }
 
     @Test
@@ -717,7 +717,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
 
         final List<GuildMemberHistory> entries = (List<GuildMemberHistory>) getGuildMemberHistoryRepository().findAll();
 
-        assertEquals(entries.get(0).getChange(),"Updated");
+        assertEquals("Updated", entries.get(0).getChange());
     }
 
     @Test
@@ -737,7 +737,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
 
         final List<GuildMemberHistory> entries = (List<GuildMemberHistory>) getGuildMemberHistoryRepository().findAll();
 
-        assertEquals(entries.get(0).getChange(),"Deleted");
+        assertEquals("Deleted", entries.get(0).getChange());
     }
 
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_role/MemberRoleControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_role/MemberRoleControllerTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MemberRoleControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class MemberRoleControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/roles/members")

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/MemberSkillServiceImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/MemberSkillServiceImplTest.java
@@ -87,9 +87,9 @@ class MemberSkillServiceImplTest extends TestContainersSuite {
         MemberSkill memberSkill = new MemberSkill(UUID.randomUUID(), UUID.randomUUID());
         Skill skill = new Skill();
 
-        when(skillRepository.findById(eq(memberSkill.getSkillid()))).thenReturn(Optional.of(skill));
-        when(memberProfileRepository.findById(eq(memberSkill.getMemberid()))).thenReturn(Optional.of(new MemberProfile()));
-        when(memberSkillRepository.save(eq(memberSkill))).thenReturn(memberSkill);
+        when(skillRepository.findById(memberSkill.getSkillid())).thenReturn(Optional.of(skill));
+        when(memberProfileRepository.findById(memberSkill.getMemberid())).thenReturn(Optional.of(new MemberProfile()));
+        when(memberSkillRepository.save(memberSkill)).thenReturn(memberSkill);
 
         assertEquals(memberSkill, memberSkillsServices.save(memberSkill));
 
@@ -147,9 +147,9 @@ class MemberSkillServiceImplTest extends TestContainersSuite {
     void testSaveMemberSkillAlreadyExistingSkill() {
         MemberSkill memberSkill = new MemberSkill(UUID.randomUUID(), UUID.randomUUID());
 
-        when(skillRepository.findById(eq(memberSkill.getSkillid()))).thenReturn(Optional.of(new Skill()));
-        when(memberProfileRepository.findById(eq(memberSkill.getMemberid()))).thenReturn(Optional.of(new MemberProfile()));
-        when(memberSkillRepository.findByMemberidAndSkillid(eq(memberSkill.getMemberid()), eq(memberSkill.getSkillid())))
+        when(skillRepository.findById(memberSkill.getSkillid())).thenReturn(Optional.of(new Skill()));
+        when(memberProfileRepository.findById(memberSkill.getMemberid())).thenReturn(Optional.of(new MemberProfile()));
+        when(memberSkillRepository.findByMemberidAndSkillid(memberSkill.getMemberid(), memberSkill.getSkillid()))
         .thenReturn(Optional.of(memberSkill));
 
         AlreadyExistsException exception = assertThrows(AlreadyExistsException.class, () -> memberSkillsServices.save(memberSkill));
@@ -166,8 +166,8 @@ class MemberSkillServiceImplTest extends TestContainersSuite {
     void testSaveMemberSkillNonExistingSkill() {
         MemberSkill memberSkill = new MemberSkill(UUID.randomUUID(), UUID.randomUUID());
 
-        when(skillRepository.findById(eq(memberSkill.getSkillid()))).thenReturn(Optional.empty());
-        when(memberProfileRepository.findById(eq(memberSkill.getMemberid()))).thenReturn(Optional.of(new MemberProfile()));
+        when(skillRepository.findById(memberSkill.getSkillid())).thenReturn(Optional.empty());
+        when(memberProfileRepository.findById(memberSkill.getMemberid())).thenReturn(Optional.of(new MemberProfile()));
 
         BadArgException exception = assertThrows(BadArgException.class, () -> memberSkillsServices.save(memberSkill));
         assertEquals(String.format("Skill %s doesn't exist", memberSkill.getSkillid()), exception.getMessage());
@@ -181,8 +181,8 @@ class MemberSkillServiceImplTest extends TestContainersSuite {
     void testSaveMemberSkillNonExistingMember() {
         MemberSkill memberSkill = new MemberSkill(UUID.randomUUID(), UUID.randomUUID());
 
-        when(skillRepository.findById(eq(memberSkill.getSkillid()))).thenReturn(Optional.of(new Skill()));
-        when(memberProfileRepository.findById(eq(memberSkill.getMemberid()))).thenReturn(Optional.empty());
+        when(skillRepository.findById(memberSkill.getSkillid())).thenReturn(Optional.of(new Skill()));
+        when(memberProfileRepository.findById(memberSkill.getMemberid())).thenReturn(Optional.empty());
 
         BadArgException exception = assertThrows(BadArgException.class, () -> memberSkillsServices.save(memberSkill));
         assertEquals(String.format("Member Profile %s doesn't exist", memberSkill.getMemberid()), exception.getMessage());

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/MemberSkillsCreateDTOTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/MemberSkillsCreateDTOTest.java
@@ -30,7 +30,7 @@ class MemberSkillsCreateDTOTest extends TestContainersSuite {
         MemberSkillCreateDTO dto = new MemberSkillCreateDTO();
 
         Set<ConstraintViolation<MemberSkillCreateDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 2);
+        assertEquals(2, violations.size());
         for (ConstraintViolation<MemberSkillCreateDTO> violation : violations) {
             assertEquals("must not be null", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportControllerTest.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SkillsReportControllerTest extends TestContainersSuite
+class SkillsReportControllerTest extends TestContainersSuite
         implements MemberSkillFixture, MemberProfileFixture, SkillFixture, RoleFixture {
 
     @Inject

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileControllerTest.java
@@ -28,7 +28,7 @@ import static com.objectcomputing.checkins.services.memberprofile.MemberProfileT
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MemberProfileControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture,
+class MemberProfileControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture,
     SkillFixture, MemberSkillFixture, TeamFixture, TeamMemberFixture, RoleFixture {
 
     @Inject
@@ -53,7 +53,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGETNonExistingEndpointReturns404() {
+    void testGETNonExistingEndpointReturns404() {
 
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
             client.toBlocking().exchange(HttpRequest.GET(String.valueOf(UUID.randomUUID()))
@@ -65,7 +65,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteThrowsExceptionWhenUserDoesNotExist() {
+    void testDeleteThrowsExceptionWhenUserDoesNotExist() {
 
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         assignAdminRole(memberProfileOfAdmin);
@@ -87,7 +87,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteThrowsExceptionIfCheckinDataExists() {
+    void testDeleteThrowsExceptionIfCheckinDataExists() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfMember = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -110,7 +110,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteThrowsExceptionIfMemberSkillExists() {
+    void testDeleteThrowsExceptionIfMemberSkillExists() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfMember = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -136,7 +136,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteThrowsExceptionIfMemberIsPartOfATeam() {
+    void testDeleteThrowsExceptionIfMemberIsPartOfATeam() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfMember = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -162,7 +162,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteThrowsExceptionIfMemberHasPDLRole() {
+    void testDeleteThrowsExceptionIfMemberHasPDLRole() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         assignPdlRole(memberProfileOfPDL);
@@ -186,7 +186,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteHappyPath() {
+    void testDeleteHappyPath() {
 
         MemberProfile memberProfileOfPDL = createADefaultMemberProfile();
         MemberProfile memberProfileOfMember = createADefaultMemberProfileForPdl(memberProfileOfPDL);
@@ -218,7 +218,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteNotAuthorized() {
+    void testDeleteNotAuthorized() {
         final HttpRequest<?> request = HttpRequest.DELETE("/01b7d769-9fa2-43ff-95c7-f3b950a27bf9")
             .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class,
@@ -228,7 +228,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testDeleteNoPermission() {
+    void testDeleteNoPermission() {
         MemberProfile pdlMember = createAnUnrelatedUser();
         assignPdlRole(pdlMember);
 
@@ -242,7 +242,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // Find By id - when no user data exists
     @Test
-    public void testGETFindByNameReturnsEmptyBody() throws UnsupportedEncodingException {
+    void testGETFindByNameReturnsEmptyBody() throws UnsupportedEncodingException {
 
         final HttpRequest<Object> request = HttpRequest.
             GET(String.format("/?name=%s", encodeValue("dnc"))).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -253,7 +253,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGETFindByValueName() throws UnsupportedEncodingException {
+    void testGETFindByValueName() throws UnsupportedEncodingException {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
         final HttpRequest<Object> request = HttpRequest.
@@ -266,7 +266,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGETGetByIdHappyPath() {
+    void testGETGetByIdHappyPath() {
 
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -280,7 +280,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testGETGetByIdNotFound() {
+    void testGETGetByIdNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
             GET(String.format("/%s", UUID.randomUUID().toString())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -341,7 +341,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPOSTCreateAMemberProfileAdmin() {
+    void testPOSTCreateAMemberProfileAdmin() {
 
         MemberProfile admin = createADefaultMemberProfile();
         assignAdminRole(admin);
@@ -360,7 +360,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPOSTCreateAMemberProfileMemberUnauthorized() {
+    void testPOSTCreateAMemberProfileMemberUnauthorized() {
 
         MemberProfile member = createADefaultMemberProfile();
         assignMemberRole(member);
@@ -376,7 +376,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPOSTCreateAMemberProfilePdlUnauthorized() {
+    void testPOSTCreateAMemberProfilePdlUnauthorized() {
 
         MemberProfile pdl = createADefaultMemberProfile();
         assignPdlRole(pdl);
@@ -397,7 +397,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPOSTCreateANullMemberProfile() {
+    void testPOSTCreateANullMemberProfile() {
         MemberProfile admin = createADefaultMemberProfile();
         assignAdminRole(admin);
 
@@ -414,7 +414,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // Find By id - when no user data exists for POST
     @Test
-    public void testPostValidationFailures() {
+    void testPostValidationFailures() {
         MemberProfile admin = createADefaultMemberProfile();
         assignAdminRole(admin);
 
@@ -431,7 +431,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPOSTSaveMemberSameEmailThrowsException() {
+    void testPOSTSaveMemberSameEmailThrowsException() {
         MemberProfile admin = createADefaultMemberProfile();
         assignAdminRole(admin);
 
@@ -461,7 +461,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPUTUpdateMemberProfile() {
+    void testPUTUpdateMemberProfile() {
 
         MemberProfileUpdateDTO profileUpdateDTO = mkUpdateMemberProfileDTO();
 
@@ -476,7 +476,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPUTUpdateNonexistentMemberProfile() {
+    void testPUTUpdateNonexistentMemberProfile() {
 
         MemberProfileCreateDTO memberProfileCreateDTO = new MemberProfileCreateDTO();
         memberProfileCreateDTO.setFirstName("reincarnation");
@@ -492,7 +492,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testPUTUpdateNullMemberProfile() {
+    void testPUTUpdateNullMemberProfile() {
 
         final HttpRequest<String> request = HttpRequest.PUT("", "").basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
@@ -504,7 +504,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // POST - Future Start Date
     @Test
-    public void testPostForFutureStartDate() {
+    void testPostForFutureStartDate() {
         MemberProfile admin = createADefaultMemberProfile();
         assignAdminRole(admin);
 
@@ -525,7 +525,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // POST - NotBlank MemberProfile first name (and last name)
     @Test
-    public void testPostWithNullName() {
+    void testPostWithNullName() {
         MemberProfile admin = createADefaultMemberProfile();
         assignAdminRole(admin);
 
@@ -542,7 +542,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // Find By id - when no user data exists for PUT
     @Test
-    public void testPutValidationFailures() {
+    void testPutValidationFailures() {
 
         final HttpRequest<MemberProfileUpdateDTO> request = HttpRequest.PUT("", new MemberProfileUpdateDTO())
             .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -558,7 +558,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // PUT - Future Start Date
     @Test
-    public void testPutFutureStartDate() {
+    void testPutFutureStartDate() {
 
         MemberProfileUpdateDTO requestBody = mkUpdateMemberProfileDTO();
         requestBody.setStartDate(maxDate);
@@ -574,7 +574,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
 
     // PUT - Request with empty body
     @Test
-    public void testPutUpdateForEmptyInput() {
+    void testPutUpdateForEmptyInput() {
         MemberProfileUpdateDTO testMemberProfile = mkUpdateMemberProfileDTO();
         testMemberProfile.setId(null);
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(HttpRequest.PUT("", testMemberProfile)
@@ -586,7 +586,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testMemberProfileWithNullTerminationDate() {
+    void testMemberProfileWithNullTerminationDate() {
         MemberProfile memberProfile = createADefaultMemberProfile();
         final HttpResponse<List < MemberProfileResponseDTO >> response = client
             .toBlocking()
@@ -600,7 +600,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testMemberProfileWithUpcomingTerminationDate() {
+    void testMemberProfileWithUpcomingTerminationDate() {
         MemberProfile memberProfile = createAFutureTerminatedMemberProfile();
 
         final HttpResponse<List < MemberProfileResponseDTO >> response = client
@@ -615,7 +615,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testMemberProfileWithPreviousTerminationDate() {
+    void testMemberProfileWithPreviousTerminationDate() {
         MemberProfile memberProfile = createAPastTerminatedMemberProfile();
 
         final HttpResponse<List <MemberProfileResponseDTO >> response = client
@@ -629,7 +629,7 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
     }
 
     @Test
-    public void testMemberProfileWithPreviousTerminationDateReturnsWhenTerminatedTrue() {
+    void testMemberProfileWithPreviousTerminationDateReturnsWhenTerminatedTrue() {
         MemberProfile memberProfile = createAPastTerminatedMemberProfile();
 
         final HttpResponse<List <MemberProfileResponseDTO >> response = client
@@ -642,5 +642,4 @@ public class MemberProfileControllerTest extends TestContainersSuite implements 
         assertEquals(1, body.size());
         assertProfilesEqual(memberProfile, Objects.requireNonNull(body.get(0)));
     }
-
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/anniversaryreport/AnniversaryReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/anniversaryreport/AnniversaryReportControllerTest.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class AnniversaryReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class AnniversaryReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/reports/anniversaries")
@@ -41,7 +41,7 @@ public class AnniversaryReportControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGETFindByMonthReturnsEmptyBody() throws UnsupportedEncodingException {
+    void testGETFindByMonthReturnsEmptyBody() throws UnsupportedEncodingException {
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         assignAdminRole(memberProfileOfAdmin);
 
@@ -55,7 +55,7 @@ public class AnniversaryReportControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGETFindByMonthNotAuthorized() throws UnsupportedEncodingException {
+    void testGETFindByMonthNotAuthorized() throws UnsupportedEncodingException {
         MemberProfile memberProfile = createAnUnrelatedUser();
         assignMemberRole(memberProfile);
 
@@ -72,7 +72,7 @@ public class AnniversaryReportControllerTest extends TestContainersSuite impleme
     }
 
     @Test
-    public void testGETFindByNoValue() {
+    void testGETFindByNoValue() {
 
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         assignAdminRole(memberProfileOfAdmin);

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/birthday/BirthDayControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/birthday/BirthDayControllerTest.java
@@ -23,7 +23,7 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMB
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class BirthDayControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class BirthDayControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/reports/birthdays")
@@ -35,7 +35,7 @@ public class BirthDayControllerTest extends TestContainersSuite implements Membe
     }
 
     @Test
-    public void testGETFindByValueNameOfTheMonth() {
+    void testGETFindByValueNameOfTheMonth() {
 
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         assignAdminRole(memberProfileOfAdmin);
@@ -52,7 +52,7 @@ public class BirthDayControllerTest extends TestContainersSuite implements Membe
     }
 
     @Test
-    public void testGETFindByValueNameOfTheMonthAndDay() {
+    void testGETFindByValueNameOfTheMonthAndDay() {
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         assignAdminRole(memberProfileOfAdmin);
 
@@ -69,7 +69,7 @@ public class BirthDayControllerTest extends TestContainersSuite implements Membe
     }
 
     @Test
-    public void testGETFindByValueNameOfTheMonthNotAuthorized() {
+    void testGETFindByValueNameOfTheMonthNotAuthorized() {
 
         MemberProfile memberProfile = createADefaultMemberProfileWithBirthDay();
         final HttpRequest<Object> request = HttpRequest.

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportControllerTest.java
@@ -23,7 +23,8 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMI
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MemberProfileReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class MemberProfileReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+
     @Inject
     @Client("/services/reports/member")
     private HttpClient client;
@@ -34,7 +35,7 @@ public class MemberProfileReportControllerTest extends TestContainersSuite imple
     }
 
     @Test
-    public void testGetReportWithAllMemberProfiles() {
+    void testGetReportWithAllMemberProfiles() {
         MemberProfile member1 = createADefaultMemberProfile();
         MemberProfile member2 = createASecondDefaultMemberProfile();
         MemberProfile member3 = createADefaultMemberProfileForPdl(member1);
@@ -50,7 +51,7 @@ public class MemberProfileReportControllerTest extends TestContainersSuite imple
     }
 
     @Test
-    public void testGetReportWithSelectedMemberProfiles() {
+    void testGetReportWithSelectedMemberProfiles() {
         MemberProfile member1 = createADefaultMemberProfile();
         MemberProfile member2 = createASecondDefaultMemberProfile();
         MemberProfile member3 = createADefaultMemberProfileForPdl(member1);
@@ -69,7 +70,7 @@ public class MemberProfileReportControllerTest extends TestContainersSuite imple
     }
 
     @Test
-    public void testGetReportNotAuthorized() {
+    void testGetReportNotAuthorized() {
         HttpRequest<?> request = HttpRequest
                 .POST("/", null)
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -80,7 +81,7 @@ public class MemberProfileReportControllerTest extends TestContainersSuite imple
     }
 
     @Test
-    public void testGetAllMemberProfileRecords() {
+    void testGetAllMemberProfileRecords() {
         MemberProfile member1 = createADefaultMemberProfile();
         MemberProfile member2 = createASecondDefaultMemberProfile();
         MemberProfile member3 = createADefaultMemberProfileForPdl(member1);
@@ -96,7 +97,7 @@ public class MemberProfileReportControllerTest extends TestContainersSuite imple
     }
 
     @Test
-    public void testGetSelectedMemberProfileRecords() {
+    void testGetSelectedMemberProfileRecords() {
         MemberProfile member1 = createADefaultMemberProfile();
         MemberProfile member2 = createASecondDefaultMemberProfile();
         MemberProfile member3 = createADefaultMemberProfileForPdl(member1);
@@ -139,5 +140,4 @@ public class MemberProfileReportControllerTest extends TestContainersSuite imple
             assertEquals(supervisor.getWorkEmail(), record.getSupervisorEmail());
         }
     }
-
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServicesImplTest.java
@@ -81,7 +81,7 @@ class MemberProfileReportServicesImplTest extends TestContainersSuite {
         List<MemberProfileRecord> allRecords = createSampleRecords();
         MemberProfileRecord expectedRecord = allRecords.get(1);
         when(memberProfileReportRepository
-                .findAllByMemberIds(eq(List.of(expectedRecord.getId().toString()))))
+                .findAllByMemberIds(List.of(expectedRecord.getId().toString())))
                 .thenReturn(List.of(expectedRecord));
         File tmpFile = File.createTempFile("member",".csv");
         tmpFile.deleteOnExit();
@@ -104,7 +104,7 @@ class MemberProfileReportServicesImplTest extends TestContainersSuite {
         List<MemberProfileRecord> allRecords = createSampleRecords();
         MemberProfileRecord expectedRecord = allRecords.get(1);
         when(memberProfileReportRepository
-                .findAllByMemberIds(eq(List.of(expectedRecord.getId().toString()))))
+                .findAllByMemberIds(List.of(expectedRecord.getId().toString())))
                 .thenReturn(List.of(expectedRecord));
 
         when(memberProfileFileProvider.provideFile()).thenThrow(new RuntimeException());

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/currentuser/CurrentUserDtoTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/currentuser/CurrentUserDtoTest.java
@@ -31,7 +31,7 @@ class CurrentUserDtoTest extends TestContainersSuite {
         CurrentUserDTO dto = new CurrentUserDTO();
 
         Set<ConstraintViolation<CurrentUserDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 4);
+        assertEquals(4, violations.size());
         int nullViolations = 0, blankViolations = 0;
         for (ConstraintViolation<CurrentUserDTO> violation : violations) {
             if (violation.getMessage().equals("must not be null")) {

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/retentionreport/RetentionReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/retentionreport/RetentionReportControllerTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class RetentionReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class RetentionReportControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/reports/retention")

--- a/server/src/test/java/com/objectcomputing/checkins/services/permissions/PermissionControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/permissions/PermissionControllerTest.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PermissionControllerTest extends TestContainersSuite implements PermissionFixture, MemberProfileFixture, RoleFixture {
+class PermissionControllerTest extends TestContainersSuite implements PermissionFixture, MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/permissions")

--- a/server/src/test/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseCreateDTOTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseCreateDTOTest.java
@@ -35,7 +35,7 @@ class PulseResponseCreateDTOTest extends TestContainersSuite {
         PulseResponseCreateDTO dto = new PulseResponseCreateDTO();
 
         Set<ConstraintViolation<PulseResponseCreateDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 3);
+        assertEquals(3, violations.size());
         for (ConstraintViolation<PulseResponseCreateDTO> violation : violations) {
             assertEquals("must not be null", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentControllerTest.java
@@ -25,7 +25,7 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMI
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ReviewAssignmentControllerTest extends TestContainersSuite implements ReviewAssignmentFixture, ReviewPeriodFixture, MemberProfileFixture, RoleFixture {
+class ReviewAssignmentControllerTest extends TestContainersSuite implements ReviewAssignmentFixture, ReviewPeriodFixture, MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/review-assignments")
@@ -41,7 +41,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPOSTCreateAReviewAssignment() {
+    void testPOSTCreateAReviewAssignment() {
         ReviewAssignmentDTO reviewAssignmentDTO = new ReviewAssignmentDTO();
         reviewAssignmentDTO.setRevieweeId(UUID.randomUUID());
         reviewAssignmentDTO.setReviewerId(UUID.randomUUID());
@@ -64,7 +64,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPOSTCreateMultipleReviewAssignments() {
+    void testPOSTCreateMultipleReviewAssignments() {
         ReviewPeriod reviewPeriod = createADefaultReviewPeriod();
 
         ReviewAssignmentDTO reviewAssignmentDTO = new ReviewAssignmentDTO();
@@ -113,7 +113,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETGetByIdHappyPath() {
+    void testGETGetByIdHappyPath() {
         ReviewAssignment reviewAssignment = createADefaultReviewAssignment();
 
         final HttpRequest<Object> request = HttpRequest.
@@ -126,7 +126,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETFindAssignmentsByPeriodIdDefaultAssignments() {
+    void testGETFindAssignmentsByPeriodIdDefaultAssignments() {
         ReviewPeriod reviewPeriod = createADefaultReviewPeriod();
         MemberProfile supervisor = createADefaultSupervisor();
         MemberProfile anotherSupervisor = createAnotherSupervisor();
@@ -155,7 +155,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testGETFindAssignmentsByPeriodIdWithoutPermissions() {
+    void testGETFindAssignmentsByPeriodIdWithoutPermissions() {
         ReviewPeriod reviewPeriod = createADefaultReviewPeriod();
         MemberProfile supervisor = createADefaultSupervisor();
         MemberProfile anotherSupervisor = createAnotherSupervisor();
@@ -166,9 +166,9 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
         MemberProfile pdlMemberProfileTwo = createASecondDefaultMemberProfile();
         assignPdlRole(pdlMemberProfileTwo);
 
-        MemberProfile memberOne = createAProfileWithSupervisorAndPDL(supervisor, pdlMemberProfile);
-        MemberProfile memberTwo = createAnotherProfileWithSupervisorAndPDL(supervisor, pdlMemberProfileTwo);
-        MemberProfile memberThree = createYetAnotherProfileWithSupervisorAndPDL(anotherSupervisor, pdlMemberProfileTwo);
+        createAProfileWithSupervisorAndPDL(supervisor, pdlMemberProfile);
+        createAnotherProfileWithSupervisorAndPDL(supervisor, pdlMemberProfileTwo);
+        createYetAnotherProfileWithSupervisorAndPDL(anotherSupervisor, pdlMemberProfileTwo);
 
         final HttpRequest<Object> request = HttpRequest.
             GET(String.format("/period/%s", reviewPeriod.getId())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -181,7 +181,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
 
 
     @Test
-    public void testGETFindAssignmentsByPeriodIdNoReviewer() {
+    void testGETFindAssignmentsByPeriodIdNoReviewer() {
         ReviewPeriod reviewPeriod = createADefaultReviewPeriod();
         MemberProfile supervisor = createADefaultSupervisor();
         MemberProfile member = createAProfileWithSupervisorAndPDL(supervisor, supervisor);
@@ -200,9 +200,8 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
         assertEquals(HttpStatus.OK, response.getStatus());
     }
 
-
     @Test
-    public void testGETFindAssignmentsByPeriodIdWithReviewer() {
+    void testGETFindAssignmentsByPeriodIdWithReviewer() {
         ReviewPeriod reviewPeriod = createADefaultReviewPeriod();
         MemberProfile supervisor = createADefaultSupervisor();
         MemberProfile member = createAProfileWithSupervisorAndPDL(supervisor, supervisor);
@@ -225,10 +224,8 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
         assertEquals(HttpStatus.OK, response.getStatus());
     }
 
-
-
     @Test
-    public void testPUTUpdateReviewAssignmentWithoutPermissions() {
+    void testPUTUpdateReviewAssignmentWithoutPermissions() {
         ReviewAssignment reviewAssignment = createADefaultReviewAssignment();
 
         final HttpRequest<ReviewAssignment> request = HttpRequest.PUT("/", reviewAssignment)
@@ -241,7 +238,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPUTUpdateNonexistentReviewAssignment() {
+    void testPUTUpdateNonexistentReviewAssignment() {
         ReviewAssignment reviewAssignment = new ReviewAssignment();
         reviewAssignment.setId(UUID.randomUUID());
         reviewAssignment.setRevieweeId(UUID.randomUUID());
@@ -257,7 +254,7 @@ public class ReviewAssignmentControllerTest extends TestContainersSuite implemen
     }
 
     @Test
-    public void testPUTUpdateNullReviewAssignment() {
+    void testPUTUpdateNullReviewAssignment() {
         final HttpRequest<String> request = HttpRequest.PUT("", "").basicAuth(ADMIN_ROLE, ADMIN_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
             () -> client.toBlocking().exchange(request, Map.class));

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/RoleCreateDTOTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/RoleCreateDTOTest.java
@@ -26,7 +26,7 @@ class RoleCreateDTOTest extends TestContainersSuite {
         RoleCreateDTO dto = new RoleCreateDTO();
 
         Set<ConstraintViolation<RoleCreateDTO>> violations = validator.validate(dto);
-        assertEquals(violations.size(), 1);
+        assertEquals(1, violations.size());
         for (ConstraintViolation<RoleCreateDTO> violation : violations) {
             assertEquals("must not be null", violation.getMessage());
         }

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
@@ -5,11 +5,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class RoleTypeTest {
+class RoleTypeTest {
 
     @Test
     void testConstants() {
-        RoleType.Constants dnc = new RoleType.Constants(); // Test coverage hack to get to 100%
         assertEquals(RoleType.Constants.PDL_ROLE, RoleType.PDL.name());
         assertEquals(RoleType.Constants.MEMBER_ROLE, RoleType.MEMBER.name());
         assertEquals(RoleType.Constants.ADMIN_ROLE, RoleType.ADMIN.name());

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
@@ -17,7 +17,7 @@ class RoleTypeTest {
     @Test
     void testValues() {
         RoleType[] roles = RoleType.values();
-        assertEquals(roles.length, 3);
+        assertEquals(3, roles.length);
         for (RoleType roleType : roles) {
             switch (roleType) {
                 case PDL:

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/role_permissions/RolePermissionsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/role_permissions/RolePermissionsControllerTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RolePermissionsControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, PermissionFixture {
+class RolePermissionsControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, PermissionFixture {
 
     @Inject
     @Client("/services/roles/role-permissions")

--- a/server/src/test/java/com/objectcomputing/checkins/services/settings/SettingsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/settings/SettingsControllerTest.java
@@ -74,8 +74,8 @@ class SettingsControllerTest extends TestContainersSuite implements RoleFixture,
                 .exchange(request, Argument.listOf(SettingsResponseDTO.class));
 
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(response.body().get(0).getId(), setting.getId());
-        assertEquals(response.body().size(), 1);
+        assertEquals(setting.getId(), response.body().get(0).getId());
+        assertEquals(1, response.body().size());
     }
 
     @Test
@@ -241,7 +241,7 @@ class SettingsControllerTest extends TestContainersSuite implements RoleFixture,
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
-        assertEquals(responseException.getMessage(), "Bad Request");
+        assertEquals("Bad Request", responseException.getMessage());
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/skill_record/SkillRecordControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skill_record/SkillRecordControllerTest.java
@@ -31,7 +31,7 @@ class SkillRecordControllerTest extends TestContainersSuite implements RoleFixtu
     }
 
     @Test
-    public void testGetSuccess() {
+    void testGetSuccess() {
         HttpRequest<?> request = HttpRequest
                 .GET("/csv")
                 .basicAuth(ADMIN_ROLE, ADMIN_ROLE);
@@ -42,7 +42,7 @@ class SkillRecordControllerTest extends TestContainersSuite implements RoleFixtu
     }
 
     @Test
-    public void testGetNotAllowed() {
+    void testGetNotAllowed() {
         HttpRequest<?> request = HttpRequest
                 .GET("/csv")
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);

--- a/server/src/test/java/com/objectcomputing/checkins/services/skillcategory/SkillCategoryControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skillcategory/SkillCategoryControllerTest.java
@@ -19,7 +19,7 @@ import java.util.*;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SkillCategoryControllerTest extends TestContainersSuite
+class SkillCategoryControllerTest extends TestContainersSuite
         implements SkillCategoryFixture, SkillFixture, SkillCategorySkillFixture, RoleFixture {
 
     @Inject
@@ -32,7 +32,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPost() {
+    void testPost() {
         SkillCategoryCreateDTO createDTO = new SkillCategoryCreateDTO();
         createDTO.setName("Languages");
         createDTO.setDescription("Programming Languages");
@@ -52,7 +52,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testCreateSkillCategoryAlreadyExists() {
+    void testCreateSkillCategoryAlreadyExists() {
         SkillCategory existingCategory = createDefaultSkillCategory();
 
         SkillCategoryCreateDTO createDTO = new SkillCategoryCreateDTO();
@@ -68,7 +68,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testCreateNotAllowed() {
+    void testCreateNotAllowed() {
         SkillCategoryCreateDTO createDTO = new SkillCategoryCreateDTO();
 
         final HttpRequest<SkillCategoryCreateDTO> request = HttpRequest
@@ -81,7 +81,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testUpdateSkillCategory() {
+    void testUpdateSkillCategory() {
         SkillCategory existingCategory = createDefaultSkillCategory();
 
         SkillCategoryUpdateDTO updateDTO = new SkillCategoryUpdateDTO();
@@ -98,7 +98,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testUpdateNotAllowed() {
+    void testUpdateNotAllowed() {
         SkillCategoryUpdateDTO updateDTO = new SkillCategoryUpdateDTO();
 
         final HttpRequest<SkillCategoryUpdateDTO> request = HttpRequest
@@ -111,7 +111,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testUpdateSkillCategoryIdDoesNotExist() {
+    void testUpdateSkillCategoryIdDoesNotExist() {
         SkillCategory existingCategory = createDefaultSkillCategory();
         SkillCategoryUpdateDTO updateDTO = new SkillCategoryUpdateDTO();
         updateDTO.setId(UUID.randomUUID());
@@ -128,7 +128,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testUpdateSkillCategory_nameAlreadyExists() {
+    void testUpdateSkillCategory_nameAlreadyExists() {
         SkillCategory existingCategory1 = createDefaultSkillCategory();
         SkillCategory another = createAnotherSkillCategory();
 
@@ -145,7 +145,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testGetByIdHappyPath() {
+    void testGetByIdHappyPath() {
         SkillCategory skillCategory = createDefaultSkillCategory();
         Skill skill = createADefaultSkill();
         Skill skill2 = createASecondarySkill();
@@ -167,7 +167,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testGetByIdNotAllowed() {
+    void testGetByIdNotAllowed() {
         final HttpRequest<Object> request = HttpRequest
                 .GET(String.format("/%s", UUID.randomUUID()))
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -179,7 +179,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testGetByIdNotFound() {
+    void testGetByIdNotFound() {
         final HttpRequest<?> request = HttpRequest
                 .GET(String.format("/%s", UUID.randomUUID()))
                 .basicAuth(ADMIN_ROLE, ADMIN_ROLE);
@@ -191,7 +191,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testFindAllWithSkills() {
+    void testFindAllWithSkills() {
         SkillCategory skillCategory = createDefaultSkillCategory();
         Skill skill = createADefaultSkill();
         createSkillCategorySkill(skillCategory.getId(), skill.getId());
@@ -213,7 +213,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testFindAllWithSkillsAlphabetical() {
+    void testFindAllWithSkillsAlphabetical() {
         // If properly sorted, "Languages" should come before "Libraries" despite having a different order in the database
         SkillCategory librariesCategory = createAnotherSkillCategory();
         SkillCategory languagesCategory = createDefaultSkillCategory();
@@ -237,7 +237,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testFindAllNotAllowed() {
+    void testFindAllNotAllowed() {
         final HttpRequest<Object> request = HttpRequest
                 .GET("/with-skills")
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -249,7 +249,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testFindAllWithoutSkills() {
+    void testFindAllWithoutSkills() {
         SkillCategory skillCategory = createDefaultSkillCategory();
 
         List<SkillCategoryResponseDTO> expectedList = new ArrayList<>();
@@ -269,7 +269,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testDeleteAllInCategory() {
+    void testDeleteAllInCategory() {
         SkillCategory category = createDefaultSkillCategory();
         Skill skill = createADefaultSkill();
         Skill skill2 = createASecondarySkill();
@@ -286,7 +286,7 @@ public class SkillCategoryControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testDeleteNotAllowed() {
+    void testDeleteNotAllowed() {
         final HttpRequest<?> request = HttpRequest
                 .DELETE(String.format("/%s", UUID.randomUUID()))
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);

--- a/server/src/test/java/com/objectcomputing/checkins/services/skillcategory/skillcategory_skill/SkillCategorySkillControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skillcategory/skillcategory_skill/SkillCategorySkillControllerTest.java
@@ -38,7 +38,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testCreate() {
+    void testCreate() {
         SkillCategory defaultSkillCategory = createDefaultSkillCategory();
         Skill aDefaultSkill = createADefaultSkill();
         SkillCategorySkill skillCategorySkill = new SkillCategorySkill(defaultSkillCategory.getId(),aDefaultSkill.getId());
@@ -54,7 +54,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testCreateFail() {
+    void testCreateFail() {
         Skill aDefaultSkill = createADefaultSkill();
         createDefaultSkillCategory();
         UUID id = UUID.randomUUID();
@@ -69,7 +69,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testCreateNullIds() {
+    void testCreateNullIds() {
         createADefaultSkill();
         createDefaultSkillCategory();
         SkillCategorySkill skillCategorySkill = new SkillCategorySkill(null, null);
@@ -83,7 +83,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testCreateNotAllowed() {
+    void testCreateNotAllowed() {
         HttpRequest<SkillCategorySkillId> httpRequest = HttpRequest
                 .POST("/", new SkillCategorySkillId())
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -94,7 +94,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testDelete() {
+    void testDelete() {
         SkillCategory defaultSkillCategory = createDefaultSkillCategory();
         Skill aDefaultSkill = createADefaultSkill();
         SkillCategorySkill skillCategorySkill = createSkillCategorySkill(defaultSkillCategory.getId(), aDefaultSkill.getId());
@@ -111,7 +111,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
 
 
     @Test
-    public void testDeleteDontExist() {
+    void testDeleteDontExist() {
         SkillCategorySkillId skillCategorySkillId =  new SkillCategorySkillId(UUID.randomUUID(),UUID.randomUUID());
         HttpRequest<SkillCategorySkillId> httpRequest = HttpRequest
                 .DELETE("/", skillCategorySkillId)
@@ -122,7 +122,7 @@ class SkillCategorySkillControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testDeleteNotAllowed() {
+    void testDeleteNotAllowed() {
         HttpRequest<SkillCategorySkillId> httpRequest = HttpRequest
                 .DELETE("/", new SkillCategorySkillId())
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);

--- a/server/src/test/java/com/objectcomputing/checkins/services/skills/SkillControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skills/SkillControllerTest.java
@@ -25,7 +25,7 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMI
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SkillControllerTest extends TestContainersSuite implements SkillFixture, MemberProfileFixture, RoleFixture {
+class SkillControllerTest extends TestContainersSuite implements SkillFixture, MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/skills")
@@ -36,7 +36,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testGETNonExistingEndpointReturns404() {
+    void testGETNonExistingEndpointReturns404() {
 
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
             client.toBlocking().exchange(HttpRequest.GET("/12345678-9123-4567-abcd-123456789abc")
@@ -48,7 +48,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testGETFindByNameReturnsEmptyBody() {
+    void testGETFindByNameReturnsEmptyBody() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/?name=%s", encodeValue("dnc"))).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -60,7 +60,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testGETFindByValueName() {
+    void testGETFindByValueName() {
 
         Skill skill = createADefaultSkill();
         final HttpRequest<Object> request = HttpRequest.
@@ -74,7 +74,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testGETFindByValuePending() {
+    void testGETFindByValuePending() {
 
         Skill skill = createADefaultSkill();
         final HttpRequest<Object> request = HttpRequest.
@@ -88,7 +88,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testGETGetByIdHappyPath() {
+    void testGETGetByIdHappyPath() {
 
         Skill skill = createADefaultSkill();
 
@@ -103,7 +103,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testGETGetByIdNotFound() {
+    void testGETGetByIdNotFound() {
 
         final HttpRequest<Object> request = HttpRequest.
                 GET(String.format("/%s", UUID.randomUUID().toString())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
@@ -117,7 +117,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPOSTCreateASkill() {
+    void testPOSTCreateASkill() {
 
         SkillCreateDTO skillCreateDTO = new SkillCreateDTO();
         skillCreateDTO.setName("reincarnation");
@@ -138,7 +138,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPOSTCreateASkillAlreadyExists() {
+    void testPOSTCreateASkillAlreadyExists() {
 
         Skill skill = createADefaultSkill();
         SkillCreateDTO skillCreateDTO = new SkillCreateDTO();
@@ -156,7 +156,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPOSTCreateASkillAlreadyExistsWhenPending() {
+    void testPOSTCreateASkillAlreadyExistsWhenPending() {
 
         Skill skill = createADefaultSkill();
         SkillCreateDTO skillCreateDTO = new SkillCreateDTO();
@@ -174,7 +174,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPOSTCreateANullSkill() {
+    void testPOSTCreateANullSkill() {
 
         SkillCreateDTO skillCreateDTO = new SkillCreateDTO();
 
@@ -207,7 +207,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPUTUpdateSkillNonAdmin() {
+    void testPUTUpdateSkillNonAdmin() {
 
         Skill skill = createADefaultSkill();
 
@@ -221,7 +221,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPUTUpdateNonexistentSkill() {
+    void testPUTUpdateNonexistentSkill() {
 
         MemberProfile memberProfileOfAdmin = createAnUnrelatedUser();
         createAndAssignAdminRole(memberProfileOfAdmin);
@@ -241,7 +241,7 @@ public class SkillControllerTest extends TestContainersSuite implements SkillFix
     }
 
     @Test
-    public void testPUTUpdateNullSkill() {
+    void testPUTUpdateNullSkill() {
 
         final HttpRequest<String> request = HttpRequest.PUT("", "").basicAuth(ADMIN_ROLE, ADMIN_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,

--- a/server/src/test/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillsControllerTest.java
@@ -139,7 +139,7 @@ class CombineSkillsControllerTest extends TestContainersSuite
     }
 
     @Test
-    public void testPOSTCombineNonExistingSkillNameAdmin() {
+    void testPOSTCombineNonExistingSkillNameAdmin() {
 
         UUID[] newSkillsArray = new UUID[2];
         newSkillsArray[0] = UUID.randomUUID();

--- a/server/src/test/java/com/objectcomputing/checkins/services/tags/EntityTagControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/tags/EntityTagControllerTest.java
@@ -28,7 +28,7 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMB
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class EntityTagControllerTest extends TestContainersSuite implements EntityTagFixture, TagFixture, MemberProfileFixture, RoleFixture {
+class EntityTagControllerTest extends TestContainersSuite implements EntityTagFixture, TagFixture, MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/entity-tags")

--- a/server/src/test/java/com/objectcomputing/checkins/services/tags/TagControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/tags/TagControllerTest.java
@@ -27,7 +27,7 @@ import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMB
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TagControllerTest extends TestContainersSuite implements TagFixture, RoleFixture, MemberProfileFixture {
+class TagControllerTest extends TestContainersSuite implements TagFixture, RoleFixture, MemberProfileFixture {
 
     @Inject
     @Client("/services/tags")
@@ -58,7 +58,6 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
         createAndAssignAdminRole(user);
 
         Tag tag = createADefaultTag();
-        String name = "";
 
         final HttpRequest<Object> request = HttpRequest.DELETE(tag.getId().toString()).basicAuth(user.getWorkEmail(), ADMIN_ROLE);
         final HttpResponse<String> response = client.toBlocking().exchange(request, String.class);
@@ -82,7 +81,6 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
     @Test
     void testReadTag() {
         Tag tag = createADefaultTag();
-        String name = null;
 
         final HttpRequest<Object> request = HttpRequest.GET(String.format("/?%s", tag.getId().toString())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         final HttpResponse<Tag> response = client.toBlocking().exchange(request, Tag.class);
@@ -103,7 +101,6 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
     @Test
     void testFindTag() {
         Tag tag = createADefaultTag();
-        String name = null;
 
         final HttpRequest<?> request = HttpRequest.GET(String.format("/?tagid=%s", tag.getId())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         final HttpResponse<Set<Tag>> response = client.toBlocking().exchange(request, Argument.setOf(Tag.class));
@@ -116,7 +113,6 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
     @Test
     void testFindTagByTagId() {
         Tag tag = createADefaultTag();
-        String name = null;
 
         final HttpRequest<?> request = HttpRequest.GET(String.format("/?tagid=%s", tag.getId())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         final HttpResponse<Set<Tag>> response = client.toBlocking().exchange(request, Argument.setOf(Tag.class));
@@ -127,11 +123,10 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
     }
 
     @Test
-    public void testPUTUpdateTag() {
+    void testPUTUpdateTag() {
         MemberProfile user = createAnUnrelatedUser();
         createAndAssignAdminRole(user);
 
-        String name = null;
         Tag tag = createADefaultTag();
 
         final HttpRequest<?> request = HttpRequest.PUT("/", tag).basicAuth(user.getWorkEmail(), ADMIN_ROLE);
@@ -144,7 +139,7 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
     }
 
     @Test
-    public void testPUTUpdateNullTag() {
+    void testPUTUpdateNullTag() {
 
         final HttpRequest<String> request = HttpRequest.PUT("", "").basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
@@ -161,10 +156,9 @@ public class TagControllerTest extends TestContainersSuite implements TagFixture
     }
 
     @Test
-    public void testPUTUpdateNonexistentTag() {
+    void testPUTUpdateNonexistentTag() {
 
         Tag tag = createADefaultTag();
-        String name = null;
 
         tag.setId(UUID.randomUUID());
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/today/TodayControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/today/TodayControllerTest.java
@@ -15,18 +15,18 @@ import org.junit.jupiter.api.Test;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TodayControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
+class TodayControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture {
 
     @Inject
     @Client("/services/today")
     private HttpClient client;
 
     @Test
-    public void testGET() {
+    void testGET() {
         MemberProfile memberProfile = createAnUnrelatedUser();
 
-        MemberProfile birthdayProfile = createADefaultMemberProfileWithBirthDayToday();
-        MemberProfile anniversaryProfile = createADefaultMemberProfileWithAnniversaryToday();
+        createADefaultMemberProfileWithBirthDayToday();
+        createADefaultMemberProfileWithAnniversaryToday();
 
 
         final HttpRequest<Object> request = HttpRequest.

--- a/web-ui/src/components/celebrations/Birthdays.css
+++ b/web-ui/src/components/celebrations/Birthdays.css
@@ -201,7 +201,7 @@ body {
 @keyframes balloon3 {
   0%,
   100% {
-    transform: translate(0, -10px) rotate(6eg);
+    transform: translate(0, -10px) rotate(6deg);
   }
   50% {
     transform: translate(-20px, 30px) rotate(-8deg);

--- a/web-ui/src/components/celebrations/MyBirthday.css
+++ b/web-ui/src/components/celebrations/MyBirthday.css
@@ -230,7 +230,7 @@ body {
 @keyframes balloon3 {
   0%,
   100% {
-    transform: translate(0, -10px) rotate(6eg);
+    transform: translate(0, -10px) rotate(6deg);
   }
   50% {
     transform: translate(-20px, 30px) rotate(-8deg);

--- a/web-ui/src/components/menu/Menu.css
+++ b/web-ui/src/components/menu/Menu.css
@@ -112,7 +112,7 @@
     cursor: pointer;
     display: grid;
     margin: 1.5rem auto;
-    box-size: border-box;
+    box-sizing: border-box;
     padding: 0;
     place-items: center;
     width: 40px;

--- a/web-ui/src/pages/ReceivedRequestsPage.css
+++ b/web-ui/src/pages/ReceivedRequestsPage.css
@@ -1,5 +1,4 @@
 .received-requests-page {
-  padding: 1rem;
   margin-top: 1rem;
   width: 100%;
   padding: 4em 2em 0 2em;

--- a/web-ui/src/pages/ViewFeedbackPage.css
+++ b/web-ui/src/pages/ViewFeedbackPage.css
@@ -1,5 +1,4 @@
 .view-feedback-page {
-  padding: 1rem;
   margin-top: 1rem;
   width: 100%;
   padding: 4em 2em 0 2em;


### PR DESCRIPTION
Best reviewed commit by commit as I've **tried** to be strong and just fix one thing per commit...

Apologies for when I may have strayed 😢 

This clears up a coupld of hundred Sonar errors and warnings

---

1. [JUnit5 class and method visibility](https://github.com/objectcomputing/check-ins/commit/95af5734022c29a1897b81e79336a7009165a3b0)

    In JUnit 5 it is recommendend to have package-private classes and methods for tests, Sonar flags this as an issue

2. [Logger should be a private static field](https://github.com/objectcomputing/check-ins/commit/69e7fc49bedd59ac30f17a72d4edb6f5c650d7f3)

    Sonar flags this as a naming vilation (as it's all in caps), I think it just needed to be `private final static`

3. [Replace `Collectors.toList()` as appropriate](https://github.com/objectcomputing/check-ins/commit/2e655b34ea934db030f8aee0bec83cf31d39499f)

    Instead of `stream.collect(Collectors.toList())`, it is (since Java 16) recommended to use `stream.toList()`.
    Care must be taken though, as the returned list is then unmodifiable (which is different to the old `Collectors` version)

4. [assertEquals argument order](https://github.com/objectcomputing/check-ins/commit/7df30942d80f06f786342e108168a22cbf7be5f4)

    AssertEquals in tests expects the first argument to be the expected value.
    Having it the wrong way round causes the output to be wrong, and can cause delays in debugging issues.

5. [accidental self assignement](https://github.com/objectcomputing/check-ins/commit/1218b7deee2869e89414fc5c4eb4d60b9ce5edd1)

    In 1 constructor, we were just setting the id to itself (as it wasn't passed as an argument)
    In the second (due to capitalization) we weren't using the passed value for `Id`.
    This wasn't an issue however as I don't believe the constructor is used 🤔 

6. [CSS: `deg` instead of `eg`](https://github.com/objectcomputing/check-ins/commit/53fc2940316bbe8ec96551deaf13161a75293cb5)

    Sonar caught a typo

7. [CSS: duplicated padding member](https://github.com/objectcomputing/check-ins/commit/b256d5df85fe3e0165b5b5dd5f52d05d1d3d195f)

    I don't believe the spec says what to do when it's declared twice (hence the warning in Sonar).
    I kept the second-most padding (which I believe is what most browsers do)

8. [CSS: invalid `box-size` parameter](https://github.com/objectcomputing/check-ins/commit/397492a3cf243a9d2498bea5ca5d8837e1ab7c6b)

    I believe this should be `box-sizing` and I've update it as such

9. [Remove unrequired Mockito `eq()` usage](https://github.com/objectcomputing/check-ins/pull/2502/commits/8759080aabce324e33ccfc62cd8ebde9abbdf001)

    This is not required and makes the tests harder to read

10. [Remove parentheses round single lambda parameters](https://github.com/objectcomputing/check-ins/pull/2502/commits/3ef25cb0f3c521f8053c6cad0d1e3b15eee0ff23)

