### PR TITLE
Feature 2868/pull slack kudos in

### DIFF
--- a/.github/workflows/gradle-build-production.yml
+++ b/.github/workflows/gradle-build-production.yml
@@ -89,6 +89,7 @@ jobs:
             --set-env-vars "SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }}" \
             --set-env-vars "SLACK_PULSE_SIGNING_SECRET=${{ secrets.SLACK_PULSE_SIGNING_SECRET }}" \
             --set-env-vars "SLACK_PULSE_BOT_TOKEN=${{ secrets.SLACK_PULSE_BOT_TOKEN }}" \
+            --set-env-vars "SLACK_KUDOS_CHANNEL_ID=${{ secrets.SLACK_KUDOS_CHANNEL_ID }}" \
             --platform "managed" \
             --max-instances 8 \
             --allow-unauthenticated

--- a/.github/workflows/gradle-deploy-develop.yml
+++ b/.github/workflows/gradle-deploy-develop.yml
@@ -113,6 +113,7 @@ jobs:
             --set-env-vars "SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}" \
             --set-env-vars "SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }}" \
             --set-env-vars "SLACK_SIGNING_SECRET=${{ secrets.SLACK_PULSE_SIGNING_SECRET }}" \
+            --set-env-vars "SLACK_KUDOS_CHANNEL_ID=${{ secrets.SLACK_KUDOS_CHANNEL_ID }}" \
             --platform "managed" \
             --max-instances 2 \
             --allow-unauthenticated

--- a/.github/workflows/gradle-deploy-native-develop.yml
+++ b/.github/workflows/gradle-deploy-native-develop.yml
@@ -113,6 +113,7 @@ jobs:
             --set-env-vars "SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }}" \
             --set-env-vars "SLACK_PULSE_SIGNING_SECRET=${{ secrets.SLACK_PULSE_SIGNING_SECRET }}" \
             --set-env-vars "SLACK_PULSE_BOT_TOKEN=${{ secrets.SLACK_PULSE_BOT_TOKEN }}" \
+            --set-env-vars "SLACK_KUDOS_CHANNEL_ID=${{ secrets.SLACK_KUDOS_CHANNEL_ID }}" \
             --platform "managed" \
             --max-instances 2 \
             --allow-unauthenticated

--- a/server/src/main/java/com/objectcomputing/checkins/configuration/CheckInsConfiguration.java
+++ b/server/src/main/java/com/objectcomputing/checkins/configuration/CheckInsConfiguration.java
@@ -82,6 +82,9 @@ public class CheckInsConfiguration {
 
             @NotBlank
             private String signingSecret;
+
+            @NotBlank
+            private String kudosChannel;
         }
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/social_media/SlackSearch.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/social_media/SlackSearch.java
@@ -58,6 +58,31 @@ public class SlackSearch {
         return null;
     }
 
+    public String findChannelName(String channelId) {
+        String token = configuration.getApplication().getSlack().getBotToken();
+        if (token != null) {
+            try {
+                MethodsClient client = Slack.getInstance().methods(token);
+                ConversationsListResponse response = client.conversationsList(
+                    ConversationsListRequest.builder().build()
+                );
+
+                if (response.isOk()) {
+                    for (Conversation conversation: response.getChannels()) {
+                        if (conversation.getId().equals(channelId)) {
+                            return conversation.getName();
+                        }
+                    }
+                }
+            } catch(IOException e) {
+                LOG.error("SlackSearch.findChannelName: " + e.toString());
+            } catch(SlackApiException e) {
+                LOG.error("SlackSearch.findChannelName: " + e.toString());
+            }
+        }
+        return null;
+    }
+
     public String findUserId(String userEmail) {
         String token = configuration.getApplication().getSlack().getBotToken();
         if (token != null) {

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/social_media/SlackSender.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/social_media/SlackSender.java
@@ -46,7 +46,6 @@ public class SlackSender {
                     .builder()
                     .channel(openResponse.getChannel().getId())
                     .blocksAsString(slackBlocks)
-                    .text("This is a test")
                     .build();
 
                 // Send it to Slack

--- a/server/src/main/java/com/objectcomputing/checkins/notifications/social_media/SlackSender.java
+++ b/server/src/main/java/com/objectcomputing/checkins/notifications/social_media/SlackSender.java
@@ -1,0 +1,71 @@
+package com.objectcomputing.checkins.notifications.social_media;
+
+import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.request.conversations.ConversationsOpenRequest;
+import com.slack.api.methods.response.conversations.ConversationsOpenResponse;
+
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+@Singleton
+public class SlackSender {
+    private static final Logger LOG = LoggerFactory.getLogger(SlackSender.class);
+
+    @Inject
+    private CheckInsConfiguration configuration;
+
+    public boolean send(List<String> userIds, String slackBlocks) {
+        // See if we have a token.
+        String token = configuration.getApplication()
+                                    .getSlack().getBotToken();
+        if (token != null && !slackBlocks.isEmpty()) {
+            MethodsClient client = Slack.getInstance().methods(token);
+
+            try {
+                ConversationsOpenResponse openResponse =
+                    client.conversationsOpen(ConversationsOpenRequest.builder()
+                        .users(userIds)
+                        .returnIm(true)
+                        .build());
+                if (!openResponse.isOk()) {
+                    LOG.error("Unable to open the conversation");
+                    return false;
+                }
+
+                ChatPostMessageRequest request = ChatPostMessageRequest
+                    .builder()
+                    .channel(openResponse.getChannel().getId())
+                    .blocksAsString(slackBlocks)
+                    .text("This is a test")
+                    .build();
+
+                // Send it to Slack
+                ChatPostMessageResponse response = client.chatPostMessage(request);
+
+                if (!response.isOk()) {
+                    LOG.error("Unable to send the chat message: " +
+                              response.getError());
+                }
+
+                return response.isOk();
+            } catch(Exception ex) {
+                LOG.error("SlackSender.send: " + ex.toString());
+                return false;
+            }
+        } else {
+            LOG.error("Missing token or missing slack blocks");
+            return false;
+        }
+    }
+}
+

--- a/server/src/main/java/com/objectcomputing/checkins/services/kudos/KudosConverter.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/kudos/KudosConverter.java
@@ -1,6 +1,6 @@
 package com.objectcomputing.checkins.services.kudos;
 
-import com.objectcomputing.checkins.notifications.social_media.SlackSearch;
+import com.objectcomputing.checkins.services.slack.SlackSearch;
 import com.objectcomputing.checkins.services.kudos.kudos_recipient.KudosRecipientServices;
 import com.objectcomputing.checkins.services.kudos.kudos_recipient.KudosRecipient;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;

--- a/server/src/main/java/com/objectcomputing/checkins/services/kudos/KudosConverter.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/kudos/KudosConverter.java
@@ -22,10 +22,6 @@ import java.util.ArrayList;
 
 @Singleton
 public class KudosConverter {
-    private record InternalBlock(
-      List<LayoutBlock> blocks
-    ) {}
-
     private final MemberProfileServices memberProfileServices;
     private final KudosRecipientServices kudosRecipientServices;
     private final SlackSearch slackSearch;
@@ -61,9 +57,8 @@ public class KudosConverter {
             .elements(content).build();
         RichTextBlock richTextBlock = RichTextBlock.builder()
             .elements(List.of(element)).build();
-        InternalBlock block = new InternalBlock(List.of(richTextBlock));
         Gson mapper = GsonFactory.createSnakeCase();
-        return mapper.toJson(block);
+        return mapper.toJson(List.of(richTextBlock));
     }
 
     private RichTextSectionElement.TextStyle boldItalic() {

--- a/server/src/main/java/com/objectcomputing/checkins/services/kudos/KudosServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/kudos/KudosServices.java
@@ -11,6 +11,8 @@ public interface KudosServices {
 
     Kudos approve(Kudos kudos);
 
+    Kudos savePreapproved(KudosCreateDTO kudos);
+
     List<KudosResponseDTO> getRecent();
 
     KudosResponseDTO getById(UUID id);

--- a/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/currentuser/CurrentUserServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/memberprofile/currentuser/CurrentUserServicesImpl.java
@@ -57,7 +57,7 @@ public class CurrentUserServicesImpl implements CurrentUserServices {
 
     @Override
     public boolean hasPermission(Permission permission) {
-        MemberProfile currentUser = getCurrentUser();
+        MemberProfile currentUser = getCurrentUserImpl();
         if (currentUser == null) {
             return false;
         }
@@ -72,7 +72,7 @@ public class CurrentUserServicesImpl implements CurrentUserServices {
         return hasRole(RoleType.ADMIN);
     }
 
-    public MemberProfile getCurrentUser() {
+    private MemberProfile getCurrentUserImpl() {
         if (securityService != null) {
             Optional<Authentication> auth = securityService.getAuthentication();
             if (auth.isPresent() && auth.get().getAttributes().get("email") != null) {
@@ -80,8 +80,15 @@ public class CurrentUserServicesImpl implements CurrentUserServices {
                 return memberProfileRepo.findByWorkEmail(workEmail).orElse(null);
             }
         }
+        return null;
+    }
 
-        throw new NotFoundException("No active members in the system");
+    public MemberProfile getCurrentUser() {
+        MemberProfile profile = getCurrentUserImpl();
+        if (profile == null) {
+            throw new NotFoundException("No active members in the system");
+        }
+        return profile;
     }
 
     private MemberProfile saveNewUser(String firstName, String lastName, String workEmail) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseController.java
@@ -1,7 +1,7 @@
 package com.objectcomputing.checkins.services.pulseresponse;
 
 import com.objectcomputing.checkins.exceptions.NotFoundException;
-import com.objectcomputing.checkins.util.form.FormUrlEncodedDecoder;
+import com.objectcomputing.checkins.services.slack.SlackSubmissionHandler;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 
 import io.micronaut.http.MediaType;
@@ -29,8 +29,6 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Map;
-import java.nio.charset.StandardCharsets;
 
 @Controller("/services/pulse-responses")
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -38,20 +36,14 @@ import java.nio.charset.StandardCharsets;
 public class PulseResponseController {
     private final PulseResponseService pulseResponseServices;
     private final MemberProfileServices memberProfileServices;
-    private final SlackSignatureVerifier slackSignatureVerifier;
-    private final PulseSlackCommand pulseSlackCommand;
-    private final SlackPulseResponseConverter slackPulseResponseConverter;
+    private final SlackSubmissionHandler slackSubmissionHandler;
 
     public PulseResponseController(PulseResponseService pulseResponseServices,
                                    MemberProfileServices memberProfileServices,
-                                   SlackSignatureVerifier slackSignatureVerifier,
-                                   PulseSlackCommand pulseSlackCommand,
-                                   SlackPulseResponseConverter slackPulseResponseConverter) {
+                                   SlackSubmissionHandler slackSubmissionHandler) {
         this.pulseResponseServices = pulseResponseServices;
         this.memberProfileServices = memberProfileServices;
-        this.slackSignatureVerifier = slackSignatureVerifier;
-        this.pulseSlackCommand = pulseSlackCommand;
-        this.slackPulseResponseConverter = slackPulseResponseConverter;
+        this.slackSubmissionHandler = slackSubmissionHandler;
     }
 
     /**
@@ -120,25 +112,8 @@ public class PulseResponseController {
                @Header("X-Slack-Signature") String signature,
                @Header("X-Slack-Request-Timestamp") String timestamp,
                @Body String requestBody) {
-        // Validate the request
-        if (slackSignatureVerifier.verifyRequest(signature,
-                                                 timestamp, requestBody)) {
-            // Convert the request body to a map of values.
-            FormUrlEncodedDecoder formUrlEncodedDecoder = new FormUrlEncodedDecoder();
-            Map<String, Object> body =
-                formUrlEncodedDecoder.decode(requestBody,
-                                             StandardCharsets.UTF_8);
-
-            // Respond to the slack command.
-            String triggerId = (String)body.get("trigger_id");
-            if (pulseSlackCommand.send(triggerId)) {
-                return HttpResponse.ok();
-            } else {
-                return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR);
-            }
-        } else {
-            return HttpResponse.unauthorized();
-        }
+        return slackSubmissionHandler.commandResponse(signature,
+                                                      timestamp, requestBody);
     }
 
     @Secured(SecurityRule.IS_ANONYMOUS)
@@ -148,53 +123,7 @@ public class PulseResponseController {
                @Header("X-Slack-Request-Timestamp") String timestamp,
                @Body String requestBody,
                HttpRequest<?> request) {
-        // Validate the request
-        if (slackSignatureVerifier.verifyRequest(signature,
-                                                 timestamp, requestBody)) {
-            // Convert the request body to a map of values.
-            FormUrlEncodedDecoder formUrlEncodedDecoder =
-                new FormUrlEncodedDecoder();
-            Map<String, Object> body =
-                formUrlEncodedDecoder.decode(requestBody,
-                                             StandardCharsets.UTF_8);
-
-            final String key = "payload";
-            if (body.containsKey(key)) {
-                PulseResponseCreateDTO pulseResponseDTO =
-                    slackPulseResponseConverter.get(memberProfileServices,
-                                                    (String)body.get(key));
-
-                // If we receive a null DTO, that means that this is not the
-                // actual submission of the form.  We can just return 200 so
-                // that Slack knows to continue without error.
-                if (pulseResponseDTO == null) {
-                    return HttpResponse.ok();
-                }
-
-                // Create the pulse response
-                PulseResponse pulseResponse =
-                    pulseResponseServices.unsecureSave(
-                        new PulseResponse(
-                            pulseResponseDTO.getInternalScore(),
-                            pulseResponseDTO.getExternalScore(),
-                            pulseResponseDTO.getSubmissionDate(),
-                            pulseResponseDTO.getTeamMemberId(),
-                            pulseResponseDTO.getInternalFeelings(),
-                            pulseResponseDTO.getExternalFeelings()
-                        )
-                );
-
-                if (pulseResponse == null) {
-                    return HttpResponse.status(HttpStatus.CONFLICT,
-                                               "Already submitted today");
-                } else {
-                    return HttpResponse.ok();
-                }
-            } else {
-                return HttpResponse.unprocessableEntity();
-            }
-        } else {
-            return HttpResponse.unauthorized();
-        }
+        return slackSubmissionHandler.externalResponse(signature, timestamp,
+                                                       requestBody, request);
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesImpl.java
@@ -5,6 +5,8 @@ import com.objectcomputing.checkins.services.feedback_request.FeedbackRequestRep
 import com.objectcomputing.checkins.services.feedback_request.FeedbackRequestServicesImpl;
 import com.objectcomputing.checkins.services.reviews.ReviewPeriodServices;
 import com.objectcomputing.checkins.services.pulse.PulseServices;
+import com.objectcomputing.checkins.services.slack.kudos.KudosChannelReader;
+
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,15 +22,18 @@ public class CheckServicesImpl implements CheckServices {
     private final FeedbackRequestRepository feedbackRequestRepository;
     private final PulseServices pulseServices;
     private final ReviewPeriodServices reviewPeriodServices;
+    private final KudosChannelReader kudosChannelReader;
 
     public CheckServicesImpl(FeedbackRequestServicesImpl feedbackRequestServices,
                              FeedbackRequestRepository feedbackRequestRepository,
                              PulseServices pulseServices,
-                             ReviewPeriodServices reviewPeriodServices) {
+                             ReviewPeriodServices reviewPeriodServices,
+                             KudosChannelReader kudosChannelReader) {
         this.feedbackRequestServices = feedbackRequestServices;
         this.feedbackRequestRepository = feedbackRequestRepository;
         this.pulseServices = pulseServices;
         this.reviewPeriodServices = reviewPeriodServices;
+        this.kudosChannelReader = kudosChannelReader;
     }
 
     @Override
@@ -43,6 +48,7 @@ public class CheckServicesImpl implements CheckServices {
         }
         pulseServices.notifyUsers(today);
         reviewPeriodServices.sendNotifications(today);
+        kudosChannelReader.readChannel();
         return true;
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/PulseSlackCommand.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/PulseSlackCommand.java
@@ -1,4 +1,4 @@
-package com.objectcomputing.checkins.services.pulseresponse;
+package com.objectcomputing.checkins.services.slack;
 
 import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackPulseResponseConverter.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackPulseResponseConverter.java
@@ -1,9 +1,10 @@
-package com.objectcomputing.checkins.services.pulseresponse;
+package com.objectcomputing.checkins.services.slack;
 
 import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.notifications.social_media.SlackSearch;
+import com.objectcomputing.checkins.services.pulseresponse.PulseResponseCreateDTO;
 
 import jakarta.inject.Singleton;
 
@@ -23,13 +24,15 @@ public class SlackPulseResponseConverter {
     private static final Logger LOG = LoggerFactory.getLogger(SlackPulseResponseConverter.class);
 
     private final SlackSearch slackSearch;
+    private final MemberProfileServices memberProfileServices;
 
-    public SlackPulseResponseConverter(SlackSearch slackSearch) {
+    public SlackPulseResponseConverter(SlackSearch slackSearch,
+                                       MemberProfileServices memberProfileServices) {
         this.slackSearch = slackSearch;
+        this.memberProfileServices = memberProfileServices;
     }
 
-    public PulseResponseCreateDTO get(
-                    MemberProfileServices memberProfileServices, String body) {
+    public PulseResponseCreateDTO get(String body) {
         try {
             // Get the map of values from the string body
             final ObjectMapper mapper = new ObjectMapper();
@@ -47,7 +50,7 @@ public class SlackPulseResponseConverter {
 
                 // Create the pulse DTO and fill in the values.
                 PulseResponseCreateDTO response = new PulseResponseCreateDTO();
-                response.setTeamMemberId(lookupUser(memberProfileServices, map));
+                response.setTeamMemberId(lookupUser(map));
                 response.setSubmissionDate(LocalDate.now());
 
                 // Internal Score
@@ -111,8 +114,7 @@ public class SlackPulseResponseConverter {
         }
     }
 
-    private UUID lookupUser(MemberProfileServices memberProfileServices,
-                            Map<String, Object> map) {
+    private UUID lookupUser(Map<String, Object> map) {
         // Get the user's profile map.
         Map<String, Object> user = (Map<String, Object>)map.get("user");
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackReader.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackReader.java
@@ -1,0 +1,66 @@
+package com.objectcomputing.checkins.services.slack;
+
+import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Message;
+import com.slack.api.model.Conversation;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.conversations.ConversationsHistoryRequest;
+import com.slack.api.methods.response.conversations.ConversationsHistoryResponse;
+
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Singleton
+public class SlackReader {
+    private static final Logger LOG = LoggerFactory.getLogger(SlackReader.class);
+
+    @Inject
+    private CheckInsConfiguration configuration;
+
+    public List<Message> read(String channelId, LocalDateTime last) {
+        String token = configuration.getApplication().getSlack().getBotToken();
+        if (token != null) {
+            try {
+                long ts = last.atZone(ZoneId.systemDefault())
+                              .toInstant().getEpochSecond();
+                String timestamp = String.valueOf(ts);
+                MethodsClient client = Slack.getInstance().methods(token);
+                ConversationsHistoryResponse response =
+                    client.conversationsHistory(
+                        ConversationsHistoryRequest.builder()
+                                                   .channel(channelId)
+                                                   .oldest(timestamp)
+                                                   .inclusive(true)
+                                                   .build());
+
+                if (response.isOk()) {
+                    return response.getMessages();
+                } else {
+                    LOG.error("Slack Response: " + response.getError() +
+                              " - " + response.getNeeded());
+                }
+            } catch(IOException e) {
+                LOG.error("SlackReader.read: " + e.toString());
+            } catch(SlackApiException e) {
+                LOG.error("SlackReader.read: " + e.toString());
+            }
+        } else {
+            LOG.error("Slack Token not available");
+        }
+        return new ArrayList<Message>();
+    }
+}
+

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSearch.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSearch.java
@@ -1,4 +1,4 @@
-package com.objectcomputing.checkins.notifications.social_media;
+package com.objectcomputing.checkins.services.slack;
 
 import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
 import com.slack.api.model.block.LayoutBlock;

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSignatureVerifier.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSignatureVerifier.java
@@ -1,4 +1,4 @@
-package com.objectcomputing.checkins.services.pulseresponse;
+package com.objectcomputing.checkins.services.slack;
 
 import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSubmissionHandler.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSubmissionHandler.java
@@ -1,0 +1,110 @@
+package com.objectcomputing.checkins.services.slack;
+
+import com.objectcomputing.checkins.util.form.FormUrlEncodedDecoder;
+import com.objectcomputing.checkins.services.pulseresponse.PulseResponse;
+import com.objectcomputing.checkins.services.pulseresponse.PulseResponseService;
+import com.objectcomputing.checkins.services.pulseresponse.PulseResponseCreateDTO;
+
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+import java.nio.charset.StandardCharsets;
+
+@Singleton
+public class SlackSubmissionHandler {
+    private final PulseResponseService pulseResponseServices;
+    private final SlackSignatureVerifier slackSignatureVerifier;
+    private final PulseSlackCommand pulseSlackCommand;
+    private final SlackPulseResponseConverter slackPulseResponseConverter;
+
+    public SlackSubmissionHandler(PulseResponseService pulseResponseServices,
+                                  SlackSignatureVerifier slackSignatureVerifier,
+                                  PulseSlackCommand pulseSlackCommand,
+                                  SlackPulseResponseConverter slackPulseResponseConverter) {
+        this.pulseResponseServices = pulseResponseServices;
+        this.slackSignatureVerifier = slackSignatureVerifier;
+        this.pulseSlackCommand = pulseSlackCommand;
+        this.slackPulseResponseConverter = slackPulseResponseConverter;
+    }
+
+    public HttpResponse commandResponse(String signature,
+                                        String timestamp,
+                                        String requestBody) {
+        // Validate the request
+        if (slackSignatureVerifier.verifyRequest(signature,
+                                                 timestamp, requestBody)) {
+            // Convert the request body to a map of values.
+            FormUrlEncodedDecoder formUrlEncodedDecoder = new FormUrlEncodedDecoder();
+            Map<String, Object> body =
+                formUrlEncodedDecoder.decode(requestBody,
+                                             StandardCharsets.UTF_8);
+
+            // Respond to the slack command.
+            String triggerId = (String)body.get("trigger_id");
+            if (pulseSlackCommand.send(triggerId)) {
+                return HttpResponse.ok();
+            } else {
+                return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        } else {
+            return HttpResponse.unauthorized();
+        }
+    }
+
+    public HttpResponse externalResponse(String signature,
+                                         String timestamp,
+                                         String requestBody,
+                                         HttpRequest<?> request) {
+        // Validate the request
+        if (slackSignatureVerifier.verifyRequest(signature,
+                                                 timestamp, requestBody)) {
+            // Convert the request body to a map of values.
+            FormUrlEncodedDecoder formUrlEncodedDecoder =
+                new FormUrlEncodedDecoder();
+            Map<String, Object> body =
+                formUrlEncodedDecoder.decode(requestBody,
+                                             StandardCharsets.UTF_8);
+
+            final String key = "payload";
+            if (body.containsKey(key)) {
+                PulseResponseCreateDTO pulseResponseDTO =
+                    slackPulseResponseConverter.get((String)body.get(key));
+
+                // If we receive a null DTO, that means that this is not the
+                // actual submission of the form.  We can just return 200 so
+                // that Slack knows to continue without error.
+                if (pulseResponseDTO == null) {
+                    return HttpResponse.ok();
+                }
+
+                // Create the pulse response
+                PulseResponse pulseResponse =
+                    pulseResponseServices.unsecureSave(
+                        new PulseResponse(
+                            pulseResponseDTO.getInternalScore(),
+                            pulseResponseDTO.getExternalScore(),
+                            pulseResponseDTO.getSubmissionDate(),
+                            pulseResponseDTO.getTeamMemberId(),
+                            pulseResponseDTO.getInternalFeelings(),
+                            pulseResponseDTO.getExternalFeelings()
+                        )
+                );
+
+                if (pulseResponse == null) {
+                    return HttpResponse.status(HttpStatus.CONFLICT,
+                                               "Already submitted today");
+                } else {
+                    return HttpResponse.ok();
+                }
+            } else {
+                return HttpResponse.unprocessableEntity();
+            }
+        } else {
+            return HttpResponse.unauthorized();
+        }
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSubmissionHandler.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSubmissionHandler.java
@@ -31,18 +31,18 @@ public class SlackSubmissionHandler {
     private static final String typeKey = "type";
 
     private final PulseResponseService pulseResponseServices;
-    private final SlackSignatureVerifier slackSignatureVerifier;
+    private final SlackSignature slackSignature;
     private final PulseSlackCommand pulseSlackCommand;
     private final SlackPulseResponseConverter slackPulseResponseConverter;
     private final SlackKudosResponseHandler slackKudosResponseHandler;
 
     public SlackSubmissionHandler(PulseResponseService pulseResponseServices,
-                                  SlackSignatureVerifier slackSignatureVerifier,
+                                  SlackSignature slackSignature,
                                   PulseSlackCommand pulseSlackCommand,
                                   SlackPulseResponseConverter slackPulseResponseConverter,
                                   SlackKudosResponseHandler slackKudosResponseHandler) {
         this.pulseResponseServices = pulseResponseServices;
-        this.slackSignatureVerifier = slackSignatureVerifier;
+        this.slackSignature = slackSignature;
         this.pulseSlackCommand = pulseSlackCommand;
         this.slackPulseResponseConverter = slackPulseResponseConverter;
         this.slackKudosResponseHandler = slackKudosResponseHandler;
@@ -52,8 +52,7 @@ public class SlackSubmissionHandler {
                                         String timestamp,
                                         String requestBody) {
         // Validate the request
-        if (slackSignatureVerifier.verifyRequest(signature,
-                                                 timestamp, requestBody)) {
+        if (slackSignature.verifyRequest(signature, timestamp, requestBody)) {
             // Convert the request body to a map of values.
             FormUrlEncodedDecoder formUrlEncodedDecoder = new FormUrlEncodedDecoder();
             Map<String, Object> body =
@@ -77,8 +76,7 @@ public class SlackSubmissionHandler {
                                          String requestBody,
                                          HttpRequest<?> request) {
         // Validate the request
-        if (slackSignatureVerifier.verifyRequest(signature,
-                                                 timestamp, requestBody)) {
+        if (slackSignature.verifyRequest(signature, timestamp, requestBody)) {
             // Convert the request body to a map of values.
             FormUrlEncodedDecoder formUrlEncodedDecoder =
                 new FormUrlEncodedDecoder();

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSubmissionHandler.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/SlackSubmissionHandler.java
@@ -19,12 +19,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.nio.charset.StandardCharsets;
 
 @Singleton
 public class SlackSubmissionHandler {
-    private final String typeKey = "type";
+    private static final Logger LOG = LoggerFactory.getLogger(SlackSubmissionHandler.class);
+    private static final String typeKey = "type";
 
     private final PulseResponseService pulseResponseServices;
     private final SlackSignatureVerifier slackSignatureVerifier;
@@ -96,6 +100,7 @@ public class SlackSubmissionHandler {
                     }
                 } catch(JsonProcessingException ex) {
                     // Fall through to the bottom...
+                    LOG.error("externalResponse: " + ex.toString());
                 }
             }
         } else {

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudos.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudos.java
@@ -47,7 +47,7 @@ public class AutomatedKudos {
 
     @NotBlank
     @Column(name = "externalid")
-    @ColumnTransformer(read = "pgp_sym_decrypt(message::bytea, '${aes.key}')", write = "pgp_sym_encrypt(?, '${aes.key}')")
+    @ColumnTransformer(read = "pgp_sym_decrypt(externalid::bytea, '${aes.key}')", write = "pgp_sym_encrypt(?, '${aes.key}')")
     @Schema(description = "the external id of the sender")
     private String externalId;
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudos.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudos.java
@@ -1,0 +1,78 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.AutoPopulated;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.annotation.sql.ColumnTransformer;
+import io.micronaut.data.model.DataType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+@Setter
+@Introspected
+@Table(name = "automated_kudos")
+public class AutomatedKudos {
+    @Id
+    @Column(name = "id")
+    @AutoPopulated
+    @TypeDef(type = DataType.STRING)
+    @Schema(description = "the id of the kudos")
+    private UUID id;
+
+    @Column(name = "requested")
+    @NotNull
+    @Schema(description = "Has permission been requested of the poster")
+    private Boolean requested;
+
+    @NotBlank
+    @Column(name = "message")
+    @ColumnTransformer(read = "pgp_sym_decrypt(message::bytea, '${aes.key}')", write = "pgp_sym_encrypt(?, '${aes.key}')")
+    @Schema(description = "message describing the kudos")
+    private String message;
+
+    @NotBlank
+    @Column(name = "externalid")
+    @ColumnTransformer(read = "pgp_sym_decrypt(message::bytea, '${aes.key}')", write = "pgp_sym_encrypt(?, '${aes.key}')")
+    @Schema(description = "the external id of the sender")
+    private String externalId;
+
+    @NotNull
+    @Column(name = "senderid")
+    @TypeDef(type = DataType.STRING)
+    @Schema(description = "id of the user who gave the kudos")
+    private UUID senderId;
+
+    @Column(name = "recipientids")
+    @TypeDef(type = DataType.STRING_ARRAY)
+    @Schema(description = "UUIDs of the recipients")
+    private List<String> recipientIds;
+
+    // This is necessary for Micronaut to persist instances of this class.
+    AutomatedKudos() {}
+
+    AutomatedKudos(AutomatedKudosDTO automatedKudosDTO) {
+        this.requested = false;
+        this.message = automatedKudosDTO.getMessage();
+        this.externalId = automatedKudosDTO.getExternalId();
+        this.senderId = automatedKudosDTO.getSenderId();
+        this.recipientIds = automatedKudosDTO.getRecipientIds()
+                                             .stream()
+                                             .map(UUID::toString)
+                                             .collect(Collectors.toList());
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudosDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudosDTO.java
@@ -1,0 +1,31 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import io.micronaut.core.annotation.Introspected;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Introspected
+public class AutomatedKudosDTO {
+
+    @NotBlank
+    private String message;
+
+    @NotNull
+    private String externalId;
+
+    @NotNull
+    private UUID senderId;
+
+    @NotNull
+    private List<UUID> recipientIds;
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudosRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/AutomatedKudosRepository.java
@@ -1,0 +1,22 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.annotation.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+public interface AutomatedKudosRepository extends CrudRepository<AutomatedKudos, UUID> {
+    @Query(value = """
+           SELECT
+             id, requested,
+             PGP_SYM_DECRYPT(cast(message as bytea), '${aes.key}') as message,
+             PGP_SYM_DECRYPT(cast(externalid as bytea), '${aes.key}') as externalid,
+             senderid, recipientids
+           FROM automated_kudos
+           WHERE requested IS FALSE""", nativeQuery = true)
+        List<AutomatedKudos> getUnrequested(); 
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/BotSentKudosLocator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/BotSentKudosLocator.java
@@ -1,0 +1,55 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import com.objectcomputing.checkins.services.kudos.Kudos;
+import com.objectcomputing.checkins.services.slack.SlackReader;
+import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
+
+import com.slack.api.model.Message;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.time.LocalDateTime;
+
+@Singleton
+public class BotSentKudosLocator {
+    private static final Logger LOG = LoggerFactory.getLogger(BotSentKudosLocator.class);
+
+    @Inject
+    private CheckInsConfiguration configuration;
+
+    @Inject
+    private SlackReader slackReader;
+
+    // The identifiers needed to identify a message is the channel id and the
+    // time stamp.  We are always looking at a specific channel.  So if we find
+    // a message, we will return the timestamp as a string.  Otherwise, we will
+    // return null.
+    public String find(Kudos kudos) {
+        String channelId = configuration.getApplication()
+                                        .getSlack().getKudosChannel();
+        List<Message> messages =
+            slackReader.read(channelId, kudos.getDateCreated().atStartOfDay());
+
+        String kudosText = kudos.getMessage().trim();
+        for (Message message : messages) {
+            // We only care about messages sent by our bot.
+            if (message.getBotId() != null) {
+                // The first line is the "kudos from" line and is not part of
+                // the kudos message.
+                int cut = message.getText().indexOf("\n");
+                if (cut >= 0) {
+                    String actual = message.getText().substring(cut + 1).trim();
+                    if (actual.equals(kudosText)) {
+                        return message.getTs();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReadTime.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReadTime.java
@@ -1,0 +1,42 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Introspected
+@Table(name = "automated_kudos_read_time")
+public class KudosChannelReadTime {
+    static final public String key = "Singleton";
+
+    @Id
+    @Column(name = "id")
+    @Schema(description = "the id of the kudos channel read time")
+    private String id;
+
+    @NotNull
+    @Column(name = "readtime")
+    @TypeDef(type = DataType.TIMESTAMP)
+    @Schema(description = "date the kudos were created")
+    private LocalDateTime readTime;
+
+    public KudosChannelReadTime() {
+        id = key;
+        readTime = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReadTimeStore.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReadTimeStore.java
@@ -1,0 +1,9 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+public interface KudosChannelReadTimeStore extends CrudRepository<KudosChannelReadTime, String> {
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
@@ -52,6 +52,8 @@ public class KudosChannelReader {
             kudosChannelReadTimeStore.save(new KudosChannelReadTime());
         }
 
-        slackKudosCreator.store(messages);
+        if (!messages.isEmpty()) {
+            slackKudosCreator.store(messages);
+        }
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
@@ -31,7 +31,7 @@ public class KudosChannelReader {
     @Inject
     private SlackKudosCreator slackKudosCreator;
 
-    @Scheduled(fixedDelay = "1m")
+    @Scheduled(fixedDelay = "10m")
     public void readChannel() {
         if (lastImport == null) {
             lastImport = LocalDateTime.now();

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
@@ -5,8 +5,6 @@ import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
 
 import com.slack.api.model.Message;
 
-import io.micronaut.scheduling.annotation.Scheduled;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +31,6 @@ public class KudosChannelReader {
     @Inject
     private SlackKudosCreator slackKudosCreator;
 
-    @Scheduled(fixedDelay = "10m")
     public void readChannel() {
         Optional<KudosChannelReadTime> readTime =
             kudosChannelReadTimeStore.findById(KudosChannelReadTime.key);

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/KudosChannelReader.java
@@ -1,0 +1,55 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import com.objectcomputing.checkins.services.slack.SlackReader;
+import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
+
+import com.slack.api.model.Message;
+
+import io.micronaut.scheduling.annotation.Scheduled;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.time.LocalDateTime;
+
+@Singleton
+public class KudosChannelReader {
+    private static final Logger LOG = LoggerFactory.getLogger(KudosChannelReader.class);
+
+    private static LocalDateTime lastImport = null;
+
+    @Inject
+    private CheckInsConfiguration configuration;
+
+    @Inject
+    private SlackReader slackReader;
+
+    @Inject
+    private SlackKudosCreator slackKudosCreator;
+
+    @Scheduled(fixedDelay = "1m")
+    public void readChannel() {
+        if (lastImport == null) {
+            lastImport = LocalDateTime.now();
+        }
+
+        String channelId = configuration.getApplication()
+                                        .getSlack().getKudosChannel();
+        List<Message> messages = slackReader.read(channelId, lastImport);
+        updateLastImportTime();
+
+        slackKudosCreator.store(messages);
+    }
+
+    private LocalDateTime getLastImportTime() {
+        return lastImport;
+    }
+
+    private void updateLastImportTime() {
+        lastImport = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
@@ -50,8 +50,7 @@ public class SlackKudosCreator {
 
     public void store(List<Message> messages) {
         for (Message message : messages) {
-            if (message.getSubtype() == null &&
-                message.getText().toLowerCase().contains("kudos")) {
+            if (message.getSubtype() == null) {
                 try {
                     AutomatedKudosDTO kudosDTO = createFromMessage(message);
                     if (kudosDTO.getRecipientIds().size() == 0) {
@@ -64,6 +63,8 @@ public class SlackKudosCreator {
                 } catch (Exception ex) {
                     LOG.error("store: " + ex.toString());
                 }
+            } else {
+                LOG.info("Skipping message: " + message.getText());
             }
         }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
@@ -1,6 +1,6 @@
 package com.objectcomputing.checkins.services.slack.kudos;
 
-import com.objectcomputing.checkins.notifications.social_media.SlackSearch;
+import com.objectcomputing.checkins.services.slack.SlackSearch;
 import com.objectcomputing.checkins.notifications.social_media.SlackSender;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileUtils;

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
@@ -1,0 +1,146 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import com.objectcomputing.checkins.notifications.social_media.SlackSearch;
+import com.objectcomputing.checkins.notifications.social_media.SlackSender;
+import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
+import com.objectcomputing.checkins.services.memberprofile.MemberProfileUtils;
+import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
+import com.objectcomputing.checkins.exceptions.NotFoundException;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import com.slack.api.model.Message;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.io.Readable;
+import io.micronaut.core.io.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+
+import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.lang.StringBuffer;
+import java.io.BufferedReader;
+
+@Singleton
+public class SlackKudosCreator {
+    private static final Logger LOG = LoggerFactory.getLogger(SlackKudosCreator.class);
+
+    @Inject
+    private SlackSearch slackSearch;
+
+    @Inject
+    private SlackSender slackSender;
+
+    @Inject
+    private AutomatedKudosRepository automatedKudosRepository;
+
+    @Inject
+    private MemberProfileServices memberProfileServices;
+
+    @Value("classpath:slack/kudos_slack_blocks.json")
+    private Readable kudosSlackBlocks;
+
+    public void store(List<Message> messages) {
+        for (Message message : messages) {
+            if (message.getSubtype() == null &&
+                message.getText().toLowerCase().contains("kudos")) {
+                try {
+                    AutomatedKudosDTO kudosDTO = createFromMessage(message);
+                    if (kudosDTO.getRecipientIds().size() == 0) {
+                        LOG.warn("Unable to extract recipients from message");
+                        LOG.warn(message.getText());
+                    } else {
+                        automatedKudosRepository.save(
+                                        new AutomatedKudos(kudosDTO));
+                    }
+                } catch (Exception ex) {
+                    LOG.error("store: " + ex.toString());
+                }
+            }
+        }
+
+        requestAction();
+    }
+
+    private AutomatedKudosDTO createFromMessage(Message message) {
+        String userId = message.getUser();
+        MemberProfile sender = lookupUser(userId);
+        List<UUID> recipients = new ArrayList<>();
+        String text = processText(message.getText(), recipients);
+        return new AutomatedKudosDTO(text, userId, sender.getId(), recipients);
+    }
+
+    private MemberProfile lookupUser(String userId) {
+        if (userId == null) {
+            throw new NotFoundException("User Id is not present");
+        }
+
+        String email = slackSearch.findUserEmail(userId);
+        if (email == null) {
+            throw new NotFoundException(
+                          "Could not find an email address for " + userId);
+        }
+        return memberProfileServices.findByWorkEmail(email);
+    }
+
+    private String processText(String text, List<UUID> recipients) {
+        StringBuffer buffer = new StringBuffer(text.length());
+        Pattern userRef = Pattern.compile("<@([^>]+)>");
+        Matcher action = userRef.matcher(StringEscapeUtils.unescapeHtml4(text));
+        while (action.find()) {
+            // Pull out the recipient user id, get the profile and add it to
+            // the list of recipients.
+            String userId = action.group(1);
+            MemberProfile profile = lookupUser(userId);
+            recipients.add(profile.getId());
+
+            // Replace the user reference with their full name.
+            action.appendReplacement(buffer, Matcher.quoteReplacement(
+                                     MemberProfileUtils.getFullName(profile)));
+        }
+        action.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private void requestAction() {
+        for (AutomatedKudos kudos : automatedKudosRepository.getUnrequested()) {
+            try {
+                // Create the slack blocks, inserting the kudos UUID as the
+                // block id.
+                String blocks = getSlackBlocks(kudos.getId().toString(),
+                                               kudos.getMessage());
+
+                // Send the message to the sender of the kudos
+                List<String> userIds = new ArrayList<>();
+                userIds.add(kudos.getExternalId());
+                if (slackSender.send(userIds, blocks)) {
+                    // If the message was sent, set the requested flag and
+                    // update the repository.
+                    kudos.setRequested(true);
+                    automatedKudosRepository.update(kudos);
+                }
+            } catch (Exception ex) {
+                LOG.error("requestAction: " + ex.toString());
+            }
+        }
+    }
+
+    private String getSlackBlocks(String kudosUUID, String contents) {
+        try {
+            return String.format(IOUtils.readText(
+                       new BufferedReader(kudosSlackBlocks.asReader())),
+                       kudosUUID, contents);
+        } catch(Exception ex) {
+            LOG.error("SlackKudosCreator.getSlackBlocks: " + ex.toString());
+            return "";
+        }
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
@@ -50,8 +50,10 @@ public class SlackKudosCreator {
 
     public void store(List<Message> messages) {
         for (Message message : messages) {
-            // User messages do not have a sub-type.
-            if (message.getSubtype() == null) {
+            // User messages do not have a sub-type.  A bot user can send
+            // messages.  They will not have a subtype, but they will have a bot
+            // id.  We want to skip those too.
+            if (message.getSubtype() == null && message.getBotId() == null) {
                 try {
                     AutomatedKudosDTO kudosDTO = createFromMessage(message);
                     if (kudosDTO.getRecipientIds().size() == 0) {
@@ -74,7 +76,7 @@ public class SlackKudosCreator {
 
     private AutomatedKudosDTO createFromMessage(Message message) {
         String userId = message.getUser();
-        MemberProfile sender = lookupUser(userId);
+            MemberProfile sender = lookupUser(userId);
         List<UUID> recipients = new ArrayList<>();
         String text = processText(message.getText(), recipients);
         return new AutomatedKudosDTO(text, userId, sender.getId(), recipients);

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosCreator.java
@@ -50,6 +50,7 @@ public class SlackKudosCreator {
 
     public void store(List<Message> messages) {
         for (Message message : messages) {
+            // User messages do not have a sub-type.
             if (message.getSubtype() == null) {
                 try {
                     AutomatedKudosDTO kudosDTO = createFromMessage(message);

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosResponseHandler.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/kudos/SlackKudosResponseHandler.java
@@ -1,0 +1,56 @@
+package com.objectcomputing.checkins.services.slack.kudos;
+
+import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
+import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
+import com.objectcomputing.checkins.services.kudos.KudosCreateDTO;
+import com.objectcomputing.checkins.services.kudos.KudosServices;
+
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Singleton
+public class SlackKudosResponseHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(SlackKudosResponseHandler.class);
+
+    @Inject
+    private KudosServices kudosServices;
+
+    @Inject
+    private AutomatedKudosRepository automatedKudosRepository;
+
+    @Inject
+    private MemberProfileServices memberProfileServices;
+
+    public void store(UUID automatedKudosId) {
+        Optional<AutomatedKudos> found =
+            automatedKudosRepository.findById(automatedKudosId);
+        if (found.isPresent()) {
+            AutomatedKudos kudos = found.get();
+            List<MemberProfile> recipients = new ArrayList<>();
+            for (String recipientId : kudos.getRecipientIds()) {
+                recipients.add(memberProfileServices.getById(
+                                   UUID.fromString(recipientId)));
+            }
+            KudosCreateDTO dto =
+                new KudosCreateDTO(kudos.getMessage(), kudos.getSenderId(),
+                                   null, true, recipients);
+            kudosServices.savePreapproved(dto);
+            automatedKudosRepository.deleteById(automatedKudosId);
+        } else {
+            LOG.error("Unable to find automated kudos: " +
+                      automatedKudosId.toString());
+        }
+    }
+
+    public void remove(UUID automatedKudosId) {
+        automatedKudosRepository.deleteById(automatedKudosId);
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/pulseresponse/PulseSlackCommand.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/pulseresponse/PulseSlackCommand.java
@@ -1,4 +1,4 @@
-package com.objectcomputing.checkins.services.slack;
+package com.objectcomputing.checkins.services.slack.pulseresponse;
 
 import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
 
@@ -54,7 +54,7 @@ public class PulseSlackCommand {
 
                 return response.isOk();
             } catch(Exception ex) {
-                LOG.error(ex.toString());
+                LOG.error("PulseSlackCommand.send: " + ex.toString());
                 return false;
             }
         } else {
@@ -68,7 +68,7 @@ public class PulseSlackCommand {
             return IOUtils.readText(
                        new BufferedReader(pulseSlackBlocks.asReader()));
         } catch(Exception ex) {
-            LOG.error(ex.toString());
+            LOG.error("PulseSlackCommand.getSlackBlocks: " + ex.toString());
             return "";
         }
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/pulseresponse/SlackPulseResponseConverter.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/pulseresponse/SlackPulseResponseConverter.java
@@ -3,7 +3,7 @@ package com.objectcomputing.checkins.services.slack.pulseresponse;
 import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
-import com.objectcomputing.checkins.notifications.social_media.SlackSearch;
+import com.objectcomputing.checkins.services.slack.SlackSearch;
 import com.objectcomputing.checkins.services.pulseresponse.PulseResponseCreateDTO;
 
 import jakarta.inject.Singleton;

--- a/server/src/main/java/com/objectcomputing/checkins/services/slack/pulseresponse/SlackPulseResponseConverter.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/slack/pulseresponse/SlackPulseResponseConverter.java
@@ -1,4 +1,4 @@
-package com.objectcomputing.checkins.services.slack;
+package com.objectcomputing.checkins.services.slack.pulseresponse;
 
 import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
@@ -10,10 +10,6 @@ import jakarta.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Map;
 import java.util.UUID;
@@ -32,14 +28,9 @@ public class SlackPulseResponseConverter {
         this.memberProfileServices = memberProfileServices;
     }
 
-    public PulseResponseCreateDTO get(String body) {
+    public PulseResponseCreateDTO get(Map<String, Object> map) {
         try {
-            // Get the map of values from the string body
-            final ObjectMapper mapper = new ObjectMapper();
-            final Map<String, Object> map =
-                    mapper.readValue(body, new TypeReference<>() {});
             final String type = (String)map.get("type");
-
             if (type.equals("view_submission")) {
                 final Map<String, Object> view =
                         (Map<String, Object>)map.get("view");
@@ -81,11 +72,8 @@ public class SlackPulseResponseConverter {
                 // response.
                 return null;
             }
-        } catch(JsonProcessingException ex) {
-            LOG.error(ex.getMessage());
-            throw new BadArgException(ex.getMessage());
         } catch(NumberFormatException ex) {
-            LOG.error(ex.getMessage());
+            LOG.error("SlackPulseResponseConverter.get: " + ex.getMessage());
             throw new BadArgException("Pulse scores must be integers");
         }
     }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -101,6 +101,7 @@ check-ins:
       webhook-url: ${ SLACK_WEBHOOK_URL }
       bot-token: ${ SLACK_BOT_TOKEN }
       signing-secret: ${ SLACK_SIGNING_SECRET }
+      kudos-channel: ${ SLACK_KUDOS_CHANNEL_ID }
   web-address: ${ WEB_ADDRESS }
 ---
 flyway:

--- a/server/src/main/resources/db/common/V121__automated_kudos_table.sql
+++ b/server/src/main/resources/db/common/V121__automated_kudos_table.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS automated_kudos;
+
+CREATE TABLE automated_kudos
+(
+    id              varchar PRIMARY KEY,
+    requested       boolean,
+    message         varchar,
+    externalid      varchar,
+    senderid        varchar REFERENCES member_profile (id),
+    recipientids    varchar[]
+);

--- a/server/src/main/resources/db/common/V121__automated_kudos_table.sql
+++ b/server/src/main/resources/db/common/V121__automated_kudos_table.sql
@@ -9,3 +9,11 @@ CREATE TABLE automated_kudos
     senderid        varchar REFERENCES member_profile (id),
     recipientids    varchar[]
 );
+
+DROP TABLE IF EXISTS automated_kudos_read_time;
+
+CREATE TABLE automated_kudos_read_time
+(
+    id              varchar PRIMARY KEY,
+    readtime        timestamp
+);

--- a/server/src/main/resources/slack/kudos_slack_blocks.json
+++ b/server/src/main/resources/slack/kudos_slack_blocks.json
@@ -1,0 +1,43 @@
+[
+  {
+    "type": "section",
+    "block_id": "%s",
+    "text": {
+      "type": "plain_text",
+      "text": "Would you like to automatically add this Kudos to Check-Ins?"
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "plain_text",
+      "text": "%s"
+    }
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "actions",
+    "elements": [
+      {
+        "type": "button",
+        "action_id": "yes_button",
+        "text": {
+          "type": "plain_text",
+          "text": "Yes"
+        },
+        "value": "yes"
+      },
+      {
+        "type": "button",
+        "action_id": "no_button",
+        "text": {
+          "type": "plain_text",
+          "text": "No"
+        },
+        "value": "no"
+      }
+    ]
+  }
+]

--- a/server/src/main/resources/slack/pulse_slack_blocks.json
+++ b/server/src/main/resources/slack/pulse_slack_blocks.json
@@ -1,5 +1,6 @@
 {
   "type": "modal",
+  "callback_id": "pulseSubmission",
   "title": {
     "type": "plain_text",
     "text": "Check-Ins Pulse",

--- a/server/src/test/java/com/objectcomputing/checkins/services/SlackReaderReplacement.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/SlackReaderReplacement.java
@@ -1,0 +1,58 @@
+package com.objectcomputing.checkins.services;
+
+import com.objectcomputing.checkins.services.slack.SlackReader;
+import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+
+import com.slack.api.model.Message;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Singleton
+@Replaces(SlackReader.class)
+@Requires(property = "replace.slackreader", value = StringUtils.TRUE)
+public class SlackReaderReplacement extends SlackReader {
+    public final Map<String, List<Message>> channelMessages = new HashMap<>();
+
+    @Override
+    public List<Message> read(String channelId, LocalDateTime last) {
+        List<Message> messages = new ArrayList<>();
+        if (channelMessages.containsKey(channelId)) {
+            long ts = last.atZone(ZoneId.systemDefault())
+                          .toInstant().getEpochSecond();
+            for (Message message : channelMessages.get(channelId)) {
+                long messageTime = Long.parseLong(message.getTs());
+                if (messageTime >= ts) {
+                    messages.add(message);
+                }
+            }
+        }
+        return messages;
+    }
+
+    public void addMessage(String channelId, String userId,
+                           String text, LocalDateTime sendTime) {
+        Message message = new Message();
+        message.setTs(String.valueOf(sendTime.atZone(ZoneId.systemDefault())
+                                             .toInstant().getEpochSecond()));
+        message.setText(text);
+        message.setUser(userId);
+
+        if (!channelMessages.containsKey(channelId)) {
+            channelMessages.put(channelId, new ArrayList<Message>());
+        }
+        channelMessages.get(channelId).add(message);
+    }
+}

--- a/server/src/test/java/com/objectcomputing/checkins/services/SlackSearchReplacement.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/SlackSearchReplacement.java
@@ -26,9 +26,19 @@ public class SlackSearchReplacement extends SlackSearch {
     }
 
     @Override
+    public String findChannelName(String channelId) {
+        return channels.containsKey(channelId) ?
+                   channels.get(channelId) : null;
+    }
+
+    @Override
     public String findChannelId(String channelName) {
-        return channels.containsKey(channelName) ?
-                   channels.get(channelName) : null;
+        for (Map.Entry<String, String> entry : channels.entrySet()) {
+            if (entry.getValue().equals(channelName)) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 
     @Override

--- a/server/src/test/java/com/objectcomputing/checkins/services/SlackSearchReplacement.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/SlackSearchReplacement.java
@@ -1,6 +1,6 @@
 package com.objectcomputing.checkins.services;
 
-import com.objectcomputing.checkins.notifications.social_media.SlackSearch;
+import com.objectcomputing.checkins.services.slack.SlackSearch;
 import com.objectcomputing.checkins.configuration.CheckInsConfiguration;
 
 import io.micronaut.context.annotation.Replaces;

--- a/server/src/test/java/com/objectcomputing/checkins/services/SlackSenderReplacement.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/SlackSenderReplacement.java
@@ -33,5 +33,14 @@ public class SlackSenderReplacement extends SlackSender {
         }
         return true;
     }
+
+    @Override
+    public boolean send(String channelId, String slackBlocks) {
+        if (!sent.containsKey(channelId)) {
+            sent.put(channelId, new ArrayList<String>());
+        }
+        sent.get(channelId).add(slackBlocks);
+        return true;
+    }
 }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/SlackSenderReplacement.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/SlackSenderReplacement.java
@@ -1,0 +1,37 @@
+package com.objectcomputing.checkins.services;
+
+import com.objectcomputing.checkins.notifications.social_media.SlackSender;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+@Singleton
+@Replaces(SlackSender.class)
+@Requires(property = "replace.slacksender", value = StringUtils.TRUE)
+public class SlackSenderReplacement extends SlackSender {
+    public final Map<String, List<String>> sent = new HashMap<>();
+
+    public void reset() {
+        sent.clear();
+    }
+
+    @Override
+    public boolean send(List<String> userIds, String slackBlocks) {
+        for (String userId : userIds) {
+            if (!sent.containsKey(userId)) {
+                sent.put(userId, new ArrayList<String>());
+            }
+            sent.get(userId).add(slackBlocks);
+        }
+        return true;
+    }
+}
+

--- a/server/src/test/java/com/objectcomputing/checkins/services/email/EmailControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/email/EmailControllerTest.java
@@ -138,14 +138,16 @@ class EmailControllerTest extends TestContainersSuite implements MemberProfileFi
         assertEquals(email.get("content"), firstEmailRes.getContents());
         assertEquals(admin.getId(), firstEmailRes.getSentBy());
         assertEquals(recipient1.getId(), firstEmailRes.getRecipient());
-        assertTrue(firstEmailRes.getTransmissionDate().isAfter(firstEmailRes.getSendDate()));
+        assertTrue(firstEmailRes.getTransmissionDate().isAfter(firstEmailRes.getSendDate()) ||
+                   firstEmailRes.getTransmissionDate().isEqual(firstEmailRes.getSendDate()));
 
         Email secondEmailRes = response.getBody().get().get(1);
         assertEquals(email.get("subject"), secondEmailRes.getSubject());
         assertEquals(email.get("content"), secondEmailRes.getContents());
         assertEquals(admin.getId(), secondEmailRes.getSentBy());
         assertEquals(recipient2.getId(), secondEmailRes.getRecipient());
-        assertTrue(secondEmailRes.getTransmissionDate().isAfter(secondEmailRes.getSendDate()));
+        assertTrue(secondEmailRes.getTransmissionDate().isAfter(secondEmailRes.getSendDate()) ||
+                   secondEmailRes.getTransmissionDate().isEqual(secondEmailRes.getSendDate()));
 
         assertEquals(1, textEmailSender.events.size());
         assertEquals(

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/AutomatedKudosFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/AutomatedKudosFixture.java
@@ -1,0 +1,15 @@
+package com.objectcomputing.checkins.services.fixture;
+
+import com.objectcomputing.checkins.services.slack.kudos.AutomatedKudos;
+import com.objectcomputing.checkins.services.slack.kudos.AutomatedKudosRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface AutomatedKudosFixture extends RepositoryFixture {
+    default List<AutomatedKudos> getAutomatedKudos() {
+        List<AutomatedKudos> list = new ArrayList<>();
+        getAutomatedKudosRepository().findAll().forEach(list::add);
+        return list;
+    }
+}

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/RepositoryFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/RepositoryFixture.java
@@ -43,6 +43,7 @@ import com.objectcomputing.checkins.services.volunteering.VolunteeringOrganizati
 import com.objectcomputing.checkins.services.volunteering.VolunteeringRelationshipRepository;
 import io.micronaut.runtime.server.EmbeddedServer;
 import com.objectcomputing.checkins.services.employee_hours.EmployeeHoursRepository;
+import com.objectcomputing.checkins.services.slack.kudos.AutomatedKudosRepository;
 
 public interface RepositoryFixture {
     EmbeddedServer getEmbeddedServer();
@@ -212,5 +213,9 @@ public interface RepositoryFixture {
 
     default RoleDocumentationRepository getRoleDocumentationRepository() {
         return getEmbeddedServer().getApplicationContext().getBean(RoleDocumentationRepository.class);
+    }
+
+    default AutomatedKudosRepository getAutomatedKudosRepository() {
+        return getEmbeddedServer().getApplicationContext().getBean(AutomatedKudosRepository.class);
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/kudos/SlackKudosTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/kudos/SlackKudosTest.java
@@ -1,0 +1,188 @@
+package com.objectcomputing.checkins.services.kudos;
+
+import com.objectcomputing.checkins.services.slack.SlackSignature;
+import com.objectcomputing.checkins.services.slack.kudos.KudosChannelReader;
+import com.objectcomputing.checkins.services.slack.kudos.AutomatedKudos;
+import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
+import com.objectcomputing.checkins.services.memberprofile.MemberProfileUtils;
+import com.objectcomputing.checkins.services.kudos.KudosResponseDTO;
+import com.objectcomputing.checkins.services.role.RoleType;
+
+import com.objectcomputing.checkins.services.TestContainersSuite;
+import com.objectcomputing.checkins.services.SlackSenderReplacement;
+import com.objectcomputing.checkins.services.SlackReaderReplacement;
+import com.objectcomputing.checkins.services.SlackSearchReplacement;
+import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
+import com.objectcomputing.checkins.services.fixture.AutomatedKudosFixture;
+import com.objectcomputing.checkins.services.fixture.RoleFixture;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.time.Instant;
+import java.net.URLEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = "replace.slacksearch", value = StringUtils.TRUE)
+@Property(name = "replace.slackreader", value = StringUtils.TRUE)
+@Property(name = "replace.slacksender", value = StringUtils.TRUE)
+class SlackKudosTest extends TestContainersSuite implements MemberProfileFixture, AutomatedKudosFixture, RoleFixture {
+    @Inject
+    private SlackReaderReplacement slackReader;
+
+    @Inject
+    private SlackSearchReplacement slackSearch;
+
+    @Inject
+    private SlackSenderReplacement slackSender;
+
+    @Inject
+    private KudosChannelReader kudosChannelReader;
+
+    @Inject
+    private SlackSignature slackSignature;
+
+    @Inject
+    @Client("/services")
+    protected HttpClient client;
+
+    MemberProfile sender;
+    MemberProfile recipient;
+
+    @BeforeEach
+    void setUp() {
+        createAndAssignRoles();
+        sender = createADefaultMemberProfile();
+        recipient = createASecondDefaultMemberProfile();
+    }
+
+    @Test
+    void testCreateKudosFromSlackMessage() throws JsonProcessingException {
+        String slackSenderId = "senderId";
+        slackSearch.users.put(slackSenderId, sender.getWorkEmail());
+        String slackRecipient = "recipientId";
+        slackSearch.users.put(slackRecipient, recipient.getWorkEmail());
+
+        // Post to "Slack"
+        final String beginning = "Kudos to ";
+        slackReader.addMessage("SLACK_KUDOS_CHANNEL_ID", slackSenderId,
+                               beginning + "<@" + slackRecipient + ">",
+                               LocalDateTime.now());
+
+        final String messageWithName = beginning +
+                               MemberProfileUtils.getFullName(recipient);
+
+        // Manually tell the reader to load messages from slack.  This normally
+        // happens on an interval.
+        kudosChannelReader.readChannel();
+
+        // Get the automated kudos from the repository and validate.
+        List<AutomatedKudos> generatedKudos = getAutomatedKudos();
+        assertEquals(1, generatedKudos.size());
+        AutomatedKudos kudos = generatedKudos.get(0);
+        assertEquals(messageWithName, kudos.getMessage());
+        assertEquals(slackSenderId, kudos.getExternalId());
+        assertEquals(sender.getId(), kudos.getSenderId());
+        assertEquals(1, kudos.getRecipientIds().size());
+        assertEquals(recipient.getId().toString(),
+                     kudos.getRecipientIds().get(0));
+
+        // A slack message should have been sent to the sender as well...
+        assertTrue(slackSender.sent.containsKey(slackSenderId));
+        List<String> messages = slackSender.sent.get(slackSenderId);
+        assertEquals(1, messages.size());
+        
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode sent = mapper.readTree(messages.get(0));
+        assertEquals(JsonNodeType.ARRAY, sent.getNodeType());
+
+        var iter = sent.elements();
+        assertTrue(iter.hasNext());
+        JsonNode section = iter.next();
+        
+        assertEquals(JsonNodeType.OBJECT, section.getNodeType());
+        assertTrue(section.has("block_id"));
+        UUID automatedKudosUUID =
+                UUID.fromString(section.get("block_id").asText());
+
+        // Post to /external to say "yes, we want it in Check-Ins".
+        final String rawBody = getSlackPostPayload(
+                                   automatedKudosUUID.toString());
+        long currentTime = Instant.now().getEpochSecond();
+        String timestamp = String.valueOf(currentTime);
+
+        HttpRequest request =
+            HttpRequest.POST("/pulse-responses/external", rawBody)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("X-Slack-Signature", slackSignature.generate(timestamp, rawBody))
+        .header("X-Slack-Request-Timestamp", timestamp);
+
+        HttpResponse response = client.toBlocking().exchange(request);
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        // Get list of kudos from kudos controller and verify.
+        request = HttpRequest.GET("/kudos/recent")
+                             .basicAuth(sender.getWorkEmail(),
+                                        RoleType.Constants.MEMBER_ROLE);
+        HttpResponse<List<KudosResponseDTO>> list =
+            client.toBlocking()
+                  .exchange(request, Argument.listOf(KudosResponseDTO.class));
+        assertEquals(HttpStatus.OK, list.getStatus());
+        assertEquals(1, list.body().size());
+        KudosResponseDTO element = list.body().getFirst();
+        assertEquals(messageWithName, element.getMessage());
+        assertEquals(sender.getId(), element.getSenderId());
+        assertTrue(element.getPubliclyVisible());
+        assertEquals(element.getRecipientMembers(), List.of(recipient));
+    }
+
+    @Test
+    void testNoSlackMessages() {
+        kudosChannelReader.readChannel();
+        List<AutomatedKudos> generatedKudos = getAutomatedKudos();
+        assertEquals(0, generatedKudos.size());
+    }
+
+    String getSlackPostPayload(String kudosId) {
+        return "payload=" +
+               URLEncoder.encode(String.format("""
+{
+  "type": "block_actions",
+  "message": {
+    "blocks": [
+      {
+        "block_id": "%s"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "action_id": "yes_button"
+    }
+  ]
+}
+""", kudosId));
+    }
+}

--- a/server/src/test/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseControllerTest.java
@@ -37,6 +37,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.time.Instant;
+import java.net.URLEncoder;
 
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
 import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
@@ -536,9 +537,10 @@ class PulseResponseControllerTest extends TestContainersSuite implements MemberP
     @Test
     void testCreateAPulseResponseFromSlack() {
         MemberProfile memberProfile = createADefaultMemberProfile();
-        slackSearch.users.put("SLACK_ID_HI", memberProfile.getWorkEmail());
+        String slackId = "SLACK_ID_HI";
+        slackSearch.users.put(slackId, memberProfile.getWorkEmail());
 
-        final String rawBody = "payload=%7B%22type%22%3A+%22view_submission%22%2C+%22user%22%3A+%7B%22id%22%3A+%22SLACK_ID_HI%22%7D%2C+%22view%22%3A+%7B%22id%22%3A+%22VNHU13V36%22%2C+%22type%22%3A+%22modal%22%2C+%22state%22%3A+%7B%22values%22%3A+%7B%22internalNumber%22%3A+%7B%22internalScore%22%3A+%7B%22selected_option%22%3A+%7B%22type%22%3A+%22radio_buttons%22%2C+%22value%22%3A+%224%22%7D%7D%7D%2C+%22internalText%22%3A+%7B%22internalFeelings%22%3A+%7B%22type%22%3A+%22plain_text_input%22%2C+%22value%22%3A+%22I+am+a+robot.%22%7D%7D%2C+%22externalNumber%22%3A+%7B%22externalScore%22%3A+%7B%22selected_option%22%3A+%7B%22type%22%3A+%22radio_buttons%22%2C+%22value%22%3A+%225%22%7D%7D%7D%2C+%22externalText%22%3A+%7B%22externalFeelings%22%3A+%7B%22type%22%3A+%22plain_text_input%22%2C+%22value%22%3A+%22You+are+a+robot.%22%7D%7D%7D%7D%7D%7D";
+        final String rawBody = getSlackPulsePayload(slackId);
 
         long currentTime = Instant.now().getEpochSecond();
         String timestamp = String.valueOf(currentTime);
@@ -602,5 +604,54 @@ class PulseResponseControllerTest extends TestContainersSuite implements MemberP
 
     private UUID id(String key) {
         return profile(key).getId();
+    }
+
+    private String getSlackPulsePayload(String slackId) {
+        return "payload=" +
+               URLEncoder.encode(String.format("""
+{
+  "type": "view_submission",
+  "user": {
+    "id": "%s"
+  },
+  "view": {
+    "id": "VNHU13V36",
+    "type": "modal",
+    "callback_id": "pulseSubmission",
+    "state": {
+      "values": {
+        "internalNumber": {
+          "internalScore": {
+            "selected_option": {
+              "type": "radio_buttons",
+              "value": "4"
+            }
+          }
+        },
+        "internalText": {
+          "internalFeelings": {
+            "type": "plain_text_input",
+            "value": "I am a robot."
+          }
+        },
+        "externalNumber": {
+          "externalScore": {
+            "selected_option": {
+              "type": "radio_buttons",
+              "value": "5"
+            }
+          }
+        },
+        "externalText": {
+          "externalFeelings": {
+            "type": "plain_text_input",
+            "value": "You are a robot."
+          }
+        }
+      }
+    }
+  }
+}
+""", slackId));
     }
 }

--- a/server/src/test/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/pulseresponse/PulseResponseControllerTest.java
@@ -33,9 +33,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.net.URLEncoder;
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesImplTest.java
@@ -13,6 +13,7 @@ import com.objectcomputing.checkins.services.MailJetFactoryReplacement;
 import com.objectcomputing.checkins.services.fixture.MemberProfileFixture;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.CurrentUserServicesReplacement;
+import com.objectcomputing.checkins.services.SlackReaderReplacement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,10 +31,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Property(name = "replace.mailjet.factory", value = StringUtils.TRUE)
 @Property(name = "replace.currentuserservices", value = StringUtils.TRUE)
+@Property(name = "replace.slackreader", value = StringUtils.TRUE)
 class CheckServicesImplTest extends TestContainersSuite
                             implements FeedbackTemplateFixture, FeedbackRequestFixture, MemberProfileFixture, RoleFixture {
     @Inject
     CurrentUserServicesReplacement currentUserServices;
+
+    @Inject
+    private SlackReaderReplacement slackReader;
 
     @Inject
     @Named(MailJetFactory.MJML_FORMAT)

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -45,6 +45,7 @@ check-ins:
       webhook-url: https://bogus.objectcomputing.com/slack
       bot-token: BOGUS_TOKEN
       signing-secret: BOGUS_SIGNING_SECRET
+      kudos-channel: SLACK_KUDOS_CHANNEL_ID
 ---
 aes:
   key: BOGUS_TEST_KEY

--- a/web-ui/src/components/kudos/PublicKudosCard.jsx
+++ b/web-ui/src/components/kudos/PublicKudosCard.jsx
@@ -98,7 +98,13 @@ const KudosCard = ({ kudos }) => {
           subheaderTypographyProps={{variant:"subtitle1"}}
         />
         <CardContent>
-          <Typography variant="body1"><em>{kudos.message}</em></Typography>
+          <div>
+          {kudos.message.split('\n').map((line, index) => (
+            <Typography key={index} variant="body1">
+              <em>{line}</em>
+            </Typography>
+          ))}
+          </div>
           {kudos.recipientTeam && (
       <AvatarGroup max={12}>
         {kudos.recipientMembers.map((member) => (

--- a/web-ui/src/components/kudos_card/KudosCard.jsx
+++ b/web-ui/src/components/kudos_card/KudosCard.jsx
@@ -136,7 +136,7 @@ const KudosCard = ({ kudos, includeActions, includeEdit, onKudosAction }) => {
         type: UPDATE_TOAST,
         payload: {
           severity: "success",
-          toast: "Pending kudos deleted",
+          toast: "Kudos deleted",
         },
       });
       onKudosAction && onKudosAction();

--- a/web-ui/src/pages/ManageKudosPage.jsx
+++ b/web-ui/src/pages/ManageKudosPage.jsx
@@ -234,7 +234,12 @@ const ManageKudosPage = () => {
             : (
               <div>
                 {approvedKudos.filter(filterApprovedKudos).map(k =>
-                  <KudosCard key={k.id} kudos={k}/>
+                  <KudosCard
+                    key={k.id}
+                    kudos={k}
+                    includeEdit
+                    onKudosAction={loadAndSetApprovedKudos}
+                  />
                 )}
               </div>
             )


### PR DESCRIPTION
This adds a scheduled task to read slack messages from a configured channel and import user messages as Check-Ins Kudos upon verification with the poster of the slack message.

1. Moved slack related functionality into a separate `slack` service directory.
2. Added the ability to save pre-approved kudos.
3. Modified `CurrentUserServicesImpl.hasPermission` to return false if there is no current user.
4. Moved Slack related functionality out of the `PulseResponseController`
  - **At some point, we will probably want to change the URI for Slack related traffic.**
5. The configuration requires a `SLACK_KUDOS_CHANNEL_ID` value.
  - For testing, I was using `C0814P2PEV7`

This will need to be deployed to finish testing.

Also, once this is deployed to production, we will need to add the following scopes to the Check-Ins Integration.
- `channels:history`
- `chat:write`
- `groups:history`
- `im:write`

