### PR TITLE
Front-end import cleanup

### DIFF
--- a/web-ui/src/api/feedback.js
+++ b/web-ui/src/api/feedback.js
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import { resolve } from './api.js';
 import { getFeedbackTemplateWithQuestions } from './feedbacktemplate.js';
 

--- a/web-ui/src/api/notifications.js
+++ b/web-ui/src/api/notifications.js
@@ -1,5 +1,4 @@
 import { resolve } from './api.js';
-import { getMember } from './member.js';
 
 const emailNotificationURL = '/services/email-notifications';
 const emailURL = '/services/email';

--- a/web-ui/src/components/admin/users/Users.jsx
+++ b/web-ui/src/components/admin/users/Users.jsx
@@ -10,7 +10,6 @@ import AdminMemberCard from '../../member-directory/AdminMemberCard';
 import MemberModal from '../../member-directory/MemberModal';
 import {
   createMember,
-  getMember,
   reportAllMembersCsv
 } from '../../../api/member';
 import { AppContext } from '../../../context/AppContext';

--- a/web-ui/src/components/celebrations/Anniversaries.jsx
+++ b/web-ui/src/components/celebrations/Anniversaries.jsx
@@ -10,14 +10,10 @@ import {
 } from '../../context/selectors';
 import SkeletonLoader from '../skeleton_loader/SkeletonLoader';
 
-import { Card, CardHeader } from '@mui/material';
+import { Card, CardHeader, Grid, Typography } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 
-import { Grid } from '@mui/material';
-
 import './Anniversaries.css';
-
-import { Typography } from '@mui/material';
 
 const PREFIX = 'MemberSummaryCard';
 const classes = {

--- a/web-ui/src/components/checkin/CheckinHistory.jsx
+++ b/web-ui/src/components/checkin/CheckinHistory.jsx
@@ -12,7 +12,6 @@ import IconButton from '@mui/material/IconButton';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { MobileDateTimePicker } from '@mui/x-date-pickers';
-import TextField from '@mui/material/TextField';
 
 import './Checkin.css';
 

--- a/web-ui/src/components/dialogs/AlertDialog.jsx
+++ b/web-ui/src/components/dialogs/AlertDialog.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
 
 import {
   Button,

--- a/web-ui/src/components/dialogs/ConfirmationDialog.jsx
+++ b/web-ui/src/components/dialogs/ConfirmationDialog.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import {
   Button,

--- a/web-ui/src/components/edit_skills/EditSkillsModal.jsx
+++ b/web-ui/src/components/edit_skills/EditSkillsModal.jsx
@@ -9,8 +9,7 @@ import { combineSkill } from '../../api/skill';
 import { getMemberSkills } from '../../api/memberskill';
 
 import Autocomplete from '@mui/material/Autocomplete';
-import { Checkbox, Modal, TextField } from '@mui/material';
-import { Button } from '@mui/material';
+import { Button, Checkbox, Modal, TextField } from '@mui/material';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 

--- a/web-ui/src/components/feedback_recipient_card/FeedbackRecipientCard.jsx
+++ b/web-ui/src/components/feedback_recipient_card/FeedbackRecipientCard.jsx
@@ -3,14 +3,14 @@ import { styled } from '@mui/material/styles';
 import { AppContext } from '../../context/AppContext';
 import { selectProfileMap } from '../../context/selectors';
 import { getAvatarURL } from '../../api/api.js';
-import { Card, CardHeader } from '@mui/material';
+import { Box, Card, CardHeader, CardContent, Container, Typography } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 import PriorityHighIcon from '@mui/icons-material/PriorityHigh';
 import { green } from '@mui/material/colors';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import Divider from '@mui/material/Divider';
+
 import './FeedbackRecipientCard.css';
-import { Box, CardContent, Container, Typography } from '@mui/material';
 
 const PREFIX = 'FeedbackRecipientCard';
 const classes = {

--- a/web-ui/src/components/feedback_recipient_selector/FeedbackRecipientSelector.jsx
+++ b/web-ui/src/components/feedback_recipient_selector/FeedbackRecipientSelector.jsx
@@ -1,19 +1,20 @@
 import React, { useContext, useEffect, useState, useRef } from 'react';
 import { styled } from '@mui/material/styles';
-import './FeedbackRecipientSelector.css';
 import FeedbackRecipientCard from '../feedback_recipient_card/FeedbackRecipientCard';
 import { AppContext } from '../../context/AppContext';
 import {
   selectProfile,
   selectCsrfToken,
+  selectCurrentUser,
   selectNormalizedMembers
 } from '../../context/selectors';
 import { getFeedbackSuggestion } from '../../api/feedback';
-import { selectCurrentUser } from '../../context/selectors';
 import Typography from '@mui/material/Typography';
 import { TextField, Grid, InputAdornment } from '@mui/material';
 import { Search } from '@mui/icons-material';
 import PropTypes from 'prop-types';
+
+import './FeedbackRecipientSelector.css';
 
 const PREFIX = 'FeedbackRecipientSelector';
 const classes = {

--- a/web-ui/src/components/feedback_template_selector/FeedbackTemplateSelector.jsx
+++ b/web-ui/src/components/feedback_template_selector/FeedbackTemplateSelector.jsx
@@ -8,9 +8,8 @@ import React, {
 import TemplateCard from '../template-card/TemplateCard';
 import TemplatePreviewModal from '../template-preview-modal/TemplatePreviewModal';
 import PropTypes from 'prop-types';
-import { InputAdornment, TextField } from '@mui/material';
+import { InputAdornment, TextField, Tooltip } from '@mui/material';
 import Button from '@mui/material/Button';
-import { Tooltip } from '@mui/material';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import {
   createFeedbackTemplateWithQuestion,
@@ -18,9 +17,10 @@ import {
 } from '../../api/feedbacktemplate';
 import { AppContext } from '../../context/AppContext';
 import { selectCsrfToken, selectCurrentUser } from '../../context/selectors';
-import './FeedbackTemplateSelector.css';
 import { Search } from '@mui/icons-material';
 import { UPDATE_TOAST } from '../../context/actions';
+
+import './FeedbackTemplateSelector.css';
 
 const propTypes = {
   query: PropTypes.string,

--- a/web-ui/src/components/guild-results/GuildSummaryCard.jsx
+++ b/web-ui/src/components/guild-results/GuildSummaryCard.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Construction, Groups } from '@mui/icons-material';
-import { Link as StyledLink } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 import { AppContext } from '../../context/AppContext';
@@ -20,6 +19,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Link as StyledLink,
   Tooltip
 } from '@mui/material';
 import PropTypes from 'prop-types';

--- a/web-ui/src/components/guild-results/GuildSummaryCard.jsx
+++ b/web-ui/src/components/guild-results/GuildSummaryCard.jsx
@@ -23,7 +23,7 @@ import {
   Tooltip
 } from '@mui/material';
 import PropTypes from 'prop-types';
-import { deleteGuild, getGuildLeaders, updateGuild } from '../../api/guild.js';
+import { deleteGuild, updateGuild } from '../../api/guild.js';
 import SplitButton from '../split-button/SplitButton';
 
 const PREFIX = 'GuildSummaryCard';

--- a/web-ui/src/components/member-directory/AdminMemberCard.jsx
+++ b/web-ui/src/components/member-directory/AdminMemberCard.jsx
@@ -4,32 +4,35 @@ import { Link } from 'react-router-dom';
 
 import MemberModal from './MemberModal';
 import { AppContext } from '../../context/AppContext';
-import { UPDATE_MEMBER_PROFILES } from '../../context/actions';
+import { DELETE_MEMBER_PROFILE, UPDATE_MEMBER_PROFILES, UPDATE_TOAST } from '../../context/actions';
 import { selectProfileMap } from '../../context/selectors';
 import { getAvatarURL } from '../../api/api.js';
 
-import { Card, CardActions, CardHeader, Tooltip } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 import PriorityHighIcon from '@mui/icons-material/PriorityHigh';
 
-import './MemberSummaryCard.css';
 import SplitButton from '../split-button/SplitButton';
 
 import { updateMember, deleteMember } from '../../api/member.js';
-import { DELETE_MEMBER_PROFILE, UPDATE_TOAST } from '../../context/actions.js';
 
 import {
   Box,
   Button,
+  Card,
+  CardActions,
   CardContent,
+  CardHeader,
   Container,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Tooltip,
   Typography
 } from '@mui/material';
+
+import './MemberSummaryCard.css';
 
 const PREFIX = 'AdminMemberCard';
 const classes = {

--- a/web-ui/src/components/member-directory/MemberModal.jsx
+++ b/web-ui/src/components/member-directory/MemberModal.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { AppContext } from '../../context/AppContext';
 import {
   selectOrderedPdls,
@@ -6,15 +6,13 @@ import {
   selectCurrentMembers
 } from '../../context/selectors';
 
-import { Modal, TextField } from '@mui/material';
+import { Button, Modal, TextField } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import { DatePicker } from '@mui/x-date-pickers';
 import { format } from 'date-fns';
-import { Button } from '@mui/material';
 import { UPDATE_TOAST } from '../../context/actions';
 
 import './MemberModal.css';
-import { useCallback } from 'react';
 
 const emptyMember = {
   employeeId: '',

--- a/web-ui/src/components/member-directory/MemberSummaryCard.jsx
+++ b/web-ui/src/components/member-directory/MemberSummaryCard.jsx
@@ -6,19 +6,21 @@ import { AppContext } from '../../context/AppContext';
 import { selectIsAdmin, selectProfileMap } from '../../context/selectors';
 import { getAvatarURL } from '../../api/api.js';
 
-import { Card, CardHeader } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 import PriorityHighIcon from '@mui/icons-material/PriorityHigh';
 
-import './MemberSummaryCard.css';
-
 import {
   Box,
+  Card,
   CardContent,
+  CardHeader,
   Container,
   Tooltip,
   Typography
 } from '@mui/material';
+
+import './MemberSummaryCard.css';
+
 const PREFIX = 'MemberSummaryCard';
 const classes = {
   header: `${PREFIX}-header`

--- a/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
+++ b/web-ui/src/components/reports-section/checkin-report/TeamMemberMap.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import {
   Accordion,
   AccordionSummary,

--- a/web-ui/src/components/reviews/SelectUserModal.jsx
+++ b/web-ui/src/components/reviews/SelectUserModal.jsx
@@ -1,9 +1,8 @@
 import React, { useContext, useState, useCallback } from 'react';
 import { AppContext } from '../../context/AppContext';
 import { selectOrderedMemberFirstName } from '../../context/selectors';
-import { Modal, TextField, Box } from '@mui/material';
+import { Box, Button, Modal, TextField } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
-import { Button } from '@mui/material';
 import { UPDATE_TOAST } from '../../context/actions';
 
 const modalStyles = {

--- a/web-ui/src/components/reviews/TeamMemberReview-old.jsx
+++ b/web-ui/src/components/reviews/TeamMemberReview-old.jsx
@@ -1,24 +1,23 @@
 import React, { useContext, useState, useCallback } from 'react';
-import { useTheme } from '@mui/material/styles';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import SwipeableViews from 'react-swipeable-views';
 import PropTypes from 'prop-types';
 import { AppContext } from '../../context/AppContext';
-import { selectCurrentUser, selectProfile } from '../../context/selectors';
-import AppBar from '@mui/material/AppBar';
-import Button from '@mui/material/Button';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
-import Typography from '@mui/material/Typography';
+import { selectCsrfToken, selectCurrentUser, selectProfile } from '../../context/selectors';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-import Box from '@mui/material/Box';
 import {
+  AppBar,
+  Box,
+  Button,
   Card,
   CardActions,
   CardContent,
   CardHeader,
-  Modal
+  Modal,
+  Tab,
+  Tabs,
+  Typography
 } from '@mui/material';
 import FeedbackSubmitForm from '../feedback_submit_form/FeedbackSubmitForm';
 import SelectUserModal from './SelectUserModal';
@@ -26,7 +25,6 @@ import {
   cancelFeedbackRequest,
   updateFeedbackRequest
 } from '../../api/feedback';
-import { selectCsrfToken } from '../../context/selectors';
 import { UPDATE_TOAST } from '../../context/actions';
 
 const propTypes = {

--- a/web-ui/src/components/reviews/TeamMemberReview.jsx
+++ b/web-ui/src/components/reviews/TeamMemberReview.jsx
@@ -1,32 +1,27 @@
 import React, { useContext, useState, useCallback } from 'react';
-import { useTheme } from '@mui/material/styles';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import SwipeableViews from 'react-swipeable-views';
 import PropTypes from 'prop-types';
 import { AppContext } from '../../context/AppContext';
-import { selectCurrentUser, selectProfile } from '../../context/selectors';
-import AppBar from '@mui/material/AppBar';
-import Button from '@mui/material/Button';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
-import Typography from '@mui/material/Typography';
+import { selectCsrfToken, selectCurrentUser, selectProfile } from '../../context/selectors';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-import Box from '@mui/material/Box';
 import {
+  AppBar,
+  Box,
+  Button,
   Card,
   CardActions,
   CardContent,
   CardHeader,
-  Modal
+  Modal,
+  Tab,
+  Tabs,
+  Typography
 } from '@mui/material';
 import FeedbackSubmitForm from '../feedback_submit_form/FeedbackSubmitForm';
 import SelectUserModal from './SelectUserModal';
-import {
-  cancelFeedbackRequest,
-  updateFeedbackRequest
-} from '../../api/feedback';
-import { selectCsrfToken } from '../../context/selectors';
+import { cancelFeedbackRequest, updateFeedbackRequest } from '../../api/feedback';
 import { UPDATE_TOAST } from '../../context/actions';
 
 const propTypes = {

--- a/web-ui/src/components/reviews/TeamReviews.jsx
+++ b/web-ui/src/components/reviews/TeamReviews.jsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState
 } from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import {
   AddCircle,

--- a/web-ui/src/components/reviews/periods/ReviewPeriods.jsx
+++ b/web-ui/src/components/reviews/periods/ReviewPeriods.jsx
@@ -19,21 +19,14 @@ import {
 } from '@mui/material';
 
 import { useQueryParameters } from '../../../helpers/query-parameters';
-import { UPDATE_TOAST } from '../../../context/actions';
+import { ADD_REVIEW_PERIOD, UPDATE_REVIEW_PERIODS, UPDATE_TOAST } from '../../../context/actions';
 
 import { styled } from '@mui/material/styles';
 
 import { findSelfReviewRequestsByPeriodAndTeamMember } from '../../../api/feedback.js';
 import { getAllFeedbackTemplates } from '../../../api/feedbacktemplate.js';
-import {
-  createReviewPeriod,
-  getReviewPeriods
-} from '../../../api/reviewperiods.js';
+import { createReviewPeriod, getReviewPeriods } from '../../../api/reviewperiods.js';
 import { AppContext } from '../../../context/AppContext';
-import {
-  ADD_REVIEW_PERIOD,
-  UPDATE_REVIEW_PERIODS
-} from '../../../context/actions';
 import {
   selectCsrfToken,
   selectCurrentUserId,

--- a/web-ui/src/components/team-results/TeamResults.jsx
+++ b/web-ui/src/components/team-results/TeamResults.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import TeamSummaryCard from './TeamSummaryCard';
 import { AppContext } from '../../context/AppContext';

--- a/web-ui/src/components/team-results/TeamsActions.jsx
+++ b/web-ui/src/components/team-results/TeamsActions.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 
 import AddTeamModal from './EditTeamModal';
 import { createTeam } from '../../api/team';

--- a/web-ui/src/components/template-card/TemplateCard.jsx
+++ b/web-ui/src/components/template-card/TemplateCard.jsx
@@ -1,18 +1,16 @@
-import './TemplateCard.css';
 import React, { useContext, useEffect, useState } from 'react';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
+import { Card, CardContent, CardHeader } from '@mui/material';
 import PropTypes from 'prop-types';
 import IconButton from '@mui/material/IconButton';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import './TemplateCard.css';
 import withStyles from '@mui/styles/withStyles';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { green } from '@mui/material/colors';
-import { CardHeader } from '@mui/material';
 import { AppContext } from '../../context/AppContext';
 import { selectCsrfToken } from '../../context/selectors';
 import { getMember } from '../../api/member';
+
+import './TemplateCard.css';
 
 const cutText = (text, maxCharacters) => {
   if (!text) {

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
-import { Avatar, Checkbox, Chip, TextField, Typography } from '@mui/material';
-import './ViewFeedbackResponses.css';
+import { Autocomplete, Avatar, Button, Checkbox, Chip, TextField, Typography } from '@mui/material';
 import FeedbackResponseCard from './feedback_response_card/FeedbackResponseCard';
 import { getQuestionsAndAnswers } from '../../api/feedbackanswer';
 import { getFeedbackRequestById } from '../../api/feedback';
@@ -12,12 +11,12 @@ import { selectCsrfToken, selectProfile } from '../../context/selectors';
 import { UPDATE_TOAST } from '../../context/actions';
 import InputAdornment from '@mui/material/InputAdornment';
 import { Search as SearchIcon } from '@mui/icons-material';
-import { Autocomplete } from '@mui/material';
 import { getAvatarURL } from '../../api/api';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import SkeletonLoader from '../skeleton_loader/SkeletonLoader';
-import { Button } from '@mui/material';
+
+import './ViewFeedbackResponses.css';
 
 const PREFIX = 'MuiCardContent';
 const classes = {

--- a/web-ui/src/components/volunteer/VolunteerTables.jsx
+++ b/web-ui/src/components/volunteer/VolunteerTables.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { useReducer, useState } from 'react';
-import { Box, Button, Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 
 import Organizations from './Organizations';
 import VolunteerEvents from './VolunteerEvents';
 import VolunteerRelationships from './VolunteerRelationships';
+
 import './VolunteerTables.css';
 
 const a11yProps = index => ({

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -17,7 +17,6 @@ import queryString from 'query-string';
 import FeedbackTemplateSelector from '../components/feedback_template_selector/FeedbackTemplateSelector';
 import FeedbackRecipientSelector from '../components/feedback_recipient_selector/FeedbackRecipientSelector';
 import SelectDate from '../components/feedback_date_selector/SelectDate';
-import './FeedbackRequestPage.css';
 import { AppContext } from '../context/AppContext';
 import { createFeedbackRequest } from '../api/feedback';
 import {
@@ -27,8 +26,9 @@ import {
   selectCurrentMemberIds
 } from '../context/selectors';
 import DateFnsUtils from '@date-io/date-fns';
-import { getFeedbackTemplate } from '../api/feedbacktemplate';
-import { softDeleteAdHocTemplates } from '../api/feedbacktemplate';
+import { getFeedbackTemplate, softDeleteAdHocTemplates } from '../api/feedbacktemplate';
+
+import './FeedbackRequestPage.css';
 
 const dateUtils = new DateFnsUtils();
 const PREFIX = 'FeedbackRequestPage';

--- a/web-ui/src/pages/FeedbackSubmitPage.jsx
+++ b/web-ui/src/pages/FeedbackSubmitPage.jsx
@@ -1,7 +1,5 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { styled } from '@mui/material/styles';
-import { useState } from 'react';
-import './FeedbackRequestPage.css';
 import FeedbackSubmissionTips from '../components/feedback_submission_tips/FeedbackSubmissionTips';
 import FeedbackSubmitForm from '../components/feedback_submit_form/FeedbackSubmitForm';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -15,6 +13,8 @@ import { getFeedbackRequestById } from '../api/feedback';
 import Typography from '@mui/material/Typography';
 import { UPDATE_TOAST } from '../context/actions';
 import * as queryString from 'query-string';
+
+import './FeedbackRequestPage.css';
 
 const PREFIX = 'FeedbackSubmitPage';
 const classes = {

--- a/web-ui/src/pages/MemberProfilePage.jsx
+++ b/web-ui/src/pages/MemberProfilePage.jsx
@@ -1,9 +1,11 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 
 import {
   selectCurrentUserId,
   selectIsAdmin,
+  selectOrderedMemberFirstName,
+  selectOrderedPdls,
   selectProfile,
   selectTerminatedMembers,
   selectSupervisorHierarchyIds
@@ -17,12 +19,6 @@ import ProfilePage from './ProfilePage';
 import CertificationBadges from '../components/certifications/CertificationBadges';
 import VolunteerBadges from '../components/volunteer/VolunteerBadges';
 import { levelList } from '../context/util';
-import {
-  selectOrderedPdls,
-  selectOrderedMemberFirstName
-} from '../context/selectors';
-
-import './MemberProfilePage.css';
 
 import {
   Avatar,
@@ -36,7 +32,8 @@ import {
   Tooltip,
   Typography
 } from '@mui/material';
-import { useHistory } from 'react-router-dom';
+
+import './MemberProfilePage.css';
 
 const MemberProfilePage = () => {
   const { state } = useContext(AppContext);

--- a/web-ui/src/pages/PulseReportPage.jsx
+++ b/web-ui/src/pages/PulseReportPage.jsx
@@ -37,8 +37,6 @@ import MemberSelector from '../components/member_selector/MemberSelector';
 import { AppContext } from '../context/AppContext.jsx';
 import {
   selectCsrfToken,
-  selectCurrentUser,
-  selectHasViewPulseReportPermission,
   selectProfileMap
 } from '../context/selectors.js';
 import ExpandMore from '../components/expand-more/ExpandMore';


### PR DESCRIPTION
This PR clears up 80 warnings issued by Sonar around imports in the React code in 2 commits (might be easier to review each commit separately)

1. [Imports from the same module should be merged](https://github.com/objectcomputing/check-ins/commit/71906208d6693fd5a57823e2e02df6a6b7f11b0d)

    > Having the same module imported multiple times can affect code readability and maintainability.

2. [Unnecessary imports should be removed](https://github.com/objectcomputing/check-ins/commit/82df0520b93db75b286b9beb067fa4b9931c7a04)

    > These imports do not contribute to the functionality of the application and only add extra weight to the JavaScript bundle, leading to potential performance and maintainability issues.