### PR TITLE
Complete Functionality for Volunteer Tracking

### DIFF
--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
@@ -32,7 +32,7 @@
   display: inline-block;
   width: 16px;
   height: 16px;
-  background-image: url('path-to-caution-icon.png'); /* Add the correct icon path */
+  background-image: url('icon.png');
   background-size: cover;
   margin-right: 8px;
 }

--- a/web-ui/src/components/volunteer/VolunteerRelationships.jsx
+++ b/web-ui/src/components/volunteer/VolunteerRelationships.jsx
@@ -21,6 +21,7 @@ import OrganizationDialog from '../dialogs/OrganizationDialog';
 import { AppContext } from '../../context/AppContext';
 import { selectCsrfToken, selectCurrentUser, selectProfileMap } from '../../context/selectors';
 import { formatDate } from '../../helpers/datetime';
+import { showError } from '../../helpers/toast';
 
 const relationshipBaseUrl = '/services/volunteer/relationship';
 
@@ -158,19 +159,19 @@ const VolunteerRelationships = ({ forceUpdate = () => {}, onlyMe = false }) => {
       (rel) => rel.organizationId === organizationId && !rel.endDate && rel.id !== id
     );
     if (existingRelationship) {
-      console.error("Cannot add duplicate active relationships.");
+      showError("Cannot add duplicate active relationships.");
       return;
     }
   
     // Ensure start date is before or equal to the current date
     if (new Date(startDate) > new Date()) {
-      console.error("Start date cannot be in the future.");
+      showError("Start date cannot be in the future.");
       return;
     }
-  
+
     // Ensure end date is after the start date
     if (endDate && new Date(endDate) <= new Date(startDate)) {
-      console.error("End date must be after the start date.");
+      showError("End date must be after the start date.");
       return;
     }
   
@@ -203,7 +204,7 @@ const VolunteerRelationships = ({ forceUpdate = () => {}, onlyMe = false }) => {
   const saveOrganizationAndRelationship = useCallback(async () => {
     const { name, description, website } = newOrganization;
     if (!name || !description) {
-      console.error('Missing organization name or description');
+      showError('Missing organization name or description');
       return;
     }
 

--- a/web-ui/src/components/volunteer/VolunteerRelationships.jsx
+++ b/web-ui/src/components/volunteer/VolunteerRelationships.jsx
@@ -84,7 +84,7 @@ const VolunteerRelationships = ({ forceUpdate = () => {}, onlyMe = false }) => {
       }
     });
     if (res.error) return;
-
+  
     const relationships = res.payload.data || [];
     relationships.sort((rel1, rel2) => {
       const member1 = profileMap[rel1.memberId];
@@ -92,7 +92,8 @@ const VolunteerRelationships = ({ forceUpdate = () => {}, onlyMe = false }) => {
       return (member1?.name || '').localeCompare(member2?.name || '');
     });
     setRelationships(relationships);
-  }, [currentUser.id, onlyMe, profileMap]);
+    setRelationshipMap(relationships.reduce((acc, rel) => ({ ...acc, [rel.id]: rel }), {}));
+  }, [currentUser.id, onlyMe, profileMap, csrf]);
 
   useEffect(() => {
     loadOrganizations();
@@ -151,34 +152,48 @@ const VolunteerRelationships = ({ forceUpdate = () => {}, onlyMe = false }) => {
 
   const saveRelationship = useCallback(async () => {
     const { id, organizationId, startDate, endDate } = selectedRelationship;
-
-    if (!organizationId || !startDate || !endDate) {
-      console.error('Organization, start date, or end date missing');
+  
+    // Restrict adding duplicate active relationships only for new ones, exclude current relationship being edited
+    const existingRelationship = relationships.find(
+      (rel) => rel.organizationId === organizationId && !rel.endDate && rel.id !== id
+    );
+    if (existingRelationship) {
+      console.error("Cannot add duplicate active relationships.");
       return;
     }
-
+  
+    // Ensure start date is before or equal to the current date
+    if (new Date(startDate) > new Date()) {
+      console.error("Start date cannot be in the future.");
+      return;
+    }
+  
+    // Ensure end date is after the start date
+    if (endDate && new Date(endDate) <= new Date(startDate)) {
+      console.error("End date must be after the start date.");
+      return;
+    }
+  
     const formattedStartDate = formatDate(new Date(startDate));
-    const formattedEndDate = formatDate(new Date(endDate));
-
+    const formattedEndDate = endDate ? formatDate(new Date(endDate)) : null;
+  
     const res = await resolve({
       method: id ? 'PUT' : 'POST',
       url: id ? `${relationshipBaseUrl}/${id}` : relationshipBaseUrl,
       headers: {
         'X-CSRF-Header': csrf,
         Accept: 'application/json',
-        'Content-Type': 'application/json;charset=UTF-8'
+        'Content-Type': 'application/json;charset=UTF-8',
       },
-      data: { ...selectedRelationship, startDate: formattedStartDate, endDate: formattedEndDate }
+      data: { ...selectedRelationship, startDate: formattedStartDate, endDate: formattedEndDate },
     });
-    if (res.error) {
-      console.error("Error saving relationship", res.error);
-      return;
-    }
-
-    await refreshRelationships(); // Refresh the list after saving
+    
+    if (res.error) return;
+  
+    await refreshRelationships();
     setSelectedRelationship(null);
     setRelationshipDialogOpen(false);
-  }, [selectedRelationship, csrf, refreshRelationships]);
+  }, [selectedRelationship, relationships, csrf, refreshRelationships]);
 
   const openCreateOrganizationDialog = useCallback(() => {
     setNewOrganization({ name: '', description: '', website: '' });
@@ -328,10 +343,12 @@ const VolunteerRelationships = ({ forceUpdate = () => {}, onlyMe = false }) => {
         <DialogContent>
         <Autocomplete
           disableClearable
-          getOptionLabel={(option) => (organizationMap[option]?.name || option)}
-          options={['Create a New Organization', ...Object.keys(organizationMap)]}
+          getOptionLabel={(option) => 
+            option === 'new' ? 'Create a New Organization' : organizationMap[option]?.name || option
+          }
+          options={['new', ...Object.keys(organizationMap)]}
           onChange={(event, value) => {
-            if (value === 'Create a New Organization') {
+            if (value === 'new') {
               setRelationshipDialogOpen(false); // Close the relationship dialog
               openCreateOrganizationDialog(); // Open the organization creation dialog
             } else {

--- a/web-ui/src/helpers/toast.js
+++ b/web-ui/src/helpers/toast.js
@@ -1,0 +1,21 @@
+import { UPDATE_TOAST } from '../context/actions';
+
+export const showToast = (severity, toast) => {
+  if (window.snackDispatch) {
+    window.snackDispatch({
+      type: UPDATE_TOAST,
+      payload: {
+        severity,
+        toast,
+      }
+    });
+  }
+};
+
+export const showError = msg => showToast('error', msg);
+
+export const showInfo = msg => showToast('info', msg);
+
+export const showSuccess = msg => showToast('success', msg);
+
+export const showWarning = msg => showToast('warning', msg);


### PR DESCRIPTION
This was an involved effort to implement upgrades and new features to Volunteer Tracking.

1. The "MY ORGS" and "EVENTS" tabs are visible following the upgrades, and have been made both visually appealing and faster.

2. The "ORGANIZATIONS" tab has been made invisible, and redundant relationships implements have been adjusted accordingly.

3. The message "The administrator may edit organizations to ensure accuracy." 'appears at the bottom of the table containing relationships with organizations'--"MY ORGS" on the Member Profile Page and "RELATIONSHIPS" on Reports > Volunteering.

4. 'The Card element that is currently containing only the data table has visually been "pulled up" to contain the tabs as well.' The original instruction, in single quotes, has been met. I will clarify that what resolving this facet actually means is that much of the code structure has been altered significantly.

5. The tab-menu's titles now include appropriate icons, and are stylistically aligned with the other cards on the Member Profile page.

6. Redundant titles have been removed from the Member Profile page.

7. A "Volunteer Activities" element has been implemented, and its width is easily adjustable for viewing and interaction on any platform. A certain width was included in the instructions and has been met on the ```develop``` branch, so I did not include further edits to that effect. Include those changes on the issue branch for best practice.

8. 'The pertinent element has been raised above the "Skills" card on the screen.' This instruction was also completed on the ```develop``` branch, so I did not do it again here. It is proper to include updates on their corresponding issue branch.

9. The 'Add Relationship' dialog only allows a new relationship with an existing organization if:
* 'There is no relationship with the organization already, OR
* Any existing relationships with this organization have an end date.'

10. The following control criteria for the "MY ORGS" and "EVENTS" tabs have been implemented to instruction:

_On "MY ORGS":_
* 'The start date must be on or before the current date'
* 'If an end date is entered it must be after the start date'

_On "EVENTS":_
* The "Hours" input box is now labeled 'Hours You Volunteered'
* Organizations with which the User already has a relationship are readily available for Event creation, except for such relationships that have been marked with an end date.
* New organizations can be created from within the 'Add Event' dialog, and are then automatically added the User's "MY ORGS" tab. This necessarily surpasses the instruction for this feature because, to the same end as the requested "Add a new organization" button, the ability to create a new organization is offered on the "MY ORGS" tab. Basically, you cannot have separate "Create new organization" and "Add new organization" functionalities on the same page. This item also involved significant changes to the codebase.
