### PR TITLE
Fix the Upload Hours multipart post

### DIFF
--- a/web-ui/src/api/hours.js
+++ b/web-ui/src/api/hours.js
@@ -16,11 +16,10 @@ export const postEmployeeHours = async (cookie, file) => {
   return resolve({
     method: 'POST',
     url: hoursUrl + '/upload',
-    data: file,
+    body: file,
     headers: {
       'X-CSRF-Header': cookie,
-      Accept: 'application/json',
-      'Content-Type': 'multipart/form-data'
+      Accept: 'application/json'
     }
   });
 };


### PR DESCRIPTION
Posting a CSV via the 'Upload Hours' screen was broken.

This PR removes the `Content-type` header (as this has to be set by the fetch command to include the boundary) And switches to use `body` instead of `data` (`body` is passed as-is, but `data` is stringified to json which breaks `FormData`)