### PR TITLE
fix: replace deprecated commons-io csv handling

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursCSVHelper.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursCSVHelper.java
@@ -15,24 +15,30 @@ import java.util.List;
 
 public class EmployeeHoursCSVHelper {
 
-    public static List<EmployeeHours> employeeHrsCsv(InputStream inputStream) {
-        try {
-            List<EmployeeHours> employeeHoursList = new ArrayList<>();
+    private EmployeeHoursCSVHelper() {
+    }
 
-            InputStreamReader input = new InputStreamReader(new BOMInputStream(inputStream,false));
-            CSVParser csvParser = CSVFormat.RFC4180.withFirstRecordAsHeader().withIgnoreSurroundingSpaces().withNullString("").parse(input);
+    public static List<EmployeeHours> employeeHrsCsv(InputStream inputStream) throws IOException {
+        try (BOMInputStream bomInputStream = BOMInputStream.builder().setInputStream(inputStream).setInclude(false).get();
+             InputStreamReader input = new InputStreamReader(bomInputStream)) {
+            List<EmployeeHours> employeeHoursList = new ArrayList<>();
+            CSVParser csvParser = CSVFormat.RFC4180
+                    .builder()
+                    .setHeader().setSkipHeaderRecord(true)
+                    .setIgnoreSurroundingSpaces(true)
+                    .setNullString("")
+                    .build()
+                    .parse(input);
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/d/yyyy");
             for (CSVRecord csvRecord : csvParser) {
                 EmployeeHours employeeHours = new EmployeeHours(csvRecord.get("employeeId"),
                         Float.parseFloat(csvRecord.get("contributionHours")),
                         Float.parseFloat(csvRecord.get("billableHours")),
-                         Float.parseFloat(csvRecord.get("ptoHours")), LocalDate.now(),Float.parseFloat(csvRecord.get("targetHours")),
+                        Float.parseFloat(csvRecord.get("ptoHours")), LocalDate.now(), Float.parseFloat(csvRecord.get("targetHours")),
                         LocalDate.parse(csvRecord.get("asOfDate"), formatter));
                 employeeHoursList.add(employeeHours);
             }
             return employeeHoursList;
-        } catch (IOException e) {
-            throw new RuntimeException("unable to read csv file:"+e.getMessage());
         }
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServices.java
@@ -1,9 +1,9 @@
 package com.objectcomputing.checkins.services.memberprofile.csvreport;
 
 import java.io.File;
+import java.io.IOException;
 
 public interface MemberProfileReportServices {
 
-    File generateFile(MemberProfileReportQueryDTO queryDTO);
-
+    File generateFile(MemberProfileReportQueryDTO queryDTO) throws IOException;
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/csvreport/MemberProfileReportServicesImpl.java
@@ -25,7 +25,7 @@ public class MemberProfileReportServicesImpl implements MemberProfileReportServi
     }
 
     @Override
-    public File generateFile(MemberProfileReportQueryDTO queryDTO) {
+    public File generateFile(MemberProfileReportQueryDTO queryDTO) throws IOException {
         List<MemberProfileRecord> memberRecords = new ArrayList<>();
         if (queryDTO == null || queryDTO.getMemberIds() == null) {
             List<MemberProfileRecord> allRecords = memberProfileReportRepository.findAll();
@@ -36,33 +36,28 @@ public class MemberProfileReportServicesImpl implements MemberProfileReportServi
             memberRecords.addAll(filteredRecords);
         }
         return createCsv(memberRecords);
-
     }
 
-    private File createCsv(List<MemberProfileRecord> memberRecords) {
-
+    private File createCsv(List<MemberProfileRecord> memberRecords) throws IOException {
         File csvFile = memberProfileFileProvider.provideFile();
         CSVFormat csvFormat = getCsvFormat();
         try (final CSVPrinter printer = new CSVPrinter(new FileWriter(csvFile, StandardCharsets.UTF_8), csvFormat)) {
-            for (MemberProfileRecord record : memberRecords) {
+            for (MemberProfileRecord memberProfileRecord : memberRecords) {
                 printer.printRecord(
-                        record.getFirstName(),
-                        record.getLastName(),
-                        record.getTitle(),
-                        record.getLocation(),
-                        record.getWorkEmail(),
-                        record.getStartDate(),
-                        record.getTenure(),
-                        record.getPdlName(),
-                        record.getPdlEmail(),
-                        record.getSupervisorName(),
-                        record.getSupervisorEmail()
+                        memberProfileRecord.getFirstName(),
+                        memberProfileRecord.getLastName(),
+                        memberProfileRecord.getTitle(),
+                        memberProfileRecord.getLocation(),
+                        memberProfileRecord.getWorkEmail(),
+                        memberProfileRecord.getStartDate(),
+                        memberProfileRecord.getTenure(),
+                        memberProfileRecord.getPdlName(),
+                        memberProfileRecord.getPdlEmail(),
+                        memberProfileRecord.getSupervisorName(),
+                        memberProfileRecord.getSupervisorEmail()
                 );
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
-
         return csvFile;
     }
 
@@ -70,7 +65,9 @@ public class MemberProfileReportServicesImpl implements MemberProfileReportServi
         String[] headers = {"First Name", "Last Name", "Title", "Location", "Work Email", "Start Date", "Tenure",
                 "PDL Name", "PDL Email", "Supervisor Name", "Supervisor Email"};
         return CSVFormat.DEFAULT
-                .withHeader(headers)
-                .withQuote('"');
+                .builder()
+                .setHeader(headers)
+                .setQuote('"')
+                .build();
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/skill_record/SkillRecordServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skill_record/SkillRecordServices.java
@@ -1,9 +1,9 @@
 package com.objectcomputing.checkins.services.skill_record;
 
 import java.io.File;
+import java.io.IOException;
 
 public interface SkillRecordServices {
 
-    File generateFile();
-
+    File generateFile() throws IOException;
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/skill_record/SkillRecordServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skill_record/SkillRecordServicesImpl.java
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Singleton
-public class SkillRecordServicesImpl implements SkillRecordServices {
+class SkillRecordServicesImpl implements SkillRecordServices {
 
     private final SkillRecordRepository skillRecordRepository;
     private final SkillRecordFileProvider skillRecordFileProvider;
@@ -22,19 +22,25 @@ public class SkillRecordServicesImpl implements SkillRecordServices {
     }
 
     @Override
-    public File generateFile() {
+    public File generateFile() throws IOException {
         List<SkillRecord> skillRecords = skillRecordRepository.findAll();
 
-        String[] headers = { "name", "description", "extraneous", "pending", "category_name" };
-        CSVFormat csvFormat = CSVFormat.DEFAULT.withHeader(headers).withQuote('"');
+        String[] headers = {"name", "description", "extraneous", "pending", "category_name"};
+        CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader(headers).setQuote('"').build();
 
         File csvFile = skillRecordFileProvider.provideFile();
-        try (final CSVPrinter printer = new CSVPrinter(new FileWriter(csvFile, StandardCharsets.UTF_8), csvFormat)) {
-            for (SkillRecord record : skillRecords) {
-                printer.printRecord(record.getName(), record.getDescription(), record.isExtraneous(), record.isPending(), record.getCategoryName());
+        try (FileWriter fileWriter = new FileWriter(csvFile, StandardCharsets.UTF_8);
+             CSVPrinter printer = new CSVPrinter(fileWriter, csvFormat)
+        ) {
+            for (SkillRecord skillRecord : skillRecords) {
+                printer.printRecord(
+                        skillRecord.getName(),
+                        skillRecord.getDescription(),
+                        skillRecord.isExtraneous(),
+                        skillRecord.isPending(),
+                        skillRecord.getCategoryName()
+                );
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
 
         return csvFile;

--- a/server/src/test/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursControllerTest.java
@@ -19,7 +19,12 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
@@ -90,7 +95,7 @@ class EmployeeHoursControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    void testFindAllRecordsWithAdminRole() {
+    void testFindAllRecordsWithAdminRole() throws IOException {
         MemberProfile memberProfile=createADefaultMemberProfile();
         createADefaultMemberProfileForPdl(memberProfile);
         MemberProfile user = createAnUnrelatedUser();
@@ -107,7 +112,7 @@ class EmployeeHoursControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    void testFindRecordsWithEmployeeId() {
+    void testFindRecordsWithEmployeeId() throws IOException {
         MemberProfile memberProfile=createADefaultMemberProfile();
         createADefaultMemberProfileForPdl(memberProfile);
         List<EmployeeHours> employeeHoursList = createEmployeeHours();
@@ -119,7 +124,7 @@ class EmployeeHoursControllerTest extends TestContainersSuite implements MemberP
     }
 
     @Test
-    void testFindAllRecordsWithNonAdminRole() {
+    void testFindAllRecordsWithNonAdminRole() throws IOException {
         MemberProfile memberProfile=createADefaultMemberProfile();
         createADefaultMemberProfileForPdl(memberProfile);
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/EmployeeHoursFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/EmployeeHoursFixture.java
@@ -2,33 +2,19 @@ package com.objectcomputing.checkins.services.fixture;
 
 import com.objectcomputing.checkins.services.employee_hours.EmployeeHours;
 import com.objectcomputing.checkins.services.employee_hours.EmployeeHoursCSVHelper;
-import com.objectcomputing.checkins.services.employee_hours.EmployeeHoursServices;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.client.multipart.MultipartBody;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 
 public interface EmployeeHoursFixture extends RepositoryFixture {
-    default List<EmployeeHours> createEmployeeHours(){
-        final EmployeeHoursServices employeeHoursServices = null;
 
+    default List<EmployeeHours> createEmployeeHours() throws IOException {
         File file = new File("src/test/java/com/objectcomputing/checkins/services/employee_hours/test.csv");
-        MultipartBody multipartBody = MultipartBody
-                .builder()
-                .addPart("file","test.csv",new MediaType("text/csv"),file)
-                .build();
-        List<EmployeeHours> employeeHoursList = new ArrayList<>();
-        try {
-            InputStream inputStream = new FileInputStream(file);
-             employeeHoursList = EmployeeHoursCSVHelper.employeeHrsCsv(inputStream);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
+        try(InputStream inputStream = new FileInputStream(file)) {
+            return getEmployeeHoursRepository().saveAll(EmployeeHoursCSVHelper.employeeHrsCsv(inputStream));
         }
-        return getEmployeeHoursRepository().saveAll(employeeHoursList);
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/skill_record/SkillRecordServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skill_record/SkillRecordServicesImplTest.java
@@ -4,7 +4,13 @@ import com.objectcomputing.checkins.services.TestContainersSuite;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -16,7 +22,9 @@ import java.io.Reader;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
@@ -70,9 +78,11 @@ class SkillRecordServicesImplTest extends TestContainersSuite {
 
         String[] headers = { "name", "description", "extraneous", "pending", "category_name" };
         CSVFormat csvFormat = CSVFormat.DEFAULT
-                .withHeader(headers)
-                .withQuote('"')
-                .withSkipHeaderRecord();
+                .builder()
+                .setHeader(headers)
+                .setQuote('"')
+                .setSkipHeaderRecord(true)
+                .build();
 
         CSVParser parser = csvFormat.parse(fileReader);
         List<CSVRecord> records = parser.getRecords();
@@ -88,7 +98,7 @@ class SkillRecordServicesImplTest extends TestContainersSuite {
 
     @Test
     @Order(2)
-    void testNoFileGenerated() throws IOException {
+    void testNoFileGenerated() {
         SkillRecord record1 = new SkillRecord();
         record1.setName("Java");
         record1.setDescription("Various technical skills");
@@ -103,5 +113,4 @@ class SkillRecordServicesImplTest extends TestContainersSuite {
             skillRecordServices.generateFile();
         });
     }
-
 }


### PR DESCRIPTION
CSVParser deprecated the `withXXX` methods and switched to a builder pattern in 2.12.0

BOMInputStream also switched to a builder pattern (instead of the constructor) in the same release.

Took advantage of this commit to properly implement the try-with-resources pattern and throw the exception up to the controller (where we catch it) instead of wrapping it in a RuntimeException so we can effectively ignore it in code.

Also renamed a couple of for-loop arguments (as they were called `record` which is now a Java reserved word