### PR TITLE
fix: Request is marked nullable, so should be checked

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/security/permissions/PermissionSecurityRule.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/permissions/PermissionSecurityRule.java
@@ -4,6 +4,7 @@ import com.objectcomputing.checkins.services.permissions.Permission;
 import com.objectcomputing.checkins.services.permissions.RequiredPermission;
 import com.objectcomputing.checkins.services.role.role_permissions.RolePermission;
 import com.objectcomputing.checkins.services.role.role_permissions.RolePermissionServices;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
@@ -19,7 +20,6 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
-import java.util.Optional;
 
 @Singleton
 public class PermissionSecurityRule implements SecurityRule<HttpRequest<?>> {
@@ -39,26 +39,28 @@ public class PermissionSecurityRule implements SecurityRule<HttpRequest<?>> {
 
     @Override
     public Publisher<SecurityRuleResult> check(@Nullable HttpRequest request, @Nullable Authentication authentication) {
-        RouteMatch routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class).orElse(null);
-        if (routeMatch instanceof MethodBasedRouteMatch methodBasedRouteMatch
-                && methodBasedRouteMatch.hasAnnotation(RequiredPermission.class)) {
-            Optional<String> optionalPermission = methodBasedRouteMatch.findAnnotation(RequiredPermission.class).flatMap(r -> r.stringValue("value"));
-
-            Map<String, Object> claims = authentication != null ? authentication.getAttributes() : null;
-            if (optionalPermission.isPresent() && claims != null && claims.containsKey("roles")) {
-                final Permission requiredPermission = Permission.valueOf(optionalPermission.get());
-
-                JSONArray jsonArray = new JSONArray(claims.get("roles").toString());
-
-                boolean requiredPermissionFoundInRoles = jsonArray.toList().stream()
-                        .map(Object::toString)
-                        .flatMap(role -> rolePermissionServices.findByRole(role).stream())
-                        .map(RolePermission::getPermission)
-                        .anyMatch(p -> p == requiredPermission);
-
-                return Mono.just(requiredPermissionFoundInRoles ? SecurityRuleResult.ALLOWED : SecurityRuleResult.REJECTED);
-            }
+        if (request == null) {
+            return Mono.just(SecurityRuleResult.UNKNOWN);
         }
-        return Mono.just(SecurityRuleResult.UNKNOWN);
+        return request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class)
+                .map(routeMatch -> routeMatch instanceof MethodBasedRouteMatch<?,?> ? (MethodBasedRouteMatch<?,?>) routeMatch : null)
+                .flatMap(routeMatch -> routeMatch.findAnnotation(RequiredPermission.class).flatMap(AnnotationValue::stringValue))
+                .map(Permission::valueOf)
+                .map(requiredPermission -> {
+                    Map<String, Object> claims = authentication != null ? authentication.getAttributes() : null;
+                    if (claims != null && claims.containsKey("roles")) {
+                        JSONArray jsonArray = new JSONArray(claims.get("roles").toString());
+                        boolean requiredPermissionFoundInRoles = jsonArray.toList().stream()
+                                .map(Object::toString)
+                                .flatMap(role -> rolePermissionServices.findByRole(role).stream())
+                                .map(RolePermission::getPermission)
+                                .anyMatch(p -> p == requiredPermission);
+                        return requiredPermissionFoundInRoles ? SecurityRuleResult.ALLOWED : SecurityRuleResult.REJECTED;
+                    } else {
+                        return SecurityRuleResult.UNKNOWN;
+                    }
+                })
+                .map(Mono::just)
+                .orElseGet(() -> Mono.just(SecurityRuleResult.UNKNOWN));
     }
 }


### PR DESCRIPTION
In the PermissionSecurityRule, the request object is annotated as Nullable, but we weren't testing for null.

This PR checks for null first of all.

I refactored the method into a optional flow which I hope is easier to read.

And then fixed the tests (we no longer call hasAnnotation as findAnnotation returns an optional, so provides enough info to continue)