### PR TITLE
Use the same message for all permission issues

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemServicesImpl.java
@@ -17,11 +17,13 @@ import org.slf4j.LoggerFactory;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
 public class AgendaItemServicesImpl implements AgendaItemServices {
-    public static final Logger LOG = LoggerFactory.getLogger(AgendaItemServicesImpl.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgendaItemServicesImpl.class);
 
     private final CheckInRepository checkinRepo;
     private final AgendaItemRepository agendaItemRepository;
@@ -62,11 +64,11 @@ public class AgendaItemServicesImpl implements AgendaItemServices {
 
             if (!canUpdateAllCheckins) {
                 boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
-                validate(isCompleted, "User is unauthorized to do this operation");
+                validate(isCompleted, NOT_AUTHORIZED_MSG);
 
                 final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
                 boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createById);
-                validate(!currentUserIsCheckinParticipant, "User is unauthorized to do this operation");
+                validate(!currentUserIsCheckinParticipant, NOT_AUTHORIZED_MSG);
             }
 
             double lastDisplayOrder = agendaItemRepository.findMaxPriorityByCheckinid(agendaItem.getCheckinid()).orElse(0d);
@@ -92,7 +94,7 @@ public class AgendaItemServicesImpl implements AgendaItemServices {
             final UUID createById = checkinRecord != null ? checkinRecord.getTeamMemberId() : null;
             
             boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createById);
-            validate(!currentUserIsCheckinParticipant, "User is unauthorized to do this operation");
+            validate(!currentUserIsCheckinParticipant, NOT_AUTHORIZED_MSG);
         }
 
         return agendaItemResult;
@@ -116,7 +118,7 @@ public class AgendaItemServicesImpl implements AgendaItemServices {
 
             CheckIn checkinRecord = checkinRepo.findById(checkinId).orElse(null);
             boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
-            validate(isCompleted, "User is unauthorized to do this operation");
+            validate(isCompleted, NOT_AUTHORIZED_MSG);
             final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
 
             final UUID createById = agendaItem.getCreatedbyid();
@@ -125,7 +127,7 @@ public class AgendaItemServicesImpl implements AgendaItemServices {
                 
             if (!canUpdateAllCheckins) {
                 boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createById);
-                validate(!currentUserIsCheckinParticipant, "User is unauthorized to do this operation");
+                validate(!currentUserIsCheckinParticipant, NOT_AUTHORIZED_MSG);
             }
 
             LOG.info("Updating new AgendaItem: {}", agendaItem.getId());
@@ -139,7 +141,7 @@ public class AgendaItemServicesImpl implements AgendaItemServices {
     public Set<AgendaItem> findByFields(@Nullable UUID checkinId, @Nullable UUID createdById) {
         MemberProfile currentUser = currentUserServices.getCurrentUser();
         if(!checkInServices.doesUserHaveViewAccess(currentUser.getId(), checkinId, createdById)){
-            throw new PermissionException("User is unauthorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         LOG.info("Finding AgendaItem by checkinId: {}, and createById: {}", checkinId, createdById);
         return agendaItemRepository.search(nullSafeUUIDToString(checkinId), nullSafeUUIDToString(createdById));
@@ -156,12 +158,12 @@ public class AgendaItemServicesImpl implements AgendaItemServices {
             CheckIn checkinRecord = checkinRepo.findById(agendaItemResult.getCheckinid()).orElse(null);
 
             boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
-            validate(isCompleted, "User is unauthorized to do this operation");
+            validate(isCompleted, NOT_AUTHORIZED_MSG);
             final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
             final UUID createById = checkinRecord != null ? checkinRecord.getTeamMemberId() : null;
 
             boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createById);
-            validate(!currentUserIsCheckinParticipant, "User is unauthorized to do this operation");
+            validate(!currentUserIsCheckinParticipant, NOT_AUTHORIZED_MSG);
         }
         LOG.info("Deleting AgendaItem by id: {}", id);
         agendaItemRepository.deleteById(id);

--- a/server/src/main/java/com/objectcomputing/checkins/services/checkin_notes/CheckinNoteServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/checkin_notes/CheckinNoteServicesImpl.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
@@ -57,13 +58,13 @@ public class CheckinNoteServicesImpl implements CheckinNoteServices {
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         boolean allowedToView = checkinServices.accessGranted(checkinId, currentUserId);
         if (!allowedToView) {
-            throw new PermissionException("You do not have permission to access this resource");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         boolean canUpdateAllCheckins = checkinServices.canUpdateAllCheckins(currentUserId);
         boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
         if (!canUpdateAllCheckins && isCompleted) {
-            validate(true, "User is unauthorized to do this operation");
+            validate(true, NOT_AUTHORIZED_MSG);
         }
         LOG.info("Saving new checkinNote");
         return checkinNoteRepository.save(checkinNote);
@@ -82,7 +83,7 @@ public class CheckinNoteServicesImpl implements CheckinNoteServices {
 
         boolean allowedToView = checkinServices.accessGranted(checkinRecord.getId(), currentUserId);
         if (!allowedToView) {
-            throw new PermissionException("User is unauthorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         LOG.info("Found checkin note with id {}", id);
         return checkInNoteResult;
@@ -107,7 +108,7 @@ public class CheckinNoteServicesImpl implements CheckinNoteServices {
         boolean allowedToView = checkinServices.accessGranted(checkinRecordId, currentUserId);
         if (!allowedToView) {
             LOG.debug("Access was not granted.");
-            throw new PermissionException("User is unauthorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         boolean canUpdateAllCheckins = checkinServices.canUpdateAllCheckins(currentUserId);
@@ -115,7 +116,7 @@ public class CheckinNoteServicesImpl implements CheckinNoteServices {
         if (!canUpdateAllCheckins && isCompleted) {
             LOG.debug("User isn't admin and checkin is completed.");
             final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
-            validate(!currentUserId.equals(pdlId), "User is unauthorized to do this operation");
+            validate(!currentUserId.equals(pdlId), NOT_AUTHORIZED_MSG);
         }
 
         LOG.info("Updating checkinNote {}", checkinNote.getId());
@@ -126,7 +127,7 @@ public class CheckinNoteServicesImpl implements CheckinNoteServices {
     public Set<CheckinNote> findByFields(@Nullable UUID checkinId, @Nullable UUID createById) {
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         if(!checkinServices.doesUserHaveViewAccess(currentUserId, checkinId, createById)){
-            throw new PermissionException("User is unauthorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         LOG.info("Finding AgendaItem by checkinId: {}, and createById: {}", checkinId, createById);
         return checkinNoteRepository.search(nullSafeUUIDToString(checkinId), nullSafeUUIDToString(createById));

--- a/server/src/main/java/com/objectcomputing/checkins/services/demographics/DemographicsServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/demographics/DemographicsServicesImpl.java
@@ -14,10 +14,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
 public class DemographicsServicesImpl implements DemographicsServices{
+
     private final DemographicsRepository demographicsRepository;
     private final MemberProfileServices memberProfileServices;
     private final CurrentUserServices currentUserServices;
@@ -35,7 +37,7 @@ public class DemographicsServicesImpl implements DemographicsServices{
         if (!currentUserServices.isAdmin() &&
                 (demographics!= null && demographics.getMemberId() != null &&
                         !demographics.getMemberId().equals(currentUserServices.getCurrentUser().getId()))) {
-            throw new PermissionException("You are not authorized to access this Demographics");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return demographics;
@@ -52,7 +54,7 @@ public class DemographicsServicesImpl implements DemographicsServices{
                                           @Nullable String militaryBranch) {
 
         if (!currentUserServices.isAdmin()) {
-            throw new PermissionException("Requires admin privileges");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return new ArrayList<>(demographicsRepository.searchByValues(nullSafeUUIDToString(memberId),
@@ -70,7 +72,7 @@ public class DemographicsServicesImpl implements DemographicsServices{
         if (!currentUserServices.isAdmin() &&
                 (demographics.getMemberId() != null &&
                         !demographics.getMemberId().equals(currentUserServices.getCurrentUser().getId()))) {
-            throw new PermissionException("You are not authorized to update this demographic");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         Demographics newDemographics;
@@ -88,7 +90,7 @@ public class DemographicsServicesImpl implements DemographicsServices{
         if (!currentUserServices.isAdmin() &&
                 (demographics.getMemberId() != null &&
                         !demographics.getMemberId().equals(currentUserServices.getCurrentUser().getId()))) {
-            throw new PermissionException("You are not authorized to create this Demographic");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         Demographics demographicsRet;
@@ -110,7 +112,7 @@ public class DemographicsServicesImpl implements DemographicsServices{
     @Override
     public List<Demographics> findAll() {
         if (!currentUserServices.isAdmin()) {
-            throw new PermissionException("Requires admin privileges");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return demographicsRepository.findAll();
@@ -119,7 +121,7 @@ public class DemographicsServicesImpl implements DemographicsServices{
     @Override
     public void deleteDemographics(@NotNull UUID id) {
         if (!currentUserServices.isAdmin()) {
-            throw new PermissionException("Requires admin privileges");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (demographicsRepository.findById(id).isEmpty()) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/email/EmailServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/email/EmailServicesImpl.java
@@ -6,11 +6,10 @@ import com.objectcomputing.checkins.notifications.email.MailJetConfig;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileRepository;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,10 +18,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class EmailServicesImpl implements EmailServices {
 
     private static final Logger LOG = LoggerFactory.getLogger(EmailServicesImpl.class);
+
     private EmailSender htmlEmailSender;
     private EmailSender textEmailSender;
     private final CurrentUserServices currentUserServices;
@@ -55,7 +57,7 @@ public class EmailServicesImpl implements EmailServices {
         List<Email> sentEmails = new ArrayList<>();
 
         if (!currentUserServices.isAdmin()) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         MemberProfile currentUser = currentUserServices.getCurrentUser();

--- a/server/src/main/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursServicesImpl.java
@@ -11,15 +11,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 
 @Singleton
 public class EmployeeHoursServicesImpl implements EmployeeHoursServices{
 
+    private static final Logger LOG = LoggerFactory.getLogger(MemberPhotoServiceImpl.class);
+
     private final MemberProfileRepository memberRepo;
     private final CurrentUserServices currentUserServices;
     private final EmployeeHoursRepository employeehourRepo;
-    private static final Logger LOG = LoggerFactory.getLogger(MemberPhotoServiceImpl.class);
 
 
 
@@ -39,7 +46,7 @@ public class EmployeeHoursServicesImpl implements EmployeeHoursServices{
         List<EmployeeHours> employeeHoursList = new ArrayList<>();
         Set<EmployeeHours> employeeHours = new HashSet<>();
         EmployeeHoursResponseDTO responseDTO = new EmployeeHoursResponseDTO();
-        validate(!isAdmin, "You are not authorized to perform this operation");
+        validate(!isAdmin, NOT_AUTHORIZED_MSG);
         responseDTO.setRecordCountDeleted(employeehourRepo.count());
         employeehourRepo.deleteAll();
         try {
@@ -72,10 +79,10 @@ public class EmployeeHoursServicesImpl implements EmployeeHoursServices{
 
         if(employeeId !=null) {
             validate((!isAdmin && currentUser!=null&& !currentUser.getEmployeeId().equals(employeeId)),
-                       "You are not authorized to perform this operation");
+                       NOT_AUTHORIZED_MSG);
             employeeHours.retainAll(employeehourRepo.findByEmployeeId(employeeId));
         } else {
-            validate(!isAdmin, "You are not authorized to perform this operation");
+            validate(!isAdmin, NOT_AUTHORIZED_MSG);
         }
 
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionServiceImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback/suggestions/FeedbackSuggestionServiceImpl.java
@@ -1,13 +1,12 @@
 package com.objectcomputing.checkins.services.feedback.suggestions;
 
-
+import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
 import com.objectcomputing.checkins.services.team.member.TeamMember;
 import com.objectcomputing.checkins.services.team.member.TeamMemberServices;
 import io.micronaut.context.annotation.Property;
-import com.objectcomputing.checkins.exceptions.PermissionException;
 import jakarta.inject.Singleton;
 
 import java.time.LocalDate;
@@ -16,6 +15,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 
 @Singleton
 public class FeedbackSuggestionServiceImpl implements FeedbackSuggestionsService {
@@ -45,7 +46,7 @@ public class FeedbackSuggestionServiceImpl implements FeedbackSuggestionsService
         MemberProfile suggestFor = memberProfileServices.getById(id);
 
         if (currentUserId == null) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         List<FeedbackSuggestionDTO> suggestions = new LinkedList<>();

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerServicesImpl.java
@@ -10,12 +10,15 @@ import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
 import com.objectcomputing.checkins.util.Util;
-import java.util.List;
 import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Singleton;
+
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 
 @Singleton
 public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
@@ -46,7 +49,7 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
 
         FeedbackRequest relatedFeedbackRequest = getRelatedFeedbackRequest(feedbackAnswer);
         if (!createIsPermitted(relatedFeedbackRequest)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         } else if (relatedFeedbackRequest.getStatus().equals("canceled")) {
             throw new BadArgException("Attempted to save an answer for a canceled feedback request");
         }
@@ -72,7 +75,7 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
 
         FeedbackRequest relatedFeedbackRequest = getRelatedFeedbackRequest(feedbackAnswer);
         if (!updateIsPermitted(relatedFeedbackRequest)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return feedbackAnswerRepository.update(feedbackAnswer);
@@ -90,7 +93,7 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
         if (getIsPermitted(relatedFeedbackRequest)) {
             return feedbackAnswer.get();
         } else {
-            throw new PermissionException("You are not authorized to do this operation :(");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
     }
 
@@ -115,7 +118,7 @@ public class FeedbackAnswerServicesImpl implements FeedbackAnswerServices {
             return response;
         }
 
-        throw new PermissionException("You are not authorized to do that operation");
+        throw new PermissionException(NOT_AUTHORIZED_MSG);
 
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerServicesImpl.java
@@ -17,9 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 
 @Singleton
 public class QuestionAndAnswerServicesImpl implements QuestionAndAnswerServices {
+
     private final FeedbackAnswerServices feedbackAnswerServices;
     private final CurrentUserServices currentUserServices;
     private final TemplateQuestionServices templateQuestionServices;
@@ -41,7 +43,7 @@ public class QuestionAndAnswerServicesImpl implements QuestionAndAnswerServices 
     public List<Tuple> getAllQuestionsAndAnswers(UUID requestId) {
         FeedbackRequest feedbackRequest = feedbackRequestServices.getById(requestId);
         if (!getIsPermitted(feedbackRequest)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         List<TemplateQuestion> templateQuestions = templateQuestionServices.findByFields(feedbackRequest.getTemplateId());
         List<FeedbackAnswer> answerList = feedbackAnswerServices.findByValues(null, requestId);
@@ -76,7 +78,7 @@ public class QuestionAndAnswerServicesImpl implements QuestionAndAnswerServices 
         FeedbackRequest feedbackRequest = feedbackRequestServices.getById(requestId);
 
         if (!getIsPermitted(feedbackRequest)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (questionId != null) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -18,8 +18,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 
 @Singleton
 public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
@@ -82,7 +90,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
     public FeedbackRequest save(FeedbackRequest feedbackRequest) {
         validateMembers(feedbackRequest);
         if (!createIsPermitted(feedbackRequest.getRequesteeId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (feedbackRequest.getId() != null) {
@@ -147,13 +155,13 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         // If a status update is made to anything other than submitted by the requestee, throw an error.
         if (!feedbackRequest.getStatus().equals("submitted") && !Objects.equals(originalFeedback.getStatus(), feedbackRequest.getStatus())) {
             if (currentUserServices.getCurrentUser().getId().equals(originalFeedback.getRequesteeId())) {
-                throw new PermissionException("You are not authorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
         }
 
         if (reassignAttempted) {
             if (!reassignIsPermitted(originalFeedback)) {
-                throw new PermissionException("You are not authorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
             feedbackRequest.setStatus("sent");
         }
@@ -163,15 +171,15 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         }
 
         if (dueDateUpdateAttempted && !updateDueDateIsPermitted(originalFeedback)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (dueDateUpdateAttempted && !updateDueDateIsPermitted(originalFeedback)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (submitDateUpdateAttempted && !updateSubmitDateIsPermitted(originalFeedback)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (feedbackRequest.getDueDate() != null && originalFeedback.getSendDate().isAfter(feedbackRequest.getDueDate())) {
@@ -216,7 +224,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         }
 
         if (!createIsPermitted(feedbackReq.get().getRequesteeId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         feedbackReqRepository.deleteById(id);
@@ -232,7 +240,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         final UUID requesteeId = feedbackReq.get().getRequesteeId();
         final UUID recipientId = feedbackReq.get().getRecipientId();
         if (!getIsPermitted(requesteeId, recipientId, sendDate)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return feedbackReq.get();
@@ -242,7 +250,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
     public List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, UUID recipientId, LocalDate oldestDate, UUID reviewPeriodId, UUID templateId, List<UUID> requesteeIds) {
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         if (currentUserId == null) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         List<FeedbackRequest> feedbackReqList = new ArrayList<>();

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
 
@@ -60,7 +62,7 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
         feedbackTemplate.setIsReview(originalTemplate.get().getIsReview());
 
         if (!updateIsPermitted(originalTemplate.get().getCreatorId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return feedbackTemplateRepository.update(feedbackTemplate);
@@ -71,7 +73,7 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
         final FeedbackTemplate template = getById(id);
 
         if (!deleteIsPermitted(template.getCreatorId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         // delete the template itself
@@ -103,7 +105,7 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
     @Override
     public boolean setAdHocInactiveByCreator(@Nullable UUID creatorId) {
         if (!updateIsPermitted(creatorId)) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         feedbackTemplateRepository.setAdHocInactiveByCreator(Util.nullSafeUUIDToString(creatorId));
         return true;

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionServicesImpl.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class TemplateQuestionServicesImpl implements TemplateQuestionServices {
 
@@ -53,7 +55,7 @@ public class TemplateQuestionServicesImpl implements TemplateQuestionServices {
         }
 
         if (!createIsPermitted(feedbackTemplate.get().getCreatorId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return templateQuestionRepository.save(templateQuestion);
@@ -84,7 +86,7 @@ public class TemplateQuestionServicesImpl implements TemplateQuestionServices {
         }
 
         if (!updateIsPermitted(feedbackTemplate.get().getCreatorId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return templateQuestionRepository.update(templateQuestion);
@@ -103,7 +105,7 @@ public class TemplateQuestionServicesImpl implements TemplateQuestionServices {
         if (feedbackTemplate.isEmpty()) {
             throw new NotFoundException("Could not find feedback template with ID " + templateQuestion.get().getTemplateId());
         } else if (!deleteIsPermitted(feedbackTemplate.get().getCreatorId())) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         // Delete the question
@@ -114,7 +116,7 @@ public class TemplateQuestionServicesImpl implements TemplateQuestionServices {
     public TemplateQuestion getById(UUID id) {
         final Optional<TemplateQuestion> templateQuestion = templateQuestionRepository.findById(id);
         if (!getIsPermitted()) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (templateQuestion.isEmpty()) {
@@ -129,7 +131,7 @@ public class TemplateQuestionServicesImpl implements TemplateQuestionServices {
         if (templateId == null) {
             throw new BadArgException("Cannot find template questions for null template ID");
         } else if (!getIsPermitted()) {
-            throw new PermissionException("You are not authorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         return new ArrayList<>(templateQuestionRepository.findByTemplateId(Util.nullSafeUUIDToString(templateId)));

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
@@ -30,6 +30,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class FileServicesImpl implements FileServices {
 
@@ -60,7 +62,7 @@ public class FileServicesImpl implements FileServices {
     public Set<FileInfoDTO> findFiles(@Nullable UUID checkInID) {
 
         boolean isAdmin = currentUserServices.isAdmin();
-        validate(checkInID == null && !isAdmin, "You are not authorized to perform this operation");
+        validate(checkInID == null && !isAdmin, NOT_AUTHORIZED_MSG);
 
         try {
             Set<FileInfoDTO> result = new HashSet<>();
@@ -118,7 +120,7 @@ public class FileServicesImpl implements FileServices {
         CheckIn associatedCheckin = checkInServices.read(cd.getCheckinsId());
 
         if(!isAdmin) {
-            validate((!currentUser.getId().equals(associatedCheckin.getTeamMemberId()) && !currentUser.getId().equals(associatedCheckin.getPdlId())), "You are not authorized to perform this operation");
+            validate((!currentUser.getId().equals(associatedCheckin.getTeamMemberId()) && !currentUser.getId().equals(associatedCheckin.getPdlId())), NOT_AUTHORIZED_MSG);
         }
         try {
             java.io.File file = java.io.File.createTempFile("tmp", ".txt");
@@ -154,7 +156,7 @@ public class FileServicesImpl implements FileServices {
         validate(checkIn == null, "Unable to find checkin record with id %s", checkInID);
         if(!isAdmin) {
             validate((!currentUser.getId().equals(checkIn.getTeamMemberId()) && !currentUser.getId().equals(checkIn.getPdlId())), "You are not authorized to perform this operation");
-            validate(checkIn.isCompleted(), "You are not authorized to perform this operation");
+            validate(checkIn.isCompleted(), NOT_AUTHORIZED_MSG);
         }
 
         // create folder for each team member
@@ -227,7 +229,7 @@ public class FileServicesImpl implements FileServices {
 
         CheckIn associatedCheckin = checkInServices.read(cd.getCheckinsId());
         if(!isAdmin) {
-            validate((!currentUser.getId().equals(associatedCheckin.getTeamMemberId()) && !currentUser.getId().equals(associatedCheckin.getPdlId())), "You are not authorized to perform this operation");
+            validate((!currentUser.getId().equals(associatedCheckin.getTeamMemberId()) && !currentUser.getId().equals(associatedCheckin.getPdlId())), NOT_AUTHORIZED_MSG);
         }
 
         try {

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
@@ -32,10 +32,15 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
 public class GuildServicesImpl implements GuildServices {
+
+    public static final String WEB_ADDRESS = "check-ins.web-address";
+
+    private static final Logger LOG = LoggerFactory.getLogger(GuildServicesImpl.class);;
 
     private final GuildRepository guildsRepo;
     private final GuildMemberRepository guildMemberRepo;
@@ -46,8 +51,6 @@ public class GuildServicesImpl implements GuildServices {
     private EmailSender emailSender;
     private final Environment environment;
     private final String webAddress;
-    public static final String WEB_ADDRESS = "check-ins.web-address";
-    private static final Logger LOG = LoggerFactory.getLogger(GuildServicesImpl.class);;
 
     public GuildServicesImpl(GuildRepository guildsRepo,
                              GuildMemberRepository guildMemberRepo, GuildMemberHistoryRepository guildMemberHistoryRepository,
@@ -216,7 +219,7 @@ public class GuildServicesImpl implements GuildServices {
 
             return updated;
         } else {
-            throw new PermissionException("You are not authorized to perform this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
     }
 
@@ -246,7 +249,7 @@ public class GuildServicesImpl implements GuildServices {
             guildMemberRepo.deleteByGuildId(id.toString());
             guildsRepo.deleteById(id);
         } else {
-            throw new PermissionException("You are not authorized to perform this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         return true;
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
@@ -23,8 +23,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class GuildMemberServicesImpl implements GuildMemberServices {
+
+    public static final String WEB_ADDRESS = "check-ins.web-address";
 
     private final GuildRepository guildRepo;
     private final GuildMemberRepository guildMemberRepo;
@@ -33,7 +37,6 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
     private final GuildMemberHistoryRepository guildMemberHistoryRepository;
     private EmailSender emailSender;
     private final String webAddress;
-    public static final String WEB_ADDRESS = "check-ins.web-address";
 
     public GuildMemberServicesImpl(GuildRepository guildRepo,
                                    GuildMemberRepository guildMemberRepo,
@@ -76,11 +79,11 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
         }
         // only allow admins to create guild leads
         else if (!currentUserServices.isAdmin() && Boolean.TRUE.equals(guildMember.getLead())) {
-            throw new BadArgException("You are not authorized to perform this operation");
+            throw new BadArgException(NOT_AUTHORIZED_MSG);
         }
         // only admins and leads can add members to guilds unless a user adds themself
         else if (!currentUserServices.isAdmin() && !guildMember.getMemberId().equals(currentUser.getId()) && !isLead){
-            throw new PermissionException("You are not authorized to perform this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         emailSender
@@ -120,7 +123,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
         } else if (guildMemberRepo.findByGuildIdAndMemberId(guildMember.getGuildId(), guildMember.getMemberId()).isEmpty()) {
             throw new BadArgException(String.format("Member %s is not part of guild %s", memberId, guildId));
         } else if (!isAdmin && guildLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
-            throw new BadArgException("You are not authorized to perform this operation");
+            throw new BadArgException(NOT_AUTHORIZED_MSG);
         }
         GuildMember guildMemberUpdate = guildMemberRepo.update(guildMember);
         guildMemberHistoryRepository.save(buildGuildMemberHistory(guildId,memberId,"Updated", LocalDateTime.now()));
@@ -159,7 +162,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
         }
         // if the current user is not an admin, is not the same as the member in the request, and is not a lead in the guild -> don't delete
         if (!currentUserServices.isAdmin() && !guildMember.getMemberId().equals(currentUser.getId()) && !currentUserIsLead) {
-            throw new PermissionException("You are not authorized to perform this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         Guild guild = guildRepo.findById(guildMember.getGuildId())

--- a/server/src/main/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesServicesImpl.java
@@ -52,7 +52,7 @@ public class OpportunitiesServicesImpl implements OpportunitiesService {
     @Override
     public Opportunities update(Opportunities opportunitiesResponse) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
         Opportunities opportunitiesResponseRet = null;
         if(opportunitiesResponse!=null){
             final UUID id = opportunitiesResponse.getId();
@@ -76,7 +76,7 @@ public class OpportunitiesServicesImpl implements OpportunitiesService {
     @Override
     public void delete(@NotNull UUID id) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
         opportunitiesResponseRepo.deleteById(id);
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteServicesImpl.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
@@ -57,12 +58,12 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
             boolean isCompleted = checkinRecord != null ? checkinRecord.isCompleted() : false;
             boolean allowedToView = checkinServices.accessGranted(checkinRecord.getId(), currentUserId);
             if (!allowedToView || isCompleted ) {
-                throw new PermissionException("User is unauthorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
 
             boolean currentUserIsCheckinSubject = currentUserId.equals(checkinRecord.getTeamMemberId());
             if(currentUserIsCheckinSubject) {
-                throw new PermissionException("User is unauthorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
 
         }
@@ -87,11 +88,11 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
             }
 
             if (!checkinServices.accessGranted(checkinRecord.getId(), currentUserId)) {
-                throw new PermissionException("User is unauthorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
 
             if(currentUserId.equals(checkinRecord.getTeamMemberId())) {
-                throw new PermissionException("User is unauthorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
         }
 
@@ -119,12 +120,12 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
             boolean allowedToView = checkinServices.accessGranted(checkinRecord.getId(), currentUserId);
 
             if (!allowedToView || isCompleted ) {
-                throw new PermissionException("User is unauthorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
 
             boolean currentUserIsCheckinSubject = currentUserId.equals(checkinRecord.getTeamMemberId());
             if(currentUserIsCheckinSubject) {
-                throw new PermissionException("User is unauthorized to do this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
         }
 
@@ -135,7 +136,7 @@ public class PrivateNoteServicesImpl implements PrivateNoteServices {
     public Set<PrivateNote> findByFields(@Nullable UUID checkinId, @Nullable UUID createById) {
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         if(!checkinServices.doesUserHaveViewAccess(currentUserId, checkinId, createById)){
-            throw new PermissionException("User is unauthorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         return privateNoteRepository.search(nullSafeUUIDToString(checkinId), nullSafeUUIDToString(createById));
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryServicesImpl.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class QuestionCategoryServicesImpl implements QuestionCategoryServices {
 
@@ -43,7 +45,7 @@ public class QuestionCategoryServicesImpl implements QuestionCategoryServices {
     @Override
     public QuestionCategory saveQuestionCategory(QuestionCategory questionCategory) {
         if (!currentUserServices.isAdmin()) {
-            throw new PermissionException("You do not have permission to access this resource");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
 
         if (questionCategory.getId() != null) {
@@ -79,7 +81,7 @@ public class QuestionCategoryServicesImpl implements QuestionCategoryServices {
         }
         if (updatedQuestionCategory != null) {
             if (!currentUserServices.isAdmin()) {
-                throw new PermissionException("You do not have permission to access this resource");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             }
             return questionCategoryRepository.update(questionCategory);
         } else {
@@ -94,7 +96,7 @@ public class QuestionCategoryServicesImpl implements QuestionCategoryServices {
             throw new NotFoundException("No question category with id " + id);
         }
         if (!currentUserServices.isAdmin()) {
-            throw new PermissionException("You do not have permission to access this resource");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         questionCategoryRepository.deleteById(id);
         return true;

--- a/server/src/main/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillServicesImpl.java
@@ -34,7 +34,7 @@ public class CombineSkillServicesImpl implements CombineSkillServices {
 
     public Skill combine(@NotNull @Valid CombineSkillsDTO skillDTO) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         Set<Skill> existingSkills = skillServices.findByValue(skillDTO.getName(), null);
         for (Skill existingSkill : existingSkills) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/survey/SurveyServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/survey/SurveyServicesImpl.java
@@ -34,7 +34,7 @@ public class SurveyServicesImpl implements SurveyService {
     @Override
     public Survey save(Survey surveyResponse) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
         Survey surveyResponseRet = null;
         if(surveyResponse!=null){
             final UUID memberId = surveyResponse.getCreatedBy();
@@ -53,14 +53,14 @@ public class SurveyServicesImpl implements SurveyService {
 
     public Set<Survey> readAll() {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
         return new HashSet<>(surveyResponseRepo.findAll());
     }
 
     @Override
     public Survey update(Survey surveyResponse) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
         Survey surveyResponseRet = null;
         if(surveyResponse!=null){
             final UUID id = surveyResponse.getId();
@@ -84,14 +84,14 @@ public class SurveyServicesImpl implements SurveyService {
     @Override
     public void delete(@NotNull UUID id) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
         surveyResponseRepo.deleteById(id);
     }
 
     @Override
     public Set<Survey> findByFields(String name, UUID createdBy) {
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         return surveyResponseRepo.findAll().stream()
                 .filter(survey -> (name == null || name.equals(survey.getName())) &&

--- a/server/src/main/java/com/objectcomputing/checkins/services/tags/TagServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/tags/TagServicesImpl.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import java.util.UUID;
 
-
 @Singleton
 public class TagServicesImpl implements TagServices {
 
@@ -27,7 +26,7 @@ public class TagServicesImpl implements TagServices {
     public Tag save(Tag tag) {
 
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         Tag tagToReturn = null;
         if (tag != null) {
@@ -54,7 +53,7 @@ public class TagServicesImpl implements TagServices {
     public Tag update(@NotNull Tag tag) {
 
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         Tag newTag = null;
 
@@ -71,7 +70,7 @@ public class TagServicesImpl implements TagServices {
     public void delete(@NotNull UUID id) {
 
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         tagRepository.deleteById(id);
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/tags/entityTag/EntityTagServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/tags/entityTag/EntityTagServicesImpl.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
-
 @Singleton
 public class EntityTagServicesImpl implements EntityTagServices {
 
@@ -35,7 +34,7 @@ public class EntityTagServicesImpl implements EntityTagServices {
     public EntityTag save(EntityTag entityTag) {
 
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         EntityTag entityTagToReturn = null;
         if (entityTag != null) {
@@ -66,7 +65,7 @@ public class EntityTagServicesImpl implements EntityTagServices {
     public EntityTag update(@NotNull EntityTag entityTag) {
 
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         EntityTag newEntityTag = null;
 
@@ -84,7 +83,7 @@ public class EntityTagServicesImpl implements EntityTagServices {
     public void delete(@NotNull UUID id) {
 
         final boolean isAdmin = currentUserServices.isAdmin();
-        permissionsValidation.validatePermissions(!isAdmin, "User is unauthorized to do this operation");
+        permissionsValidation.validatePermissions(!isAdmin);
 
         entityTagRepository.deleteById(id);
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/TeamServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/TeamServicesImpl.java
@@ -13,9 +13,14 @@ import jakarta.inject.Singleton;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static com.objectcomputing.checkins.util.Util.nullSafeUUIDToString;
 
 @Singleton
@@ -122,7 +127,7 @@ public class TeamServicesImpl implements TeamServices {
             }
             return updated;
         } else {
-            throw new PermissionException("You are not authorized to perform this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
     }
 
@@ -150,7 +155,7 @@ public class TeamServicesImpl implements TeamServices {
             teamMemberServices.deleteByTeam(id);
             teamsRepo.deleteById(id);
         } else {
-            throw new PermissionException("You are not authorized to perform this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
         return true;
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/member/TeamMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/member/TeamMemberServicesImpl.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Singleton
 public class TeamMemberServicesImpl implements TeamMemberServices {
 
@@ -66,7 +68,7 @@ public class TeamMemberServicesImpl implements TeamMemberServices {
         } else if (teamMemberRepo.findByTeamIdAndMemberId(teamMember.getTeamId(), teamMember.getMemberId()).isPresent()) {
             throw new BadArgException(String.format("Member %s already exists in team %s", memberId, teamId));
         } else if (!isAdmin && teamLeads.size() > 0 && teamLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
-            throw new BadArgException("You are not authorized to perform this operation");
+            throw new BadArgException(NOT_AUTHORIZED_MSG);
         }
 
         TeamMember newTeamMember = teamMemberRepo.save(teamMember);
@@ -101,7 +103,7 @@ public class TeamMemberServicesImpl implements TeamMemberServices {
         } else if (teamMemberRepo.findByTeamIdAndMemberId(teamMember.getTeamId(), teamMember.getMemberId()).isEmpty()) {
             throw new BadArgException(String.format("Member %s is not part of team %s", memberId, teamId));
         } else if (!isAdmin && teamLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
-            throw new BadArgException("You are not authorized to perform this operation");
+            throw new BadArgException(NOT_AUTHORIZED_MSG);
         }
 
         TeamMember teamMemberUpdate = teamMemberRepo.update(teamMember);
@@ -135,7 +137,7 @@ public class TeamMemberServicesImpl implements TeamMemberServices {
             Set<TeamMember> teamLeads = this.findByFields(teamMember.getTeamId(), null, true);
 
             if (!isAdmin && teamLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
-                throw new PermissionException("You are not authorized to perform this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             } else {
                 teamMemberRepo.deleteById(id);
             }
@@ -156,7 +158,7 @@ public class TeamMemberServicesImpl implements TeamMemberServices {
             List<TeamMember> teamLeads = teamMembers.stream().filter(TeamMember::isLead).toList();
 
             if (!isAdmin && teamLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
-                throw new PermissionException("You are not authorized to perform this operation");
+                throw new PermissionException(NOT_AUTHORIZED_MSG);
             } else {
                 teamMembers.forEach(member -> {
                     teamMemberRepo.deleteById(member.getId());

--- a/server/src/main/java/com/objectcomputing/checkins/services/validate/PermissionsValidation.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/validate/PermissionsValidation.java
@@ -7,7 +7,10 @@ import jakarta.validation.constraints.NotNull;
 @Singleton
 public class PermissionsValidation {
 
-    public PermissionsValidation() {
+    public static final String NOT_AUTHORIZED_MSG = "You are not authorized to perform this operation";
+
+    public void validatePermissions(@NotNull boolean isError) {
+        validatePermissions(isError, NOT_AUTHORIZED_MSG);
     }
 
     public void validatePermissions(@NotNull boolean isError, @NotNull String message, Object... args) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/validate/crud/ActionItemCRUDValidator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/validate/crud/ActionItemCRUDValidator.java
@@ -16,6 +16,8 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
+
 @Named("ActionItem")
 public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
 
@@ -25,7 +27,6 @@ public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
     private final PermissionsValidation permissionsValidation;
     private final ActionItemRepository actionItemRepo;
     private final CurrentUserServices currentUserServices;
-
 
     @Inject
     public ActionItemCRUDValidator(CheckInServices checkInServices, MemberProfileServices memberServices,
@@ -105,14 +106,13 @@ public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
             CheckIn checkinRecord = checkInServices.read(checkinId);
 
             boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
-            permissionsValidation.validatePermissions(isCompleted, "User is unauthorized to do this operation");
+            permissionsValidation.validatePermissions(isCompleted);
 
             final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
             final UUID teamMemberId = checkinRecord != null ? checkinRecord.getTeamMemberId() : null;
 
             boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(teamMemberId);
-            permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant,
-                    "User is unauthorized to do this operation");
+            permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant);
         }
     }
 
@@ -127,8 +127,7 @@ public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
             final UUID createById = checkinRecord != null ? checkinRecord.getTeamMemberId() : null;
 
             boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createById);
-            permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant,
-                    "User is unauthorized to do this operation");
+            permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant);
         }
     }
 
@@ -143,13 +142,13 @@ public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
                 CheckIn checkinRecord = checkInServices.read(checkinId);
 
                 boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
-                permissionsValidation.validatePermissions(isCompleted, "User is unauthorized to do this operation");
+                permissionsValidation.validatePermissions(isCompleted);
 
                 final UUID createdById = actionItem.getCreatedbyid();
                 final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
 
                 boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createdById);
-                permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant, "User is unauthorized to do this operation");
+                permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant);
             }
         }
     }
@@ -158,7 +157,7 @@ public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
     public void validatePermissionsFindByFields(UUID checkinId, UUID createdById) {
         final UUID currentUserId = currentUserServices.getCurrentUser().getId();
         if(!checkInServices.doesUserHaveViewAccess(currentUserId, checkinId, createdById)){
-            throw new PermissionException("User is unauthorized to do this operation");
+            throw new PermissionException(NOT_AUTHORIZED_MSG);
         }
     }
 
@@ -172,13 +171,13 @@ public class ActionItemCRUDValidator implements CRUDValidator<ActionItem> {
             CheckIn checkinRecord = checkInServices.read(checkinId);
             boolean isCompleted = checkinRecord != null && checkinRecord.isCompleted();
 
-            permissionsValidation.validatePermissions(isCompleted, "User is unauthorized to do this operation");
+            permissionsValidation.validatePermissions(isCompleted);
 
             final UUID createdById = actionItem.getCreatedbyid();
             final UUID pdlId = checkinRecord != null ? checkinRecord.getPdlId() : null;
             boolean currentUserIsCheckinParticipant = currentUserId.equals(pdlId) || currentUserId.equals(createdById);
 
-            permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant, "User is unauthorized to do this operation");
+            permissionsValidation.validatePermissions(!currentUserIsCheckinParticipant);
         }
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/validate/crud/GuildCRUDValidator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/validate/crud/GuildCRUDValidator.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 @Named("Guild")
 public class GuildCRUDValidator implements CRUDValidator<Guild> {
+
     private final ArgumentsValidation argumentsValidation;
     private final PermissionsValidation permissionsValidation;
     private final CurrentUserServices currentUserServices;
@@ -87,7 +88,6 @@ public class GuildCRUDValidator implements CRUDValidator<Guild> {
     }
 
     private void validatePermissionCommon() {
-        permissionsValidation.validatePermissions(!currentUserServices.isAdmin(),
-                "You are not authorized to perform this operation");
+        permissionsValidation.validatePermissions(!currentUserServices.isAdmin());
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/action_item/ActionItemControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/action_item/ActionItemControllerTest.java
@@ -9,6 +9,7 @@ import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
 import com.objectcomputing.checkins.services.fixture.RoleFixture;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.role.Role;
+import com.objectcomputing.checkins.services.validate.PermissionsValidation;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -24,6 +25,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ActionItemControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, CheckInFixture, ActionItemFixture {
@@ -216,7 +218,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -240,7 +242,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -348,7 +350,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -369,7 +371,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -424,7 +426,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -515,7 +517,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -602,7 +604,7 @@ class ActionItemControllerTest extends TestContainersSuite implements MemberProf
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         JsonNode errors = Objects.requireNonNull(body).get("message");
         JsonNode href = Objects.requireNonNull(body).get("_links").get("self").get("href");
-        assertEquals("User is unauthorized to do this operation", errors.asText());
+        assertEquals(NOT_AUTHORIZED_MSG, errors.asText());
         assertEquals(request.getPath(), href.asText());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/agenda_item/AgendaItemControllerTest.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AgendaItemControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, AgendaItemFixture, RoleFixture {
@@ -214,7 +215,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -301,7 +302,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
 
     }
@@ -338,7 +339,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertTrue(error.contains("User is unauthorized to do this operation"));
+        assertTrue(error.contains(NOT_AUTHORIZED_MSG));
 
     }
 
@@ -434,7 +435,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -473,7 +474,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -672,7 +673,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         String error = Objects.requireNonNull(body).get("message").asText();
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
         assertEquals(request.getPath(), href);
 
     }
@@ -774,7 +775,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -795,7 +796,7 @@ class AgendaItemControllerTest extends TestContainersSuite implements MemberProf
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkin_notes/CheckinNoteControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkin_notes/CheckinNoteControllerTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.PDL_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -234,7 +235,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -261,7 +262,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -288,7 +289,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You do not have permission to access this resource", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -393,7 +394,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -437,7 +438,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -498,7 +499,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -599,7 +600,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -640,7 +641,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -856,7 +857,7 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String error = Objects.requireNonNull(body).get("message").asText();
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
         assertEquals(request.getPath(), href);
 
     }
@@ -900,6 +901,6 @@ class CheckinNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/checkins/CheckInControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/checkins/CheckInControllerTest.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CheckInControllerTest extends TestContainersSuite implements MemberProfileFixture, CheckInFixture, RoleFixture {
@@ -130,7 +131,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -352,7 +353,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -440,7 +441,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -704,7 +705,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -723,7 +724,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -774,7 +775,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -898,7 +899,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -914,7 +915,7 @@ class CheckInControllerTest extends TestContainersSuite implements MemberProfile
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/demographics/DemographicsControllerTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import static com.objectcomputing.checkins.services.memberprofile.MemberProfileTestUtil.mkMemberProfile;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DemographicsControllerTest extends TestContainersSuite implements DemographicsFixture, MemberProfileFixture, RoleFixture {
@@ -282,7 +283,7 @@ class DemographicsControllerTest extends TestContainersSuite implements Demograp
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
 
-        assertEquals("Requires admin privileges", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
         assertEquals(HttpStatus.FORBIDDEN,responseException.getStatus());
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/email/EmailControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/email/EmailControllerTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -166,7 +167,7 @@ class EmailControllerTest extends TestContainersSuite implements MemberProfileFi
                 client.toBlocking().exchange(request, Argument.listOf(Email.class)));
 
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
-        assertEquals("You are not authorized to do this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
     }
 
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/employee_hours/EmployeeHoursControllerTest.java
@@ -23,6 +23,7 @@ import java.util.*;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -131,7 +132,7 @@ class EmployeeHoursControllerTest extends TestContainersSuite implements MemberP
         String error = Objects.requireNonNull(body).get("message").asText();
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -82,7 +83,7 @@ class FeedbackAnswerControllerTest extends TestContainersSuite implements Feedba
     }
 
     void assertUnauthorized(HttpClientResponseException exception) {
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/question_and_answer/QuestionAndAnswerControllerTest.java
@@ -22,6 +22,7 @@ import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class QuestionAndAnswerControllerTest extends TestContainersSuite implements FeedbackAnswerFixture, TemplateQuestionFixture, MemberProfileFixture, FeedbackTemplateFixture, FeedbackRequestFixture, RoleFixture {
@@ -129,7 +130,7 @@ class QuestionAndAnswerControllerTest extends TestContainersSuite implements Fee
                 .basicAuth(random.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpClientResponseException exception = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
     }
 
@@ -163,7 +164,7 @@ class QuestionAndAnswerControllerTest extends TestContainersSuite implements Fee
                 .basicAuth(random.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpClientResponseException exception = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.memberprofile.MemberProfileTestUtil.mkMemberProfile;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -111,7 +112,7 @@ class FeedbackRequestControllerTest extends TestContainersSuite implements Membe
     }
 
     private void assertUnauthorized(HttpClientResponseException responseException) {
-        assertEquals("You are not authorized to do this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateControllerTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class FeedbackTemplateControllerTest extends TestContainersSuite implements MemberProfileFixture, RoleFixture, TemplateQuestionFixture, FeedbackTemplateFixture {
@@ -218,7 +219,7 @@ class FeedbackTemplateControllerTest extends TestContainersSuite implements Memb
         final HttpClientResponseException exception = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
 
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
     }
 
@@ -615,7 +616,7 @@ class FeedbackTemplateControllerTest extends TestContainersSuite implements Memb
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
     }
 
     @Test
@@ -677,6 +678,6 @@ class FeedbackTemplateControllerTest extends TestContainersSuite implements Memb
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_template/template_question/TemplateQuestionControllerTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.inject.Inject;
@@ -113,7 +114,7 @@ class TemplateQuestionControllerTest extends TestContainersSuite implements Memb
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
     }
 
     @Test
@@ -271,7 +272,7 @@ class TemplateQuestionControllerTest extends TestContainersSuite implements Memb
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
     }
 
     @Test
@@ -400,7 +401,7 @@ class TemplateQuestionControllerTest extends TestContainersSuite implements Memb
         final JsonNode body = exception.getResponse().getBody(JsonNode.class).orElse(null);
 
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
-        assertEquals("You are not authorized to do this operation", exception.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, exception.getMessage());
 
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/file/FileServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/file/FileServicesImplTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -214,7 +215,7 @@ class FileServicesImplTest extends TestContainersSuite {
         final FileRetrievalException responseException = assertThrows(FileRetrievalException.class, () ->
                 services.findFiles(null));
 
-        assertEquals("You are not authorized to perform this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
     }
 
     @Test
@@ -443,7 +444,7 @@ class FileServicesImplTest extends TestContainersSuite {
         final FileRetrievalException responseException = assertThrows(FileRetrievalException.class, () ->
                 services.downloadFiles(testUploadDocId));
 
-        assertEquals("You are not authorized to perform this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
         verify(mockGoogleApiAccess, times(0)).getDrive();
         verify(checkinDocumentServices, times(1)).getFindByUploadDocId(testUploadDocId);
         verify(checkInServices, times(1)).read(testCheckinId);
@@ -573,7 +574,7 @@ class FileServicesImplTest extends TestContainersSuite {
         final FileRetrievalException responseException = assertThrows(FileRetrievalException.class, () ->
                 services.deleteFile(uploadDocId));
 
-        assertEquals("You are not authorized to perform this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
         verify(checkinDocumentServices, times(1)).getFindByUploadDocId(uploadDocId);
         verify(checkInServices, times(1)).read(testCheckinId);
         verify(mockGoogleApiAccess, times(0)).getDrive();
@@ -868,7 +869,7 @@ class FileServicesImplTest extends TestContainersSuite {
         final FileRetrievalException responseException = assertThrows(FileRetrievalException.class, () ->
                 services.uploadFile(testCheckinId, fileToUpload));
 
-        assertEquals("You are not authorized to perform this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
         verify(checkInServices, times(1)).read(testCheckinId);
         verify(memberProfileServices, times(0)).getById(any(UUID.class));
         verify(mockGoogleApiAccess, times(0)).getDrive();

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildControllerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import java.util.*;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -333,7 +334,7 @@ class GuildControllerTest extends TestContainersSuite implements GuildFixture,
 
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -458,7 +459,7 @@ class GuildControllerTest extends TestContainersSuite implements GuildFixture,
 
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         JsonNode errors = Objects.requireNonNull(body).get("message");
-        assertEquals("You are not authorized to perform this operation", errors.asText());
+        assertEquals(NOT_AUTHORIZED_MSG, errors.asText());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 
@@ -509,7 +510,7 @@ class GuildControllerTest extends TestContainersSuite implements GuildFixture,
 
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         JsonNode errors = Objects.requireNonNull(body).get("message");
-        assertEquals("You are not authorized to perform this operation", errors.asText());
+        assertEquals(NOT_AUTHORIZED_MSG, errors.asText());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -215,7 +216,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 
@@ -477,7 +478,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
         assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/opportunities/OpportunitiesControllerTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -368,7 +369,7 @@ class OpportunitiesControllerTest extends TestContainersSuite implements MemberP
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -388,7 +389,7 @@ class OpportunitiesControllerTest extends TestContainersSuite implements MemberP
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/private_notes/PrivateNoteControllerTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.PDL_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -86,7 +87,7 @@ class PrivateNoteControllerTest extends TestContainersSuite implements MemberPro
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
-        assertEquals("User is unauthorized to do this operation", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
     }
 
     @Test
@@ -312,7 +313,7 @@ class PrivateNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -463,7 +464,7 @@ class PrivateNoteControllerTest extends TestContainersSuite implements MemberPro
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/question_category/QuestionCategoryControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -126,7 +127,7 @@ class QuestionCategoryControllerTest extends TestContainersSuite implements Ques
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
-        assertEquals("You do not have permission to access this resource", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
 
     }
 
@@ -193,7 +194,7 @@ class QuestionCategoryControllerTest extends TestContainersSuite implements Ques
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
-        assertEquals("You do not have permission to access this resource", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
     }
 
     @Test
@@ -254,7 +255,7 @@ class QuestionCategoryControllerTest extends TestContainersSuite implements Ques
                 () -> client.toBlocking().exchange(request, Map.class)
         );
 
-        assertEquals("You do not have permission to access this resource", responseException.getMessage());
+        assertEquals(NOT_AUTHORIZED_MSG, responseException.getMessage());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillsControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/skills/combineskills/CombineSkillsControllerTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -134,7 +135,7 @@ class CombineSkillsControllerTest extends TestContainersSuite
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/survey/SurveyControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/survey/SurveyControllerTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -414,7 +415,7 @@ class SurveyControllerTest extends TestContainersSuite implements MemberProfileF
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -430,7 +431,7 @@ class SurveyControllerTest extends TestContainersSuite implements MemberProfileF
         String error = Objects.requireNonNull(body).get("message").asText();
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -448,7 +449,7 @@ class SurveyControllerTest extends TestContainersSuite implements MemberProfileF
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         String error = Objects.requireNonNull(body).get("message").asText();
 
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
 
     }
 
@@ -467,7 +468,7 @@ class SurveyControllerTest extends TestContainersSuite implements MemberProfileF
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("User is unauthorized to do this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/team/TeamControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/team/TeamControllerTest.java
@@ -22,6 +22,7 @@ import jakarta.inject.Inject;
 import java.util.*;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -221,7 +222,7 @@ class TeamControllerTest extends TestContainersSuite implements TeamFixture, Mem
 
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
     }
 
     @Test
@@ -320,7 +321,7 @@ class TeamControllerTest extends TestContainersSuite implements TeamFixture, Mem
 
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         JsonNode errors = Objects.requireNonNull(body).get("message");
-        assertEquals("You are not authorized to perform this operation", errors.asText());
+        assertEquals(NOT_AUTHORIZED_MSG, errors.asText());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 
@@ -372,7 +373,7 @@ class TeamControllerTest extends TestContainersSuite implements TeamFixture, Mem
 
         JsonNode body = responseException.getResponse().getBody(JsonNode.class).orElse(null);
         JsonNode errors = Objects.requireNonNull(body).get("message");
-        assertEquals("You are not authorized to perform this operation", errors.asText());
+        assertEquals(NOT_AUTHORIZED_MSG, errors.asText());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/team/member/TeamMemberControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/team/member/TeamMemberControllerTest.java
@@ -1,6 +1,5 @@
 package com.objectcomputing.checkins.services.team.member;
 
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.objectcomputing.checkins.services.TestContainersSuite;
 import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
@@ -25,6 +24,7 @@ import java.util.stream.Collectors;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static com.objectcomputing.checkins.services.validate.PermissionsValidation.NOT_AUTHORIZED_MSG;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TeamMemberControllerTest extends TestContainersSuite implements TeamFixture, MemberProfileFixture, RoleFixture, TeamMemberFixture {
@@ -90,7 +90,7 @@ class TeamMemberControllerTest extends TestContainersSuite implements TeamFixtur
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
         assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
     }
 
@@ -351,7 +351,7 @@ class TeamMemberControllerTest extends TestContainersSuite implements TeamFixtur
         String href = Objects.requireNonNull(body).get("_links").get("self").get("href").asText();
 
         assertEquals(request.getPath(), href);
-        assertEquals("You are not authorized to perform this operation", error);
+        assertEquals(NOT_AUTHORIZED_MSG, error);
         assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
     }
 


### PR DESCRIPTION
Currently in the back-end, we have 8 different messages when the current user's permissions are not enough to perform an operation;

- "Requires admin privileges
- "User is unauthorized to do this operation"
- "You are not authorized to access this Demographics"
- "You are not authorized to do that operation"
- "You are not authorized to do this operation"
- "You are not authorized to do this operation :("
- "You are not authorized to perform this operation"
- "You do not have permission to access this resource"

This PR consolodates all these to a single message (the same message as in the front-end)

- "You are not authorized to perform this operation"

The value of this comes from a constant in PermissionsValidation incase we want to update across the app at a future date.