### PR TITLE
Tidy up mailjet related classes and config

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetConfiguration.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetConfiguration.java
@@ -1,0 +1,16 @@
+package com.objectcomputing.checkins.notifications.email;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = MailJetConfiguration.PREFIX + ".from-address")
+@Requires(property = MailJetConfiguration.PREFIX + ".from-name")
+@ConfigurationProperties(MailJetConfiguration.PREFIX)
+public interface MailJetConfiguration {
+
+    String PREFIX = "mail-jet";
+
+    String getFromAddress();
+
+    String getFromName();
+}

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetFactory.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetFactory.java
@@ -40,5 +40,4 @@ public class MailJetFactory {
         sender.setEmailFormat(Emailv31.Message.TEXTPART);
         return sender;
     }
-
 }

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetFactory.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetFactory.java
@@ -8,6 +8,7 @@ import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 
 import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 @Factory
 public class MailJetFactory {
@@ -26,14 +27,14 @@ public class MailJetFactory {
         );
     }
 
-    @Bean
+    @Singleton
     @Named(HTML_FORMAT)
     EmailSender getHtmlSender(MailJetSender sender) {
         sender.setEmailFormat(Emailv31.Message.HTMLPART);
         return sender;
     }
 
-    @Bean
+    @Singleton
     @Named(TEXT_FORMAT)
     EmailSender getTextSender(MailJetSender sender) {
         sender.setEmailFormat(Emailv31.Message.TEXTPART);

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetFactory.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetFactory.java
@@ -10,7 +10,7 @@ import io.micronaut.context.annotation.Factory;
 import jakarta.inject.Named;
 
 @Factory
-public class MailJetConfig {
+public class MailJetFactory {
 
     public static final String HTML_FORMAT = "html";
     public static final String TEXT_FORMAT = "text";

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetNotificationController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetNotificationController.java
@@ -20,7 +20,7 @@ public class MailJetNotificationController {
     private final EmailSender emailSender;
 
     public MailJetNotificationController(CurrentUserServices currentUserServices,
-                                         @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender) {
+                                         @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender) {
         this.currentUserServices = currentUserServices;
         this.emailSender = emailSender;
     }

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetSender.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/email/MailJetSender.java
@@ -6,7 +6,6 @@ import com.mailjet.client.MailjetResponse;
 import com.mailjet.client.errors.MailjetException;
 import com.mailjet.client.resource.Emailv31;
 import com.objectcomputing.checkins.exceptions.BadArgException;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
 import org.json.JSONArray;
@@ -18,28 +17,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@Requires(property = MailJetSender.FROM_ADDRESS)
-@Requires(property = MailJetSender.FROM_NAME)
 @Prototype
+@Requires(bean = MailJetConfiguration.class)
 public class MailJetSender implements EmailSender {
 
     private static final Logger LOG = LoggerFactory.getLogger(MailJetSender.class);
     private final MailjetClient client;
 
-    public static final String FROM_ADDRESS = "mail-jet.from_address";
-    public static final String FROM_NAME = "mail-jet.from_name";
     public static final int MAILJET_RECIPIENT_LIMIT = 49;
 
     private final String fromAddress;
     private final String fromName;
     private String emailFormat;
 
-    public MailJetSender(MailjetClient client,
-                         @Property(name = FROM_ADDRESS) String fromAddress,
-                         @Property(name = FROM_NAME) String fromName) {
+    public MailJetSender(
+            MailjetClient client,
+            MailJetConfiguration configuration
+    ) {
         this.client = client;
-        this.fromAddress = fromAddress;
-        this.fromName = fromName;
+        this.fromAddress = configuration.getFromAddress();
+        this.fromName = configuration.getFromName();
         this.emailFormat = Emailv31.Message.HTMLPART;
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/email/EmailServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/email/EmailServicesImpl.java
@@ -2,7 +2,7 @@ package com.objectcomputing.checkins.services.email;
 
 import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileRepository;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
@@ -31,8 +31,8 @@ public class EmailServicesImpl implements EmailServices {
     private final MemberProfileRepository memberProfileRepository;
     private final EmailRepository emailRepository;
 
-    public EmailServicesImpl(@Named(MailJetConfig.HTML_FORMAT) EmailSender htmlEmailSender,
-                             @Named(MailJetConfig.TEXT_FORMAT) EmailSender textEmailSender,
+    public EmailServicesImpl(@Named(MailJetFactory.HTML_FORMAT) EmailSender htmlEmailSender,
+                             @Named(MailJetFactory.TEXT_FORMAT) EmailSender textEmailSender,
                              CurrentUserServices currentUserServices,
                              MemberProfileRepository memberProfileRepository,
                              EmailRepository emailRepository) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -4,7 +4,7 @@ import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
@@ -49,7 +49,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
                                        CurrentUserServices currentUserServices,
                                        MemberProfileServices memberProfileServices,
                                        ReviewPeriodRepository reviewPeriodRepository,
-                                       @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender,
+                                       @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender,
                                        @Property(name = FEEDBACK_REQUEST_NOTIFICATION_SUBJECT) String notificationSubject,
                                        @Property(name = WEB_UI_URL) String webURL
     ) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
@@ -5,7 +5,7 @@ import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.guild.member.GuildMember;
 import com.objectcomputing.checkins.services.guild.member.GuildMemberHistoryRepository;
 import com.objectcomputing.checkins.services.guild.member.GuildMemberRepository;
@@ -57,7 +57,7 @@ public class GuildServicesImpl implements GuildServices {
                              CurrentUserServices currentUserServices,
                              MemberProfileServices memberProfileServices,
                              GuildMemberServices guildMemberServices,
-                             @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender,
+                             @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender,
                              Environment environment,
                              @Property(name = WEB_ADDRESS) String webAddress
     ) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
@@ -4,7 +4,7 @@ import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.guild.Guild;
 import com.objectcomputing.checkins.services.guild.GuildRepository;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
@@ -43,7 +43,7 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
                                    MemberProfileRepository memberRepo,
                                    CurrentUserServices currentUserServices,
                                    GuildMemberHistoryRepository guildMemberHistoryRepository,
-                                   @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender,
+                                   @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender,
                                    @Property(name = WEB_ADDRESS) String webAddress
     ) {
         this.guildRepo = guildRepo;

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/MemberProfileServicesImpl.java
@@ -5,7 +5,7 @@ import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.checkins.CheckInServices;
 import com.objectcomputing.checkins.services.member_skill.MemberSkillServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
@@ -44,7 +44,7 @@ public class MemberProfileServicesImpl implements MemberProfileServices {
                                      CheckInServices checkInServices,
                                      MemberSkillServices memberSkillServices,
                                      TeamMemberServices teamMemberServices,
-                                     @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender) {
+                                     @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender) {
         this.memberProfileRepository = memberProfileRepository;
         this.currentUserServices = currentUserServices;
         this.roleServices = roleServices;

--- a/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseServicesImpl.java
@@ -2,7 +2,7 @@ package com.objectcomputing.checkins.services.pulseresponse;
 
 import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileRepository;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
@@ -36,7 +36,7 @@ public class PulseResponseServicesImpl implements PulseResponseService {
             MemberProfileRepository memberRepo,
             CurrentUserServices currentUserServices,
             RolePermissionServices rolePermissionServices,
-            @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender
+            @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender
     ) {
         this.pulseResponseRepo = pulseResponseRepo;
         this.memberProfileServices = memberProfileServices;

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewPeriodServicesImpl.java
@@ -4,7 +4,7 @@ import com.objectcomputing.checkins.Environments;
 import com.objectcomputing.checkins.exceptions.AlreadyExistsException;
 import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.notifications.email.EmailSender;
-import com.objectcomputing.checkins.notifications.email.MailJetConfig;
+import com.objectcomputing.checkins.notifications.email.MailJetFactory;
 import com.objectcomputing.checkins.services.feedback_request.FeedbackRequestServices;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileRepository;
 import io.micronaut.context.annotation.Property;
@@ -43,7 +43,7 @@ class ReviewPeriodServicesImpl implements ReviewPeriodServices {
                                     MemberProfileRepository memberProfileRepository,
                                     FeedbackRequestServices feedbackRequestServices,
                                     ReviewStatusTransitionValidator reviewStatusTransitionValidator,
-                                    @Named(MailJetConfig.HTML_FORMAT) EmailSender emailSender,
+                                    @Named(MailJetFactory.HTML_FORMAT) EmailSender emailSender,
                                     Environment environment,
                                     @Property(name = WEB_ADDRESS) String webAddress) {
         this.reviewPeriodRepository = reviewPeriodRepository;

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -136,8 +136,8 @@ ehcache:
       enabled: true
 ---
 mail-jet:
-  from_address: ${ FROM_ADDRESS }
-  from_name: ${ FROM_NAME }
+  from-address: ${ FROM_ADDRESS }
+  from-name: ${ FROM_NAME }
 ---
 github-credentials:
   github_token: ${ GITHUB_TOKEN }

--- a/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetConfigurationTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetConfigurationTest.java
@@ -1,0 +1,57 @@
+package com.objectcomputing.checkins.notifications.email;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MailJetConfigurationTest {
+
+    @Test
+    void happyConfig() {
+        String email = "tim@here.com";
+        String name = "Tim";
+
+        try (var ctx = ApplicationContext.run(Map.of(
+                "datasources.enabled", false,
+                "mail-jet.from-address", email,
+                "mail-jet.from-name", name
+        ))) {
+            var config = ctx.getBean(MailJetConfiguration.class);
+            assertEquals(email, config.getFromAddress());
+            assertEquals(name, config.getFromName());
+        }
+
+        try (var ctx = ApplicationContext.run(Map.of(
+                "datasources.enabled", false,
+                "mail-jet.fromAddress", email,
+                "mail-jet.fromName", name
+        ))) {
+            var config = ctx.getBean(MailJetConfiguration.class);
+            assertEquals(email, config.getFromAddress());
+            assertEquals(name, config.getFromName());
+        }
+
+        try (var ctx = ApplicationContext.run(Map.of(
+                "datasources.enabled", false,
+                "mailJet.fromAddress", email,
+                "mailJet.fromName", name
+        ))) {
+            var config = ctx.getBean(MailJetConfiguration.class);
+            assertEquals(email, config.getFromAddress());
+            assertEquals(name, config.getFromName());
+        }
+
+        try (var ctx = ApplicationContext.run(Map.of(
+                "datasources.enabled", false,
+                "mailJet.from_address", email,
+                "mailJet.from_name", name
+        ))) {
+            var config = ctx.getBean(MailJetConfiguration.class);
+            assertEquals(email, config.getFromAddress());
+            assertEquals(name, config.getFromName());
+        }
+    }
+}

--- a/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
@@ -43,14 +43,14 @@ class MailJetSenderTest extends TestContainersSuite {
         int numRecipients = MailJetSender.MAILJET_RECIPIENT_LIMIT + 10;
 
         for (int i = 1; i <= numRecipients; i++) {
-            recipients.add("recipient" + String.format("%02d", i) + "@objectcomputing.com");
+            recipients.add("recipient%02d@objectcomputing.com".formatted(i));
         }
 
         List<JSONArray> batches = MailJetSender.getEmailBatches(recipients.toArray(String[]::new));
 
         assertEquals(2, batches.size());
 
-        JSONArray firstBatch = batches.get(0);
+        JSONArray firstBatch = batches.getFirst();
         assertEquals(MailJetSender.MAILJET_RECIPIENT_LIMIT, firstBatch.length());
 
         List<String> firstEmailGroup = recipients.subList(0, MailJetSender.MAILJET_RECIPIENT_LIMIT);

--- a/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/notifications/email/MailJetSenderTest.java
@@ -1,14 +1,41 @@
 package com.objectcomputing.checkins.notifications.email;
 
 import com.objectcomputing.checkins.services.TestContainersSuite;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import org.json.JSONArray;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MailJetSenderTest extends TestContainersSuite {
+
+    @Test
+    void namedSendersAreSingletons() {
+        // given
+        var htmlSender = getEmailSender(MailJetFactory.HTML_FORMAT);
+        var textSender = getEmailSender(MailJetFactory.TEXT_FORMAT);
+        var secondHtmlSender = getEmailSender(MailJetFactory.HTML_FORMAT);
+
+        // then htmlSender and secondHtmlSender should be the same instance
+        assertSame(htmlSender, secondHtmlSender);
+
+        // then textSender should be a different instance to htmlSender
+        assertNotSame(htmlSender, textSender);
+
+        // then textSender should be a different instance to secondHtmlSender
+        assertNotSame(secondHtmlSender, textSender);
+    }
+
+    private EmailSender getEmailSender(String name) {
+        return getEmbeddedServer().getApplicationContext().getBean(EmailSender.class, Qualifiers.byName(name));
+    }
 
     @Test
     void testCreateBatchesForManyRecipients() {

--- a/server/src/test/java/com/objectcomputing/checkins/services/TestContainersSuite.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/TestContainersSuite.java
@@ -92,8 +92,8 @@ public abstract class TestContainersSuite implements RepositoryFixture, TestProp
         properties.put("datasources.default.dialect", "POSTGRES");
         properties.put("datasources.default.driverClassName", "org.postgresql.Driver");
         properties.put("flyway.datasources.default.clean-schema", "true"); // Needed to run Flyway.clean()
-        properties.put("mail-jet.from_address", "someEmail@gmail.com");
-        properties.put("mail-jet.from_name", "John Doe");
+        properties.put("mail-jet.from-address", "someEmail@gmail.com");
+        properties.put("mail-jet.from-name", "John Doe");
         return properties;
     }
 

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -6,8 +6,8 @@ micronaut:
       enabled: false
 ---
 mail-jet:
-  from_address: "someEmail@test.com"
-  from_name: "John Doe"
+  from-address: "someEmail@test.com"
+  from-name: "John Doe"
 ---
 credentials:
   roles:


### PR DESCRIPTION
This alters 2 main things:

1. Makes named `EmailSender` instances [singletons](https://github.com/objectcomputing/check-ins/commit/28a34655042d6974590e8110a77080ace068dddc).

    This means we have one instance for `HTML_FORMAT` and one instance for `TEXT_FORMAT`.
    Currently we have one instance per injection point, which I don't believe is necessary 🤔 

2. Uses a [configuration object](https://github.com/objectcomputing/check-ins/commit/0982480c52ffa0124c24eec1215cd0b39cb80513) for `fromAddress` and `fromName`.

    Currently, we use `@Property(name = FROM_ADDRESS) String fromAddress` to inject the values in by name.
    It is safer to use a typed configuration object and get the config from this instead