### PR TITLE
fix: Move certification and volunteer permissions to admin

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -912,6 +912,31 @@ insert into role_permissions
 values
     ('e8a4fff8-e984-4e59-be84-a713c9fa8d23', 'CAN_VIEW_ALL_PULSE_RESPONSES');
 
+insert into role_permissions
+(roleid, permission)
+values
+    ('e8a4fff8-e984-4e59-be84-a713c9fa8d23', 'CAN_MANAGE_CERTIFICATIONS');
+
+insert into role_permissions
+(roleid, permission)
+values
+    ('e8a4fff8-e984-4e59-be84-a713c9fa8d23', 'CAN_MANAGE_EARNED_CERTIFICATIONS');
+
+insert into role_permissions
+(roleid, permission)
+values
+    ('e8a4fff8-e984-4e59-be84-a713c9fa8d23', 'CAN_ADMINISTER_VOLUNTEERING_ORGANIZATIONS');
+
+insert into role_permissions
+(roleid, permission)
+values
+    ('e8a4fff8-e984-4e59-be84-a713c9fa8d23', 'CAN_ADMINISTER_VOLUNTEERING_RELATIONSHIPS');
+
+insert into role_permissions
+(roleid, permission)
+values
+    ('e8a4fff8-e984-4e59-be84-a713c9fa8d23', 'CAN_ADMINISTER_VOLUNTEERING_EVENTS');
+
 -- PDL Permissions
 insert into role_permissions
     (roleid, permission)
@@ -987,31 +1012,6 @@ insert into role_permissions
 (roleid, permission)
 values
     ('d03f5f0b-e29c-4cf4-9ea4-6baa09405c56', 'CAN_VIEW_REVIEW_PERIOD');
-
-insert into role_permissions
-(roleid, permission)
-values
-    ('d03f5f0b-e29c-4cf4-9ea4-6baa09405c56', 'CAN_MANAGE_CERTIFICATIONS');
-
-insert into role_permissions
-(roleid, permission)
-values
-    ('d03f5f0b-e29c-4cf4-9ea4-6baa09405c56', 'CAN_MANAGE_EARNED_CERTIFICATIONS');
-
-insert into role_permissions
-(roleid, permission)
-values
-    ('d03f5f0b-e29c-4cf4-9ea4-6baa09405c56', 'CAN_ADMINISTER_VOLUNTEERING_ORGANIZATIONS');
-
-insert into role_permissions
-(roleid, permission)
-values
-    ('d03f5f0b-e29c-4cf4-9ea4-6baa09405c56', 'CAN_ADMINISTER_VOLUNTEERING_RELATIONSHIPS');
-
-insert into role_permissions
-(roleid, permission)
-values
-    ('d03f5f0b-e29c-4cf4-9ea4-6baa09405c56', 'CAN_ADMINISTER_VOLUNTEERING_EVENTS');
 
 -- Member permissions
 insert into role_permissions


### PR DESCRIPTION
In the dev data load, I accidentally assigned the Certification and Volunteer permissions to the PDL role, not ADMIN.