### PR TITLE
[chore] dependencies update

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -3,14 +3,9 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id("com.gradleup.shadow") version "8.3.1"
+    id("com.gradleup.shadow") version "8.3.2"
     id("io.micronaut.application") version "4.4.2"
     id "jacoco"
-    id("org.openrewrite.rewrite") version "latest.release"
-}
-
-rewrite {
-    activeRecipe("org.openrewrite.java.micronaut.Micronaut3to4Migration")
 }
 
 version "0.7.0"
@@ -40,8 +35,6 @@ configurations {
 }
 
 dependencies {
-    rewrite('org.openrewrite.recipe:rewrite-micronaut:2.5.0')
-
     runtimeOnly("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.yaml:snakeyaml")
     runtimeOnly("ch.qos.logback:logback-classic")
@@ -76,20 +69,20 @@ dependencies {
 
     implementation("io.swagger.core.v3:swagger-annotations")
 
-    implementation 'org.apache.commons:commons-lang3:3.14.0'
-    implementation "commons-io:commons-io:2.16.1"
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation "commons-io:commons-io:2.17.0"
     implementation 'org.apache.commons:commons-csv:1.11.0'
 
     implementation "jakarta.annotation:jakarta.annotation-api"
     implementation "jakarta.persistence:jakarta.persistence-api"
 
-    implementation "com.google.api-client:google-api-client:2.5.1"
+    implementation "com.google.api-client:google-api-client:2.7.0"
     implementation "com.google.oauth-client:google-oauth-client-jetty:1.36.0"
-    implementation "com.google.apis:google-api-services-drive:v3-rev20240509-2.0.0"
-    implementation "com.google.apis:google-api-services-gmail:v1-rev20240422-2.0.0"
-    implementation "com.google.apis:google-api-services-admin-directory:directory_v1-rev20240509-2.0.0"
+    implementation "com.google.apis:google-api-services-drive:v3-rev20240903-2.0.0"
+    implementation "com.google.apis:google-api-services-gmail:v1-rev20240520-2.0.0"
+    implementation "com.google.apis:google-api-services-admin-directory:directory_v1-rev20240903-2.0.0"
 
-    implementation 'com.google.cloud.sql:postgres-socket-factory:1.18.1'
+    implementation 'com.google.cloud.sql:postgres-socket-factory:1.20.1'
 
     implementation("io.micronaut.reactor:micronaut-reactor")
     implementation("io.micrometer:context-propagation")
@@ -98,7 +91,7 @@ dependencies {
     testRuntimeOnly "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
 
     testImplementation('io.projectreactor:reactor-test')
-    testImplementation 'io.github.bonigarcia:webdrivermanager:5.8.0'
+    testImplementation 'io.github.bonigarcia:webdrivermanager:5.9.2'
     testImplementation "org.seleniumhq.selenium:selenium-java:$seleniumVersion"
     testImplementation "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
     testImplementation "org.seleniumhq.selenium:selenium-api:$seleniumVersion"

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,2 +1,2 @@
 micronautVersion=4.6.2
-seleniumVersion=4.21.0
+seleniumVersion=4.24.0


### PR DESCRIPTION
This commit performs the following:

Gradle plugins:

- Shadow `8.3.1` -> `8.3.2`
- OpenRewrite plugin removed as Micronaut 3 -> 4 migration is done

Main dependencies:

- commons-lang3: `3.14.0` -> `3.17.0`
- commons-io: `2.16.1` -> `2.17.0`
- google-api-client: `2.5.1` -> `2.7.0`
- google-api-services-drive: `v3-rev20240509-2.0.0` -> `v3-rev20240903-2.0.0`
- google-api-services-gmail: `v1-rev20240422-2.0.0` -> `v1-rev20240520-2.0.0`
- google-api-services-admin-directory: `directory_v1-rev20240509-2.0.0` -> `directory_v1-rev20240903-2.0.0`
- postgres-socket-factory: `1.18.1` -> `1.20.1`

Test dependencies:

- webdrivermanager: `5.8.0` -> `5.9.2`
- selenium: `4.21.0` -> `4.24.0`