### PR TITLE
Added the application form url encoded media type to the external…

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseController.java
@@ -140,7 +140,7 @@ public class PulseResponseController {
     }
 
     @Secured(SecurityRule.IS_ANONYMOUS)
-    @Post("/external")
+    @Post(uri = "/external", consumes = MediaType.APPLICATION_FORM_URLENCODED)
     public HttpResponse<PulseResponse> externalPulseResponse(
                @Header("X-Slack-Signature") String signature,
                @Header("X-Slack-Request-Timestamp") String timestamp,

--- a/server/src/main/resources/slack/pulse_slack_blocks.json
+++ b/server/src/main/resources/slack/pulse_slack_blocks.json
@@ -71,6 +71,7 @@
     },
     {
       "type": "input",
+      "optional": true,
       "element": {
         "type": "plain_text_input",
         "action_id": "internalFeelings",
@@ -140,6 +141,7 @@
     },
     {
       "type": "input",
+      "optional": true,
       "element": {
         "type": "plain_text_input",
         "action_id": "externalFeelings",


### PR DESCRIPTION
…pulse response method.

When submitting a pulse response from Slack, I was seeing a 415 error in the GCP log.  I believe, but am not 100% certain, that this was due to a missing media type designation on the external response method.