### PR TITLE
Bufix 2638/reviews all users return on all deletion

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServices.java
@@ -16,4 +16,5 @@ public interface ReviewAssignmentServices {
     void delete(UUID id);
     Set<ReviewAssignment> findAllByReviewPeriodIdAndReviewerId(UUID reviewPeriodId, @Nullable UUID reviewerId);
 
+    Set<ReviewAssignment> defaultReviewAssignments(UUID reviewPeriodId);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServicesImpl.java
@@ -82,10 +82,6 @@ public class ReviewAssignmentServicesImpl implements ReviewAssignmentServices {
         } else {
             reviewAssignments = reviewAssignmentRepository.findByReviewPeriodIdAndReviewerId(reviewPeriodId, reviewerId);
         }
-        if (reviewAssignments.isEmpty()) {
-            //If no assignments exist for the review period, then a set of default review assignments should be returned
-            reviewAssignments = defaultReviewAssignments(reviewPeriodId);
-        }
 
         return reviewAssignments;
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/reviews/ReviewAssignmentServicesImpl.java
@@ -109,7 +109,7 @@ public class ReviewAssignmentServicesImpl implements ReviewAssignmentServices {
         }
     }
 
-    private Set<ReviewAssignment> defaultReviewAssignments(UUID reviewPeriodId) {
+    public Set<ReviewAssignment> defaultReviewAssignments(UUID reviewPeriodId) {
         Set<ReviewAssignment> reviewAssignments = new HashSet<>();
 
         memberProfileRepository.findAll().forEach(memberProfile -> {


### PR DESCRIPTION
Made it so the "list all user" server-method will no longer return list of all users if the list is empty
Made it so upon review-creation, it adds all users to the review, and saves them as assignment records