### PR TITLE
Switch caching to Caffeine

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-management")
     implementation('io.micronaut:micronaut-runtime')
-    implementation("io.micronaut.cache:micronaut-cache-ehcache")
+    implementation("io.micronaut.cache:micronaut-cache-caffeine")
     implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.flyway:micronaut-flyway")
     implementation("io.micronaut.security:micronaut-security")

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/GooglePhotoAccessor.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/GooglePhotoAccessor.java
@@ -1,0 +1,9 @@
+package com.objectcomputing.checkins.services.memberprofile.memberphoto;
+
+/**
+ * Interface to access Google Photo data, and allow for simpler mocking in tests
+ */
+interface GooglePhotoAccessor {
+
+    byte[] getPhotoData(String workEmail);
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/GooglePhotoAccessorImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/GooglePhotoAccessorImpl.java
@@ -1,0 +1,68 @@
+package com.objectcomputing.checkins.services.memberprofile.memberphoto;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.services.directory.Directory;
+import com.google.api.services.directory.model.UserPhoto;
+import com.objectcomputing.checkins.util.googleapiaccess.GoogleApiAccess;
+import io.micronaut.context.env.Environment;
+import jakarta.inject.Singleton;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Base64;
+import java.util.Optional;
+
+@Singleton
+class GooglePhotoAccessorImpl implements GooglePhotoAccessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GooglePhotoAccessorImpl.class);
+
+    private final byte[] defaultPhoto;
+    private final GoogleApiAccess googleApiAccess;
+
+    GooglePhotoAccessorImpl(
+            Environment environment,
+            GoogleApiAccess googleApiAccess
+    ) {
+        this.googleApiAccess = googleApiAccess;
+        byte[] localDefaultPhoto = new byte[0];
+        Optional<URL> resource = environment.getResource("public/default_profile.jpg");
+        try {
+            if(resource.isPresent()) {
+                URL defaultImageUrl = resource.get();
+                InputStream in = defaultImageUrl.openStream();
+                localDefaultPhoto = IOUtils.toByteArray(in);
+            }
+        } catch (IOException e) {
+            LOG.error("Error occurred while loading the default profile photo.", e);
+        }
+        this.defaultPhoto = localDefaultPhoto;
+    }
+
+    @Override
+    public byte[] getPhotoData(String workEmail) {
+        Directory directory = googleApiAccess.getDirectory();
+        try {
+            UserPhoto userPhoto = directory.users().photos().get(workEmail).execute();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Photo data successfully retrieved from Google Directory API for: %s", workEmail));
+            }
+            return Base64.getUrlDecoder().decode(userPhoto.getPhotoData());
+        } catch (GoogleJsonResponseException gjse) {
+            if (gjse.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+                LOG.info(String.format("No photo was found for: %s", workEmail));
+            } else {
+                LOG.error(String.format("An unexpected error occurred while retrieving photo from Google Directory API for: %s", workEmail), gjse);
+            }
+            return defaultPhoto;
+        } catch (IOException e) {
+            LOG.error(String.format("An unexpected error occurred while retrieving photo from Google Directory API for: %s", workEmail), e);
+            return defaultPhoto;
+        }
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImpl.java
@@ -1,73 +1,25 @@
 package com.objectcomputing.checkins.services.memberprofile.memberphoto;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.services.directory.Directory;
-import com.google.api.services.directory.model.UserPhoto;
-import com.objectcomputing.checkins.util.googleapiaccess.GoogleApiAccess;
 import io.micronaut.cache.annotation.CacheConfig;
 import io.micronaut.cache.annotation.Cacheable;
-import io.micronaut.context.env.Environment;
 import jakarta.inject.Singleton;
 import jakarta.validation.constraints.NotNull;
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Base64;
-import java.util.Optional;
 
 @Singleton
 @CacheConfig("photo-cache")
 public class MemberPhotoServiceImpl implements MemberPhotoService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MemberPhotoServiceImpl.class);
-    private final GoogleApiAccess googleApiAccess;
-    private final byte[] defaultPhoto;
+    private final GooglePhotoAccessor googlePhotoAccessor;
 
-    public MemberPhotoServiceImpl(GoogleApiAccess googleApiAccess,
-                                  Environment environment) {
-        byte[] defaultPhoto = new byte[0];
-        this.googleApiAccess = googleApiAccess;
-        Optional<URL> resource = environment.getResource("public/default_profile.jpg");
-        try {
-            if(resource.isPresent()) {
-                URL defaultImageUrl = resource.get();
-                InputStream in = defaultImageUrl.openStream();
-                defaultPhoto = IOUtils.toByteArray(in);
-            }
-        } catch (IOException e) {
-            LOG.error("Error occurred while loading the default profile photo.", e);
-        }
-        this.defaultPhoto = defaultPhoto;
+    MemberPhotoServiceImpl(
+            GooglePhotoAccessor googlePhotoAccessor
+    ) {
+        this.googlePhotoAccessor = googlePhotoAccessor;
     }
 
     @Override
     @Cacheable
     public byte[] getImageByEmailAddress(@NotNull String workEmail) {
-
-        byte[] photoData;
-
-        Directory directory = googleApiAccess.getDirectory();
-        try {
-            UserPhoto userPhoto = directory.users().photos().get(workEmail).execute();
-            photoData = Base64.getUrlDecoder().decode(userPhoto.getPhotoData());
-            LOG.debug(String.format("Photo data successfully retrieved from Google Directory API for: %s", workEmail));
-        } catch(GoogleJsonResponseException gjse) {
-            if(gjse.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-                LOG.info(String.format("No photo was found for: %s", workEmail));
-            } else {
-                LOG.error(String.format("An unexpected error occurred while retrieving photo from Google Directory API for: %s", workEmail), gjse);
-            }
-            photoData = defaultPhoto;
-        } catch (IOException e) {
-            LOG.error(String.format("An unexpected error occurred while retrieving photo from Google Directory API for: %s", workEmail), e);
-            photoData = defaultPhoto;
-        }
-
-        return photoData;
+        return googlePhotoAccessor.getPhotoData(workEmail);
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -9,13 +9,12 @@ micronaut:
       max-file-size: 100MB
   caches:
     photo-cache:
-      expire-after-write: 86400
+      expire-after-write: 1d # 1 day
     member-cache:
-      expire-after-write: 300
-      heap:
-        max-entries: 600
+      expire-after-write: 300s # 5 minutes
+      maximum-size: 600
     role-permission-cache:
-      expire-after-write: 86400
+      expire-after-write: 1d # 1 day
 
   router:
     static-resources:
@@ -125,15 +124,6 @@ service-account-credentials:
   client_x509_cert_url: ${ CLIENT_X509_CERT_URL }
   oauth_client_id: ${ OAUTH_CLIENT_ID }
   oauth_client_secret: ${ OAUTH_CLIENT_SECRET }
----
-ehcache:
-  caches:
-    photo-cache:
-      enabled: true
-    member-cache:
-      enabled: true
-    role-permission-cache:
-      enabled: true
 ---
 mail-jet:
   from_address: ${ FROM_ADDRESS }

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoControllerTest.java
@@ -10,12 +10,15 @@ import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Base64;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MemberPhotoControllerTest extends TestContainersSuite {
@@ -25,30 +28,33 @@ class MemberPhotoControllerTest extends TestContainersSuite {
     private HttpClient client;
 
     @Inject
-    private MemberPhotoService memberPhotoService;
+    GooglePhotoAccessor googlePhotoAccessor;
 
-    //Happy path
     @Test
-    void testGetForValidInput() throws IOException {
+    void testGetForValidInput() {
 
         String testEmail = "test@test.com";
-        String testPhotoData = "test.photo.data";
-        byte[] testData = Base64.getUrlEncoder().encode(testPhotoData.getBytes());
+        byte[] testData = Base64.getUrlEncoder().encode("test.photo.data".getBytes());
 
-        when(memberPhotoService.getImageByEmailAddress(testEmail)).thenReturn(testData);
+        when(googlePhotoAccessor.getPhotoData(testEmail)).thenReturn(testData);
 
         final HttpRequest<?> request = HttpRequest.GET(String.format("/%s", testEmail)).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         final HttpResponse<byte[]> response = client.toBlocking().exchange(request, byte[].class);
+        client.toBlocking().exchange(request, byte[].class);
+        client.toBlocking().exchange(request, byte[].class);
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatus());
         assertTrue(response.getBody().isPresent());
         byte[] result = response.getBody().get();
         assertEquals(new String(testData), new String(result));
+
+        // Only called once due to the cache
+        verify(googlePhotoAccessor, times(1)).getPhotoData(testEmail);
     }
 
-    @MockBean(MemberPhotoServiceImpl.class)
-    public MemberPhotoService memberPhotoService() {
-        return mock(MemberPhotoService.class);
+    @MockBean(GooglePhotoAccessorImpl.class)
+    public GooglePhotoAccessor googlePhotoAccessor() {
+        return mock(GooglePhotoAccessor.class);
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/memberprofile/memberphoto/MemberPhotoServiceImplTest.java
@@ -21,7 +21,10 @@ import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class MemberPhotoServiceImplTest extends TestContainersSuite {
 
@@ -47,7 +50,9 @@ class MemberPhotoServiceImplTest extends TestContainersSuite {
     private Environment mockEnvironment;
 
     @InjectMocks
-    private MemberPhotoServiceImpl services;
+    private GooglePhotoAccessorImpl accessor;
+
+    private MemberPhotoServiceImpl service;
 
     private AutoCloseable mockFinalizer;
 
@@ -70,6 +75,7 @@ class MemberPhotoServiceImplTest extends TestContainersSuite {
         reset(mockPhotos);
         reset(mockGet);
         reset(mockEnvironment);
+        service = new MemberPhotoServiceImpl(accessor);
     }
 
     // happy path
@@ -93,7 +99,7 @@ class MemberPhotoServiceImplTest extends TestContainersSuite {
         when(mockPhotos.get(testEmail)).thenReturn(mockGet);
         when(mockGet.execute()).thenReturn(testUserPhoto);
 
-        final byte[] result = services.getImageByEmailAddress(testEmail);
+        final byte[] result = service.getImageByEmailAddress(testEmail);
 
         assertNotNull(result);
         assertEquals(testPhotoData, new String(result, StandardCharsets.UTF_8));
@@ -111,7 +117,7 @@ class MemberPhotoServiceImplTest extends TestContainersSuite {
         when(mockPhotos.get(testEmail)).thenReturn(mockGet);
         when(mockGet.execute()).thenThrow(GoogleJsonResponseException.class);
 
-        final byte[] result = services.getImageByEmailAddress(testEmail);
+        final byte[] result = service.getImageByEmailAddress(testEmail);
 
         assertNotNull(result);
         assertEquals("", new String(result, StandardCharsets.UTF_8));


### PR DESCRIPTION
For the past 4 years, we've been using ehcache as the caching layer, but I believe the configuration was incorrect.

We had a block

```yaml
ehcache:
  caches:
    photo-cache:
      enabled: true
    member-cache:
      enabled: true
    role-permission-cache:
      enabled: true
```

Which doesn't match any of the [cache properties in the docs](https://micronaut-projects.github.io/micronaut-cache/latest/guide/configurationreference.html#io.micronaut.cache.ehcache.configuration.EhcacheClusterResourcePoolConfiguration) that I can see...

Then we also had

```yaml
micronaut:
  caches:
    member-cache:
      expire-after-write: 300
      heap:
        max-entries: 600
```

Where `micronaut.caches.member-cache.heap.max-entries` [is supposed to be](https://micronaut-projects.github.io/micronaut-cache/latest/guide/configurationreference.html#io.micronaut.cache.ehcache.configuration.EhcacheConfiguration$HeapTieredCacheConfiguration) in the `ehcache` namespace...

And `micronaut.caches.member-cache.expire-after-write` is a caffeine cache configuration entry, with no analog in ehcache (and it is also expecting a Duration).

In an effort to fix this, I have _*arbitrarially*_ decided to switch across to use `caffeine` in place of `ehcache`, so the consolodated config now looks like:

```yaml
micronaut:
  caches:
    photo-cache:
      expire-after-write: 1d # 1 day
    member-cache:
      expire-after-write: 300s # 5 minutes
      maximum-size: 600
    role-permission-cache:
      expire-after-write: 1d # 1 day
```

The ehcache `heap.max-entries` I have just converted to `maximum-size` for [the caffeine config](https://micronaut-projects.github.io/micronaut-cache/latest/guide/configurationreference.html#io.micronaut.cache.caffeine.DefaultCacheConfiguration)

I extracted a further class out of the service to actually fetch the image from Google so we can test that the caching is working more easily with Mocks (mocking the service threw away the cache annotations)