### PR TITLE
Remove instance booleans and fix conditionals

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/checkindocument/CheckinDocumentRepository.java
@@ -15,8 +15,8 @@ public interface CheckinDocumentRepository extends CrudRepository<CheckinDocumen
     
     Set<CheckinDocument> findByCheckinsId(@NotNull UUID checkinsId);
     Optional<CheckinDocument> findByUploadDocId(@NotBlank String uploadDocId);
-    Boolean existsByCheckinsId(@NotNull UUID checkinsId);
-    Boolean existsByUploadDocId(@NotBlank String uploadDocId);
+    boolean existsByCheckinsId(@NotNull UUID checkinsId);
+    boolean existsByUploadDocId(@NotBlank String uploadDocId);
     void deleteByCheckinsId(@NotNull UUID checkinsId);
     void deleteByUploadDocId(@NotBlank String uploadDocId);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/checkins/CheckIn.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/checkins/CheckIn.java
@@ -54,7 +54,7 @@ public class CheckIn {
 
     public CheckIn() {}
 
-    public CheckIn(UUID id,UUID teamMemberId, UUID pdlId, LocalDateTime checkInDate, Boolean completed) {
+    public CheckIn(UUID id,UUID teamMemberId, UUID pdlId, LocalDateTime checkInDate, boolean completed) {
         this.id=id;
         this.teamMemberId= teamMemberId;
         this.pdlId=pdlId;
@@ -62,7 +62,7 @@ public class CheckIn {
         this.completed=completed;
     }
     
-    public CheckIn(UUID teamMemberId, UUID pdlId, LocalDateTime checkInDate, Boolean completed) {
+    public CheckIn(UUID teamMemberId, UUID pdlId, LocalDateTime checkInDate, boolean completed) {
         this(null, teamMemberId, pdlId, checkInDate,completed);
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/checkins/CheckInServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/checkins/CheckInServices.java
@@ -16,13 +16,13 @@ public interface CheckInServices {
 
     Set<CheckIn> findByFields(UUID teamMemberId, UUID pdlId, Boolean completed);
 
-    Boolean hasPermission(UUID memberId, Permission permission);
+    boolean hasPermission(UUID memberId, Permission permission);
 
-    Boolean accessGranted(UUID checkinId, UUID memberId);
+    boolean accessGranted(UUID checkinId, UUID memberId);
 
-    Boolean doesUserHaveViewAccess(UUID currentUserId, UUID checkinId, UUID createdById);
+    boolean doesUserHaveViewAccess(UUID currentUserId, UUID checkinId, UUID createdById);
 
-    Boolean canViewAllCheckins(UUID memberId);
+    boolean canViewAllCheckins(UUID memberId);
 
-    Boolean canUpdateAllCheckins(UUID memberId);
+    boolean canUpdateAllCheckins(UUID memberId);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/checkins/CheckInServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/checkins/CheckInServicesImpl.java
@@ -41,7 +41,7 @@ public class CheckInServicesImpl implements CheckInServices {
     }
 
     @Override
-    public Boolean hasPermission(@NotNull UUID memberId, @NotNull Permission permission) {
+    public boolean hasPermission(@NotNull UUID memberId, @NotNull Permission permission) {
         boolean hasPermission = false;
         List<Permission> userPermissions = rolePermissionServices.findUserPermissions(memberId);
         if (!userPermissions.isEmpty()) {
@@ -52,7 +52,7 @@ public class CheckInServicesImpl implements CheckInServices {
     }
 
     @Override
-    public Boolean accessGranted(@NotNull UUID checkinId, @NotNull UUID memberId) {
+    public boolean accessGranted(@NotNull UUID checkinId, @NotNull UUID memberId) {
         memberRepo.findById(memberId).orElseThrow(() -> new NotFoundException(String.format("Member %s not found", memberId)));
 
         if(!canViewAllCheckins(memberId)) {
@@ -76,7 +76,7 @@ public class CheckInServicesImpl implements CheckInServices {
     }
 
     @Override
-    public Boolean doesUserHaveViewAccess(UUID currentUserId, UUID checkinId, UUID createdById) {
+    public boolean doesUserHaveViewAccess(UUID currentUserId, UUID checkinId, UUID createdById) {
         if (canViewAllCheckins(currentUserId)) {
             return true;
         } else if (checkinId != null) {
@@ -200,12 +200,12 @@ public class CheckInServicesImpl implements CheckInServices {
     }
 
     @Override
-    public Boolean canViewAllCheckins(UUID memberId) {
+    public boolean canViewAllCheckins(UUID memberId) {
         return hasPermission(memberId, Permission.CAN_VIEW_ALL_CHECKINS);
     }
 
     @Override
-    public Boolean canUpdateAllCheckins(UUID memberId) {
+    public boolean canUpdateAllCheckins(UUID memberId) {
         return hasPermission(memberId, Permission.CAN_UPDATE_ALL_CHECKINS);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServices.java
@@ -17,6 +17,6 @@ public interface FeedbackTemplateServices {
 
     List<FeedbackTemplate> findByFields(UUID creatorId, String title);
 
-    Boolean setAdHocInactiveByCreator(@Nullable UUID creatorId);
+    boolean setAdHocInactiveByCreator(@Nullable UUID creatorId);
 
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
@@ -102,7 +102,7 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
     }
 
     @Override
-    public Boolean setAdHocInactiveByCreator(@Nullable UUID creatorId) {
+    public boolean setAdHocInactiveByCreator(@Nullable UUID creatorId) {
         if (!updateIsPermitted(creatorId)) {
             throw new PermissionException("You are not authorized to do this operation");
         }

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileServices.java
@@ -10,5 +10,5 @@ public interface FileServices {
     Set<FileInfoDTO> findFiles(UUID checkInId);
     File downloadFiles(String uploadDocId);
     FileInfoDTO uploadFile(UUID checkInID, CompletedFileUpload file);
-    Boolean deleteFile(String uploadDocId);
+    boolean deleteFile(String uploadDocId);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
@@ -225,7 +225,7 @@ public class FileServicesImpl implements FileServices {
     }
 
     @Override
-    public Boolean deleteFile(@NotNull String uploadDocId) {
+    public boolean deleteFile(@NotNull String uploadDocId) {
 
         MemberProfile currentUser = currentUserServices.getCurrentUser();
         boolean isAdmin = currentUserServices.isAdmin();

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildUpdateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildUpdateDTO.java
@@ -45,8 +45,8 @@ public class GuildUpdateDTO {
         this.community = community;
     }
 
-    public GuildUpdateDTO(String id, String name, String description, @Nullable String link, Boolean isCommunity) {
-        this(nullSafeUUIDFromString(id), name, description, link, isCommunity);
+    public GuildUpdateDTO(String id, String name, String description, @Nullable String link, boolean community) {
+        this(nullSafeUUIDFromString(id), name, description, link, community);
     }
 
     public GuildUpdateDTO() {

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
@@ -75,7 +75,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
             throw new BadArgException(String.format("Member %s already exists in guild %s", memberId, guildId));
         }
         // only allow admins to create guild leads
-        else if (!currentUserServices.isAdmin() && guildMember.getLead()) {
+        else if (!currentUserServices.isAdmin() && Boolean.TRUE.equals(guildMember.getLead())) {
             throw new BadArgException("You are not authorized to perform this operation");
         }
         // only admins and leads can add members to guilds unless a user adds themself
@@ -154,7 +154,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
         boolean currentUserIsLead = guildLeads.stream().anyMatch(o -> o.getMemberId().equals(currentUser.getId()));
 
         // don't allow guild lead to be removed if they are the only lead
-        if (guildMember.getLead() && guildLeads.size() == 1){
+        if (Boolean.TRUE.equals(guildMember.getLead()) && guildLeads.size() == 1){
             throw new BadArgException("At least one guild lead must be present in the guild at all times");
         }
         // if the current user is not an admin, is not the same as the member in the request, and is not a lead in the guild -> don't delete
@@ -177,7 +177,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
 
     private Set<String> getGuildLeadsEmails(Set<GuildMember> guildLeads, GuildMember guildMember){
         // remove email from set of guildleads so they aren't included in email
-        if (guildMember.getLead()){
+        if (Boolean.TRUE.equals(guildMember.getLead())){
             guildLeads.remove(guildMember);
         }
         Set<String> guildLeadEmails = new HashSet<>();
@@ -188,7 +188,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
     }
 
 
-    private String constructEmailContent (GuildMember guildMember, Boolean isAdded){
+    private String constructEmailContent (GuildMember guildMember, boolean isAdded){
         MemberProfile memberProfile = memberRepo.findById(guildMember.getMemberId())
                 .orElseThrow(() -> new NotFoundException("No member profile found for guild member with memberid " + guildMember.getMemberId()));
         Guild guild = guildRepo.findById(guildMember.getGuildId())

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileServices.java
@@ -14,7 +14,7 @@ public interface MemberProfileServices {
 
     MemberProfile saveProfile(MemberProfile memberProfile);
 
-    Boolean deleteProfile(UUID id);
+    boolean deleteProfile(UUID id);
 
     MemberProfile findByName(@NotNull String firstName, @NotNull String lastName);
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileServicesImpl.java
@@ -152,7 +152,7 @@ public class MemberProfileServicesImpl implements MemberProfileServices {
     }
 
     @Override
-    public Boolean deleteProfile(@NotNull UUID id) {
+    public boolean deleteProfile(@NotNull UUID id) {
         if (!currentUserServices.isAdmin()) {
             throw new PermissionException("Requires admin privileges");
         }

--- a/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryServices.java
@@ -9,6 +9,6 @@ public interface QuestionCategoryServices {
     QuestionCategory update(QuestionCategory questionCategory);
     QuestionCategory findByName(String name);
     Set<QuestionCategory> findByValue(String name, UUID id);
-    Boolean delete(UUID id);
+    boolean delete(UUID id);
 
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryServicesImpl.java
@@ -88,7 +88,7 @@ public class QuestionCategoryServicesImpl implements QuestionCategoryServices {
     }
 
     @Override
-    public Boolean delete(@NotNull UUID id) {
+    public boolean delete(@NotNull UUID id) {
         final Optional<QuestionCategory> questionCategory = questionCategoryRepository.findById(id);
         if (questionCategory.isEmpty()) {
             throw new NotFoundException("No question category with id " + id);

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentController.java
@@ -62,7 +62,7 @@ public class ReviewAssignmentController {
     public Mono<HttpResponse<List<ReviewAssignment>>> createReviewAssignment(@NotNull UUID reviewPeriodId,
                                                                              @Body List<@Valid ReviewAssignmentDTO> assignments) {
         return Mono.fromCallable(() -> reviewAssignmentServices.saveAll(reviewPeriodId,
-                assignments.stream().map(ReviewAssignmentDTO::convertToEntity).collect(Collectors.toList()), Boolean.TRUE)
+                assignments.stream().map(ReviewAssignmentDTO::convertToEntity).collect(Collectors.toList()), true)
                 ).map(HttpResponse::created);
 
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServices.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface ReviewAssignmentServices {
     ReviewAssignment save(ReviewAssignment reviewAssignment);
-    List<ReviewAssignment> saveAll(UUID reviewPeriodId, List<ReviewAssignment> reviewAssignments, Boolean deleteExisting);
+    List<ReviewAssignment> saveAll(UUID reviewPeriodId, List<ReviewAssignment> reviewAssignments, boolean deleteExisting);
     ReviewAssignment findById(UUID id);
 
     ReviewAssignment update(ReviewAssignment reviewAssignment);

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServicesImpl.java
@@ -44,7 +44,7 @@ public class ReviewAssignmentServicesImpl implements ReviewAssignmentServices {
     }
 
     @Override
-    public List<ReviewAssignment> saveAll(UUID reviewPeriodId, List<ReviewAssignment> reviewAssignments, Boolean deleteExisting) {
+    public List<ReviewAssignment> saveAll(UUID reviewPeriodId, List<ReviewAssignment> reviewAssignments, boolean deleteExisting) {
 
         if(deleteExisting) {
             LOG.warn(String.format("Deleting all review assignments for review period %s", reviewPeriodId));

--- a/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingOption.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingOption.java
@@ -32,7 +32,7 @@ public enum SettingOption {
                 .collect(Collectors.toList());
     }
 
-    public static Boolean isValidOption(String name){
+    public static boolean isValidOption(String name){
         return Stream.of(SettingOption.values())
                 .anyMatch(option -> option.name().equalsIgnoreCase(name));
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingsServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingsServices.java
@@ -15,5 +15,5 @@ public interface SettingsServices {
 
     List<Setting> findAllSettings();
 
-    Boolean delete(UUID id);
+    boolean delete(UUID id);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingsServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/settings/SettingsServicesImpl.java
@@ -42,7 +42,7 @@ public class SettingsServicesImpl implements SettingsServices {
         return settingsRepository.findAll();
     }
 
-    public Boolean delete(@NotNull UUID id) {
+    public boolean delete(@NotNull UUID id) {
         if (!settingsRepository.existsById(id)) {
             throw new NotFoundException("No setting with id " + id);
         }

--- a/server/src/main/java/com/objectcomputing/checkins/services/skills/Skill.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skills/Skill.java
@@ -57,14 +57,14 @@ public class Skill {
         this(name, true, description, false);
     }
 
-    public Skill(String name, Boolean pending, String description, Boolean extraneous) {
+    public Skill(String name, boolean pending, String description, boolean extraneous) {
         this.name = name;
         this.pending = pending;
         this.description = description;
         this.extraneous = extraneous;
     }
 
-    public Skill(UUID id, String name, Boolean pending, String description, Boolean extraneous) {
+    public Skill(UUID id, String name, boolean pending, String description, boolean extraneous) {
         this.id = id;
         this.name = name;
         this.pending = pending;

--- a/server/src/test/java/com/objectcomputing/checkins/services/file/FileServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/file/FileServicesImplTest.java
@@ -233,7 +233,7 @@ class FileServicesImplTest extends TestContainersSuite {
         when(files.get(any(String.class))).thenReturn(get);
         when(get.setSupportsAllDrives(any())).thenReturn(get);
         when(get.execute()).thenReturn(file);
-        when(checkInServices.accessGranted(testCheckinId, testMemberProfileId)).thenReturn(Boolean.TRUE);
+        when(checkInServices.accessGranted(testCheckinId, testMemberProfileId)).thenReturn(true);
         when(testCheckIn.getTeamMemberId()).thenReturn(testMemberProfileId);
         when(currentUserServices.getCurrentUser()).thenReturn(testMemberProfile);
         when(testMemberProfile.getId()).thenReturn(testMemberProfileId);
@@ -255,7 +255,7 @@ class FileServicesImplTest extends TestContainersSuite {
         UUID testCheckinId = UUID.randomUUID();
         UUID testMemberProfileId = UUID.randomUUID();
         when(mockGoogleApiAccess.getDrive()).thenReturn(drive);
-        when(checkInServices.accessGranted(testCheckinId, testMemberProfileId)).thenReturn(Boolean.TRUE);
+        when(checkInServices.accessGranted(testCheckinId, testMemberProfileId)).thenReturn(true);
         when(testCheckIn.getTeamMemberId()).thenReturn(testMemberProfileId);
         when(currentUserServices.getCurrentUser()).thenReturn(testMemberProfile);
         when(testMemberProfile.getId()).thenReturn(testMemberProfileId);
@@ -274,7 +274,7 @@ class FileServicesImplTest extends TestContainersSuite {
     void testFindByCheckinIdForUnauthorizedUser() {
         UUID testCheckinId = UUID.randomUUID();
         when(mockGoogleApiAccess.getDrive()).thenReturn(drive);
-        when(checkInServices.accessGranted(testCheckinId, testMemberProfile.getId())).thenReturn(Boolean.FALSE);
+        when(checkInServices.accessGranted(testCheckinId, testMemberProfile.getId())).thenReturn(false);
         when(testCheckIn.getTeamMemberId()).thenReturn(UUID.randomUUID());
         when(currentUserServices.getCurrentUser()).thenReturn(testMemberProfile);
         when(testMemberProfile.getId()).thenReturn(UUID.randomUUID());
@@ -331,7 +331,7 @@ class FileServicesImplTest extends TestContainersSuite {
 
         when(currentUserServices.isAdmin()).thenReturn(true);
         when(checkInServices.read(testCheckinId)).thenReturn(testCheckIn);
-        when(checkInServices.accessGranted(testCheckinId, testMemberProfile.getId())).thenReturn(Boolean.TRUE);
+        when(checkInServices.accessGranted(testCheckinId, testMemberProfile.getId())).thenReturn(true);
         when(currentUserServices.getCurrentUser()).thenReturn(testMemberProfile);
         when(checkinDocumentServices.read(testCheckinId)).thenReturn(testCheckinDocument);
         when(testCd.getUploadDocId()).thenReturn("some.upload.doc.id");

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/OpportunitiesFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/OpportunitiesFixture.java
@@ -8,6 +8,6 @@ import java.time.LocalDate;
 public interface OpportunitiesFixture extends RepositoryFixture {
     default Opportunities createADefaultOpportunities(MemberProfile memberprofile) {
         return getOpportunitiesRepository().save(new Opportunities("Name", "Description","https://objectcomputing.com/jobs", LocalDate.now(), LocalDate.now(),
-                memberprofile.getId(), Boolean.FALSE));
+                memberprofile.getId(), false));
     }
 }


### PR DESCRIPTION
Where possible this commit switches from `Boolean` class parameters to primitive booleans.

The problem with `Boolean` is that it introduces 3 states, `TRUE`, `FALSE` and `null`.

Where the contract has a Nullable requirement, I have updated the `if` statements, as `if (obj.nullableMember()) {` will throw a null pointer exception if the Boolean result is `null`.  The safe replacement is `if (Boolean.TRUE.equals(obj.nullableMember())) {`