### PR TITLE
[cosmetic] Group Certification endpoints in Swagger

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/certification/EarnedCertificationController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/certification/EarnedCertificationController.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @ExecuteOn(TaskExecutors.BLOCKING)
 @Secured(SecurityRule.IS_AUTHENTICATED)
 @Controller("/services/earned-certification")
-@Tag(name = "earned-certification")
+@Tag(name = "certification")
 class EarnedCertificationController {
 
     private final CertificationService certificationService;


### PR DESCRIPTION
Currently the Certification endpoints are under 'certification', and the EarnedCertification endpoints are under 'earned-certification'.

They should be next to each other in the Swagger-UI as they are strongly related.

This commit changes the EarnedCertification tag to 'certification'