### PR TITLE
Mark externalScore nullable so that we can pull responses with null v…

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponse.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponse.java
@@ -77,7 +77,7 @@ public class PulseResponse {
     protected PulseResponse() {
     }
 
-    public PulseResponse(UUID id, Integer internalScore, Integer externalScore, LocalDate submissionDate, @Nullable UUID teamMemberId, String internalFeelings, String externalFeelings) {
+    public PulseResponse(UUID id, Integer internalScore, @Nullable Integer externalScore, LocalDate submissionDate, @Nullable UUID teamMemberId, String internalFeelings, String externalFeelings) {
         this.id = id;
         this.internalScore = internalScore;
         this.externalScore = externalScore;


### PR DESCRIPTION
…alues in the pulse report.