### PR TITLE
Bugfix 2542/adding a supervisor in reviews

### DIFF
--- a/web-ui/src/components/reviews/TeamReviews.jsx
+++ b/web-ui/src/components/reviews/TeamReviews.jsx
@@ -241,7 +241,20 @@ const TeamReviews = ({ onBack, periodId }) => {
     if (res.error) return;
 
     setTeamMembers(teamMembers);
+    addAssignmentForMemberWithNone(teamMembers);
   };
+
+  const addAssignmentForMemberWithNone = async (members) => {
+    members.forEach(member => {
+      const exists = assignments.some(
+          a => a.revieweeId === member.id
+      );
+      if (!!!exists && member.reviewerId) {
+        const reviewers = [{ id: member.reviewerId }];
+        updateReviewers(member, reviewers);
+      }
+    });
+  }
 
   const getReviewStatus = useCallback(
     teamMemberId => {

--- a/web-ui/src/components/reviews/TeamReviews.jsx
+++ b/web-ui/src/components/reviews/TeamReviews.jsx
@@ -249,9 +249,9 @@ const TeamReviews = ({ onBack, periodId }) => {
       const exists = assignments.some(
           a => a.revieweeId === member.id
       );
-      if (!!!exists && member.reviewerId) {
-        const reviewers = [{ id: member.reviewerId }];
-        updateReviewers(member, reviewers);
+      if (!!!exists && member.supervisorid) {
+        const reviewers = [{ id: member.supervisorid }];
+        updateReviewers(member, reviewers, true);
       }
     });
   }
@@ -689,7 +689,7 @@ const TeamReviews = ({ onBack, periodId }) => {
       return compare;
     });
 
-  const updateReviewers = async (member, reviewers) => {
+  const updateReviewers = async (member, reviewers, addAsApproved) => {
     const memberId = member.id;
 
     let newAssignments = [...assignments];
@@ -707,7 +707,8 @@ const TeamReviews = ({ onBack, periodId }) => {
         newAssignments.push({
           reviewPeriodId: periodId,
           reviewerId: reviewer.id,
-          revieweeId: member.id
+          revieweeId: member.id,
+          approved: addAsApproved,
         });
       }
     }
@@ -1057,7 +1058,7 @@ const TeamReviews = ({ onBack, periodId }) => {
         selectedMembers={selectedReviewers}
         onClose={closeReviewerDialog}
         onSubmit={reviewers => {
-          updateReviewers(selectedMember, reviewers);
+          updateReviewers(selectedMember, reviewers, null);
           closeReviewerDialog();
         }}
       />

--- a/web-ui/src/components/reviews/TeamReviews.jsx
+++ b/web-ui/src/components/reviews/TeamReviews.jsx
@@ -225,7 +225,7 @@ const TeamReviews = ({ onBack, periodId }) => {
       revieweeId: tm.id,
       reviewerId: tm.supervisorid,
       reviewPeriodId: periodId,
-      approved: true
+      approved: false
     }));
 
     const res = await resolve({
@@ -251,7 +251,7 @@ const TeamReviews = ({ onBack, periodId }) => {
       );
       if (!!!exists && member.supervisorid) {
         const reviewers = [{ id: member.supervisorid }];
-        updateReviewers(member, reviewers, true);
+        updateReviewers(member, reviewers);
       }
     });
   }
@@ -689,7 +689,7 @@ const TeamReviews = ({ onBack, periodId }) => {
       return compare;
     });
 
-  const updateReviewers = async (member, reviewers, addAsApproved) => {
+  const updateReviewers = async (member, reviewers) => {
     const memberId = member.id;
 
     let newAssignments = [...assignments];
@@ -707,8 +707,7 @@ const TeamReviews = ({ onBack, periodId }) => {
         newAssignments.push({
           reviewPeriodId: periodId,
           reviewerId: reviewer.id,
-          revieweeId: member.id,
-          approved: addAsApproved,
+          revieweeId: member.id
         });
       }
     }
@@ -1058,7 +1057,7 @@ const TeamReviews = ({ onBack, periodId }) => {
         selectedMembers={selectedReviewers}
         onClose={closeReviewerDialog}
         onSubmit={reviewers => {
-          updateReviewers(selectedMember, reviewers, null);
+          updateReviewers(selectedMember, reviewers);
           closeReviewerDialog();
         }}
       />


### PR DESCRIPTION
Made it so:
Whenever the members list is refreshed/changed, such as when new team-members are assigned,,, If any reviewee has no reviewer, then assigned reviewee's supervisor as a reviewer. 
Whenever members/reviewees are assigned, the assignment record is created as un-approved, including the initial review-creation.
